### PR TITLE
fix decision bug in sam rotation

### DIFF
--- a/BossMod/Autorotation/SAM/SAMRotation.cs
+++ b/BossMod/Autorotation/SAM/SAMRotation.cs
@@ -480,7 +480,7 @@ namespace BossMod.SAM
             uint gcdsInAdvance = 0
         )
         {
-            if (strategy.HiganbanaStrategy == HiganbanaUse.Never)
+            if (strategy.HiganbanaStrategy == HiganbanaUse.Never || !state.HasCombatBuffs)
                 return false;
 
             // force use to get shoha even if the target is dying, dot overwrite doesn't matter


### PR DESCRIPTION
my fault on this one, I only eye tested it. the missing conditional causes sam to repeatedly use Gekko in a meikyo window under some conditions.