### PR TITLE
HoC mouseover support

### DIFF
--- a/BossMod/Autorotation/GNB/GNBActions.cs
+++ b/BossMod/Autorotation/GNB/GNBActions.cs
@@ -139,6 +139,7 @@ namespace BossMod.GNB
             SupportedSpell(AID.DemonSlaughter).TransformAction = _config.AOECombos ? () => ActionID.MakeSpell(Rotation.GetNextAOEComboAction(ComboLastMove)) : null;
 
             // smart targets
+            SupportedSpell(AID.HeartOfCorundum).TransformTarget = SupportedSpell(AID.HeartOfStone).TransformTarget = _config.SmartHeartofCorundumShirkTarget ? SmartTargetFriendly : null;
             SupportedSpell(AID.Shirk).TransformTarget = _config.SmartHeartofCorundumShirkTarget ? SmartTargetCoTank : null;
             SupportedSpell(AID.Provoke).TransformTarget = _config.ProvokeMouseover ? SmartTargetHostile : null; // TODO: also interject/low-blow
         }


### PR DESCRIPTION
HoC can be applied to any party member including self, which is why I use `SmartTargetFriendly` instead of cotank