### PR TITLE
added module viewer

### DIFF
--- a/BossMod/BossModule/BossModule.cs
+++ b/BossMod/BossModule/BossModule.cs
@@ -17,6 +17,11 @@ namespace BossMod
         public Type? StatusIDType; // default: ns.SID
         public Type? TetherIDType; // default: ns.TetherID
         public Type? IconIDType; // default: ns.IconID
+        public uint DynamicEventID; // default: 0
+        public uint FateID; // default: 0
+        public uint NotoriousMonsterID; // default: 0
+        public uint NameID; // default: 0
+        public uint CFCID; // default: 0
         public uint PrimaryActorOID; // default: OID.Boss
     }
 

--- a/BossMod/Debug/DebugObjects.cs
+++ b/BossMod/Debug/DebugObjects.cs
@@ -41,6 +41,7 @@ namespace BossMod
                     _tree.LeafNode($"Gimmick ID: {Utils.ReadField<uint>(internalObj, 0x7C):X}");
                     _tree.LeafNode($"Radius: {obj.HitboxRadius:f3}");
                     _tree.LeafNode($"Owner: {Utils.ObjectString(obj.OwnerId)}");
+                    _tree.LeafNode($"BNpcBase/Name: {obj.DataId}/{((FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject*)obj.Address)->GetNpcID()}");
                     _tree.LeafNode($"Targetable: {obj.IsTargetable}");
                     _tree.LeafNode($"Friendly: {Utils.GameObjectIsFriendly(obj)}");
                     _tree.LeafNode($"Is character: {internalObj->IsCharacter()}");

--- a/BossMod/Debug/DebugObjects.cs
+++ b/BossMod/Debug/DebugObjects.cs
@@ -41,7 +41,7 @@ namespace BossMod
                     _tree.LeafNode($"Gimmick ID: {Utils.ReadField<uint>(internalObj, 0x7C):X}");
                     _tree.LeafNode($"Radius: {obj.HitboxRadius:f3}");
                     _tree.LeafNode($"Owner: {Utils.ObjectString(obj.OwnerId)}");
-                    _tree.LeafNode($"BNpcBase/Name: {obj.DataId}/{((FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject*)obj.Address)->GetNpcID()}");
+                    _tree.LeafNode($"BNpcBase/Name: {obj.DataId}/{Utils.GameObjectInternal(obj)->GetNpcID()}");
                     _tree.LeafNode($"Targetable: {obj.IsTargetable}");
                     _tree.LeafNode($"Friendly: {Utils.GameObjectIsFriendly(obj)}");
                     _tree.LeafNode($"Is character: {internalObj->IsCharacter()}");

--- a/BossMod/Debug/MainDebugWindow.cs
+++ b/BossMod/Debug/MainDebugWindow.cs
@@ -240,7 +240,7 @@ namespace BossMod
             var dist = selfToObj.Length();
             var angle = Angle.FromDirection(new(selfToObj.XZ())) - refAngle;
             var visHalf = Angle.Asin(obj->HitboxRadius / dist);
-            ImGui.TextUnformatted($"{kind}: #{obj->ObjectIndex} {Utils.ObjectString(obj->ObjectID)}, hb={obj->HitboxRadius} ({visHalf}), dist={dist}, angle={angle} ({Math.Max(0, angle.Abs().Rad - visHalf.Rad).Radians()})");
+            ImGui.TextUnformatted($"{kind}: #{obj->ObjectIndex} {Utils.ObjectString(obj->ObjectID)} {obj->DataID}:{obj->GetNpcID()}, hb={obj->HitboxRadius} ({visHalf}), dist={dist}, angle={angle} ({Math.Max(0, angle.Abs().Rad - visHalf.Rad).Radians()})");
         }
 
         private unsafe void DrawPlayerAttributes()

--- a/BossMod/Framework/Service.cs
+++ b/BossMod/Framework/Service.cs
@@ -24,6 +24,7 @@ namespace BossMod
         [PluginService] public static ICondition Condition { get; private set; }
         [PluginService] public static ITargetManager TargetManager { get; private set; }
         [PluginService] public static IFramework Framework { get; private set; }
+        [PluginService] public static ITextureProvider Texture { get; private set; }
 #pragma warning restore CS8618
 
         public static Action<string>? LogHandler = null;

--- a/BossMod/Modules/Endwalker/Alliance/A10Lions/A10Lions.cs
+++ b/BossMod/Modules/Endwalker/Alliance/A10Lions/A10Lions.cs
@@ -21,7 +21,7 @@ namespace BossMod.Endwalker.Alliance.A10Lions
         }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.Lion)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.Lion, CFCID = 866, NameID = 11294)]
     public class A10Lions : BossModule
     {
         private Actor? _lioness;

--- a/BossMod/Modules/Endwalker/Alliance/A10RhalgrEmissary/A10RhalgrEmissary.cs
+++ b/BossMod/Modules/Endwalker/Alliance/A10RhalgrEmissary/A10RhalgrEmissary.cs
@@ -20,6 +20,7 @@
         public DestructiveStrike() : base(ActionID.MakeSpell(AID.DestructiveStrike), new AOEShapeCone(13, 60.Degrees())) { } // TODO: verify angle
     }
 
+    [ModuleInfo(CFCID = 866, NameID = 11274)]
     public class A10RhalgrEmissary : BossModule
     {
         public A10RhalgrEmissary(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(74, 516), 25)) { }

--- a/BossMod/Modules/Endwalker/Alliance/A11Byregot/A11Byregot.cs
+++ b/BossMod/Modules/Endwalker/Alliance/A11Byregot/A11Byregot.cs
@@ -5,6 +5,7 @@
         public ByregotWard() : base(ActionID.MakeSpell(AID.ByregotWard), new AOEShapeCone(10, 45.Degrees())) { }
     }
 
+    [ModuleInfo(CFCID = 866, NameID = 11281)]
     public class A11Byregot : BossModule
     {
         public A11Byregot(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(0, 700), 25)) { }

--- a/BossMod/Modules/Endwalker/Alliance/A12Rhalgr/A12Rhalgr.cs
+++ b/BossMod/Modules/Endwalker/Alliance/A12Rhalgr/A12Rhalgr.cs
@@ -15,6 +15,7 @@
         public BronzeLightning() : base(ActionID.MakeSpell(AID.BronzeLightning), new AOEShapeCone(50, 22.5f.Degrees()), 4) { }
     }
 
+    [ModuleInfo(CFCID = 866, NameID = 11273)]
     public class A12Rhalgr : BossModule
     {
         public A12Rhalgr(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(-15, 275), 30)) // note: arena has a really complex shape...

--- a/BossMod/Modules/Endwalker/Alliance/A13Azeyma/A13Azeyma.cs
+++ b/BossMod/Modules/Endwalker/Alliance/A13Azeyma/A13Azeyma.cs
@@ -25,6 +25,7 @@
         public SublimeSunset() : base(ActionID.MakeSpell(AID.SublimeSunsetAOE), 40) { } // TODO: check falloff
     }
 
+    [ModuleInfo(CFCID = 866, NameID = 11277)]
     public class A13Azeyma : BossModule
     {
         public A13Azeyma(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(-750, -750), 30)) { }

--- a/BossMod/Modules/Endwalker/Alliance/A14Naldthal/A14Naldthal.cs
+++ b/BossMod/Modules/Endwalker/Alliance/A14Naldthal/A14Naldthal.cs
@@ -46,6 +46,7 @@
     }
 
     // TODO: balancing counter
+    [ModuleInfo(CFCID = 866, NameID = 11286)]
     public class A14Naldthal : BossModule
     {
         public A14Naldthal(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(750, -750), 30)) { }

--- a/BossMod/Modules/Endwalker/Alliance/A21Nophica/A21Nophica.cs
+++ b/BossMod/Modules/Endwalker/Alliance/A21Nophica/A21Nophica.cs
@@ -30,6 +30,7 @@
         public HeavensEarth() : base(ActionID.MakeSpell(AID.HeavensEarthAOE), new AOEShapeCircle(5), true) { }
     }
 
+    [ModuleInfo(CFCID = 911, NameID = 12065)]
     public class A21Nophica : BossModule
     {
         public A21Nophica(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(0, -238), 30)) { }

--- a/BossMod/Modules/Endwalker/Alliance/A22AlthykNymeia/A22AlthykNymeia.cs
+++ b/BossMod/Modules/Endwalker/Alliance/A22AlthykNymeia/A22AlthykNymeia.cs
@@ -12,7 +12,7 @@ namespace BossMod.Endwalker.Alliance.A22AlthykNymeia
         public Hydroptosis() : base(ActionID.MakeSpell(AID.HydroptosisAOE), 6) { }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.Althyk)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.Althyk, CFCID = 911, NameID = 12244)]
     public class A22AlthykNymeia : BossModule
     {
         private Actor? _nymeia;

--- a/BossMod/Modules/Endwalker/Alliance/A23Halone/A23Halone.cs
+++ b/BossMod/Modules/Endwalker/Alliance/A23Halone/A23Halone.cs
@@ -45,6 +45,7 @@
         public Niphas() : base(ActionID.MakeSpell(AID.Niphas), new AOEShapeCircle(9)) { }
     }
 
+    [ModuleInfo(CFCID = 911, NameID = 12064)]
     public class A23Halone : BossModule
     {
         public A23Halone(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(-700, 600), 30)) { }

--- a/BossMod/Modules/Endwalker/Alliance/A24Menphina/A24Menphina.cs
+++ b/BossMod/Modules/Endwalker/Alliance/A24Menphina/A24Menphina.cs
@@ -60,6 +60,7 @@
         public MoonsetRays() : base(ActionID.MakeSpell(AID.MoonsetRaysAOE), 6, 4) { }
     }
 
+    [ModuleInfo(CFCID = 911, NameID = 12063)]
     public class A24Menphina : BossModule
     {
         public A24Menphina(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(800, 750), 30)) { }

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Armor.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Armor.cs
@@ -57,6 +57,6 @@
     [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss, CFCID = 878, NameID = 11515)]
     public class C010NArmor : SimpleBossModule { public C010NArmor(WorldState ws, Actor primary) : base(ws, primary) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 878, NameID = 11515)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 879, NameID = 11515)]
     public class C010SArmor : SimpleBossModule { public C010SArmor(WorldState ws, Actor primary) : base(ws, primary) { } }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Armor.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Armor.cs
@@ -54,9 +54,9 @@
     class C010NArmorStates : C010ArmorStates { public C010NArmorStates(BossModule module) : base(module, false) { } }
     class C010SArmorStates : C010ArmorStates { public C010SArmorStates(BossModule module) : base(module, true) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss, CFCID = 878, NameID = 11515)]
     public class C010NArmor : SimpleBossModule { public C010NArmor(WorldState ws, Actor primary) : base(ws, primary) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 878, NameID = 11515)]
     public class C010SArmor : SimpleBossModule { public C010SArmor(WorldState ws, Actor primary) : base(ws, primary) { } }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Belladonna.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Belladonna.cs
@@ -57,6 +57,6 @@
     [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss, CFCID = 878, NameID = 11514)]
     public class C010NBelladonna : SimpleBossModule { public C010NBelladonna(WorldState ws, Actor primary) : base(ws, primary) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 878, NameID = 11514)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 879, NameID = 11514)]
     public class C010SBelladonna : SimpleBossModule { public C010SBelladonna(WorldState ws, Actor primary) : base(ws, primary) { } }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Belladonna.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Belladonna.cs
@@ -54,9 +54,9 @@
     class C010NBelladonnaStates : C010BelladonnaStates { public C010NBelladonnaStates(BossModule module) : base(module, false) { } }
     class C010SBelladonnaStates : C010BelladonnaStates { public C010SBelladonnaStates(BossModule module) : base(module, true) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss, CFCID = 878, NameID = 11514)]
     public class C010NBelladonna : SimpleBossModule { public C010NBelladonna(WorldState ws, Actor primary) : base(ws, primary) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 878, NameID = 11514)]
     public class C010SBelladonna : SimpleBossModule { public C010SBelladonna(WorldState ws, Actor primary) : base(ws, primary) { } }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Dryad.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Dryad.cs
@@ -70,7 +70,7 @@ namespace BossMod.Endwalker.Criterion.C01ASS.C010Dryad
     class C010NDryadStates : C010DryadStates { public C010NDryadStates(BossModule module) : base(module, false) { } }
     class C010SDryadStates : C010DryadStates { public C010SDryadStates(BossModule module) : base(module, true) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss, CFCID = 878, NameID = 11513)]
     public class C010NDryad : SimpleBossModule
     {
         public C010NDryad(WorldState ws, Actor primary) : base(ws, primary) { }
@@ -82,7 +82,7 @@ namespace BossMod.Endwalker.Criterion.C01ASS.C010Dryad
         }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 878, NameID = 11513)]
     public class C010SDryad : SimpleBossModule
     {
         public C010SDryad(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Dryad.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Dryad.cs
@@ -82,7 +82,7 @@ namespace BossMod.Endwalker.Criterion.C01ASS.C010Dryad
         }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 878, NameID = 11513)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 879, NameID = 11513)]
     public class C010SDryad : SimpleBossModule
     {
         public C010SDryad(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Dullahan.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Dullahan.cs
@@ -57,6 +57,6 @@
     [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss, CFCID = 878, NameID = 11506)]
     public class C010NDullahan : SimpleBossModule { public C010NDullahan(WorldState ws, Actor primary) : base(ws, primary) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 878, NameID = 11506)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 879, NameID = 11506)]
     public class C010SDullahan : SimpleBossModule { public C010SDullahan(WorldState ws, Actor primary) : base(ws, primary) { } }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Dullahan.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Dullahan.cs
@@ -54,9 +54,9 @@
     class C010NDullahanStates : C010DullahanStates { public C010NDullahanStates(BossModule module) : base(module, false) { } }
     class C010SDullahanStates : C010DullahanStates { public C010SDullahanStates(BossModule module) : base(module, true) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss, CFCID = 878, NameID = 11506)]
     public class C010NDullahan : SimpleBossModule { public C010NDullahan(WorldState ws, Actor primary) : base(ws, primary) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 878, NameID = 11506)]
     public class C010SDullahan : SimpleBossModule { public C010SDullahan(WorldState ws, Actor primary) : base(ws, primary) { } }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Kaluk.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Kaluk.cs
@@ -54,9 +54,9 @@
     class C010NKalukStates : C010KalukStates { public C010NKalukStates(BossModule module) : base(module, false) { } }
     class C010SKalukStates : C010KalukStates { public C010SKalukStates(BossModule module) : base(module, true) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss, CFCID = 878, NameID = 11510)]
     public class C010NKaluk : SimpleBossModule { public C010NKaluk(WorldState ws, Actor primary) : base(ws, primary) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 878, NameID = 11510)]
     public class C010SKaluk : SimpleBossModule { public C010SKaluk(WorldState ws, Actor primary) : base(ws, primary) { } }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Kaluk.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Kaluk.cs
@@ -57,6 +57,6 @@
     [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss, CFCID = 878, NameID = 11510)]
     public class C010NKaluk : SimpleBossModule { public C010NKaluk(WorldState ws, Actor primary) : base(ws, primary) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 878, NameID = 11510)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 879, NameID = 11510)]
     public class C010SKaluk : SimpleBossModule { public C010SKaluk(WorldState ws, Actor primary) : base(ws, primary) { } }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Udumbara.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Udumbara.cs
@@ -70,7 +70,7 @@ namespace BossMod.Endwalker.Criterion.C01ASS.C010Udumbara
     class C010NUdumbaraStates : C010UdumbaraStates { public C010NUdumbaraStates(BossModule module) : base(module, false) { } }
     class C010SUdumbaraStates : C010UdumbaraStates { public C010SUdumbaraStates(BossModule module) : base(module, true) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss, CFCID = 878, NameID = 11511)]
     public class C010NUdumbara : SimpleBossModule
     {
         public C010NUdumbara(WorldState ws, Actor primary) : base(ws, primary) { }
@@ -82,7 +82,7 @@ namespace BossMod.Endwalker.Criterion.C01ASS.C010Udumbara
         }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 878, NameID = 11511)]
     public class C010SUdumbara : SimpleBossModule
     {
         public C010SUdumbara(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Udumbara.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Udumbara.cs
@@ -82,7 +82,7 @@ namespace BossMod.Endwalker.Criterion.C01ASS.C010Udumbara
         }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 878, NameID = 11511)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 879, NameID = 11511)]
     public class C010SUdumbara : SimpleBossModule
     {
         public C010SUdumbara(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C011Silkie/C011Silkie.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C011Silkie/C011Silkie.cs
@@ -58,9 +58,9 @@
         public C011Silkie(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(-335, -155), 20)) { }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss, CFCID = 878, NameID = 11369)]
     public class C011NSilkie : C011Silkie { public C011NSilkie(WorldState ws, Actor primary) : base(ws, primary) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 878, NameID = 11369)]
     public class C011SSilkie : C011Silkie { public C011SSilkie(WorldState ws, Actor primary) : base(ws, primary) { } }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C011Silkie/C011Silkie.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C011Silkie/C011Silkie.cs
@@ -61,6 +61,6 @@
     [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss, CFCID = 878, NameID = 11369)]
     public class C011NSilkie : C011Silkie { public C011NSilkie(WorldState ws, Actor primary) : base(ws, primary) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 878, NameID = 11369)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 879, NameID = 11369)]
     public class C011SSilkie : C011Silkie { public C011SSilkie(WorldState ws, Actor primary) : base(ws, primary) { } }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C012Gladiator/C012Gladiator.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C012Gladiator/C012Gladiator.cs
@@ -19,9 +19,9 @@
         public C012Gladiator(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(-35, -271), 20)) { }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss, CFCID = 878, NameID = 11387)]
     public class C012NGladiator : C012Gladiator { public C012NGladiator(WorldState ws, Actor primary) : base(ws, primary) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 878, NameID = 11387)]
     public class C012SGladiator : C012Gladiator { public C012SGladiator(WorldState ws, Actor primary) : base(ws, primary) { } }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C012Gladiator/C012Gladiator.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C012Gladiator/C012Gladiator.cs
@@ -22,6 +22,6 @@
     [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss, CFCID = 878, NameID = 11387)]
     public class C012NGladiator : C012Gladiator { public C012NGladiator(WorldState ws, Actor primary) : base(ws, primary) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 878, NameID = 11387)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 879, NameID = 11387)]
     public class C012SGladiator : C012Gladiator { public C012SGladiator(WorldState ws, Actor primary) : base(ws, primary) { } }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C013Shadowcaster/C013Shadowcaster.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C013Shadowcaster/C013Shadowcaster.cs
@@ -30,6 +30,6 @@
     [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss, CFCID = 878, NameID = 11393)]
     public class C013NShadowcaster : C013Shadowcaster { public C013NShadowcaster(WorldState ws, Actor primary) : base(ws, primary) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 878, NameID = 11393)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 879, NameID = 11393)]
     public class C013SShadowcaster : C013Shadowcaster { public C013SShadowcaster(WorldState ws, Actor primary) : base(ws, primary) { } }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C013Shadowcaster/C013Shadowcaster.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C013Shadowcaster/C013Shadowcaster.cs
@@ -27,9 +27,9 @@
         public C013Shadowcaster(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsRect(new(289, -105), 15, 20)) { }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss, CFCID = 878, NameID = 11393)]
     public class C013NShadowcaster : C013Shadowcaster { public C013NShadowcaster(WorldState ws, Actor primary) : base(ws, primary) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 878, NameID = 11393)]
     public class C013SShadowcaster : C013Shadowcaster { public C013SShadowcaster(WorldState ws, Actor primary) : base(ws, primary) { } }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C020Trash/C020Fuko.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C020Trash/C020Fuko.cs
@@ -95,7 +95,7 @@
         }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SFuko, CFCID = 946, NameID = 12399)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SFuko, CFCID = 947, NameID = 12399)]
     public class C020SFuko : C020Trash1
     {
         public C020SFuko(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C020Trash/C020Fuko.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C020Trash/C020Fuko.cs
@@ -82,7 +82,7 @@
     class C020NFukoStates : C020FukoStates { public C020NFukoStates(BossModule module) : base(module, false) { } }
     class C020SFukoStates : C020FukoStates { public C020SFukoStates(BossModule module) : base(module, true) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.NFuko)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.NFuko, CFCID = 946, NameID = 12399)]
     public class C020NFuko : C020Trash1
     {
         public C020NFuko(WorldState ws, Actor primary) : base(ws, primary) { }
@@ -95,7 +95,7 @@
         }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SFuko)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SFuko, CFCID = 946, NameID = 12399)]
     public class C020SFuko : C020Trash1
     {
         public C020SFuko(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C020Trash/C020Kotengu.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C020Trash/C020Kotengu.cs
@@ -76,6 +76,6 @@ namespace BossMod.Endwalker.Criterion.C02AMR.C020Trash2
     [ModuleInfo(PrimaryActorOID = (uint)OID.NKotengu, CFCID = 946, NameID = 12410)]
     public class C020NKotengu : C020Trash2 { public C020NKotengu(WorldState ws, Actor primary) : base(ws, primary) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SKotengu, CFCID = 946, NameID = 12410)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SKotengu, CFCID = 947, NameID = 12410)]
     public class C020SKotengu : C020Trash2 { public C020SKotengu(WorldState ws, Actor primary) : base(ws, primary) { } }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C020Trash/C020Kotengu.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C020Trash/C020Kotengu.cs
@@ -73,9 +73,9 @@ namespace BossMod.Endwalker.Criterion.C02AMR.C020Trash2
     class C020NKotenguStates : C020KotenguStates { public C020NKotenguStates(BossModule module) : base(module, false) { } }
     class C020SKotenguStates : C020KotenguStates { public C020SKotenguStates(BossModule module) : base(module, true) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.NKotengu)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.NKotengu, CFCID = 946, NameID = 12410)]
     public class C020NKotengu : C020Trash2 { public C020NKotengu(WorldState ws, Actor primary) : base(ws, primary) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SKotengu)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SKotengu, CFCID = 946, NameID = 12410)]
     public class C020SKotengu : C020Trash2 { public C020SKotengu(WorldState ws, Actor primary) : base(ws, primary) { } }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C020Trash/C020Onmitsugashira.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C020Trash/C020Onmitsugashira.cs
@@ -55,6 +55,6 @@
     [ModuleInfo(PrimaryActorOID = (uint)OID.NOnmitsugashira, CFCID = 946, NameID = 12424)]
     public class C020NOnmitsugashira : C020Trash2 { public C020NOnmitsugashira(WorldState ws, Actor primary) : base(ws, primary) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SOnmitsugashira, CFCID = 946, NameID = 12424)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SOnmitsugashira, CFCID = 947, NameID = 12424)]
     public class C020SOnmitsugashira : C020Trash2 { public C020SOnmitsugashira(WorldState ws, Actor primary) : base(ws, primary) { } }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C020Trash/C020Onmitsugashira.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C020Trash/C020Onmitsugashira.cs
@@ -52,9 +52,9 @@
     class C020NOnmitsugashiraStates : C020OnmitsugashiraStates { public C020NOnmitsugashiraStates(BossModule module) : base(module, false) { } }
     class C020SOnmitsugashiraStates : C020OnmitsugashiraStates { public C020SOnmitsugashiraStates(BossModule module) : base(module, true) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.NOnmitsugashira)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.NOnmitsugashira, CFCID = 946, NameID = 12424)]
     public class C020NOnmitsugashira : C020Trash2 { public C020NOnmitsugashira(WorldState ws, Actor primary) : base(ws, primary) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SOnmitsugashira)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SOnmitsugashira, CFCID = 946, NameID = 12424)]
     public class C020SOnmitsugashira : C020Trash2 { public C020SOnmitsugashira(WorldState ws, Actor primary) : base(ws, primary) { } }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C020Trash/C020Raiko.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C020Trash/C020Raiko.cs
@@ -89,7 +89,7 @@
     class C020NRaikoStates : C020RaikoStates { public C020NRaikoStates(BossModule module) : base(module, false) { } }
     class C020SRaikoStates : C020RaikoStates { public C020SRaikoStates(BossModule module) : base(module, true) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.NRaiko)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.NRaiko, CFCID = 946, NameID = 12422)]
     public class C020NRaiko : C020Trash1
     {
         public C020NRaiko(WorldState ws, Actor primary) : base(ws, primary) { }
@@ -102,7 +102,7 @@
         }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SRaiko)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SRaiko, CFCID = 946, NameID = 12422)]
     public class C020SRaiko : C020Trash1
     {
         public C020SRaiko(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C020Trash/C020Raiko.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C020Trash/C020Raiko.cs
@@ -102,7 +102,7 @@
         }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SRaiko, CFCID = 946, NameID = 12422)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SRaiko, CFCID = 947, NameID = 12422)]
     public class C020SRaiko : C020Trash1
     {
         public C020SRaiko(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C020Trash/C020Yuki.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C020Trash/C020Yuki.cs
@@ -31,6 +31,6 @@
     [ModuleInfo(PrimaryActorOID = (uint)OID.NYuki, CFCID = 946, NameID = 12425)]
     public class C020NYuki : C020Trash1 { public C020NYuki(WorldState ws, Actor primary) : base(ws, primary) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SYuki, CFCID = 946, NameID = 12425)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SYuki, CFCID = 947, NameID = 12425)]
     public class C020SYuki : C020Trash1 { public C020SYuki(WorldState ws, Actor primary) : base(ws, primary) { } }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C020Trash/C020Yuki.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C020Trash/C020Yuki.cs
@@ -28,9 +28,9 @@
     class C020NYukiStates : C020YukiStates { public C020NYukiStates(BossModule module) : base(module, false) { } }
     class C020SYukiStates : C020YukiStates { public C020SYukiStates(BossModule module) : base(module, true) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.NYuki)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.NYuki, CFCID = 946, NameID = 12425)]
     public class C020NYuki : C020Trash1 { public C020NYuki(WorldState ws, Actor primary) : base(ws, primary) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SYuki)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SYuki, CFCID = 946, NameID = 12425)]
     public class C020SYuki : C020Trash1 { public C020SYuki(WorldState ws, Actor primary) : base(ws, primary) { } }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C021Shishio/C021Shishio.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C021Shishio/C021Shishio.cs
@@ -19,9 +19,9 @@
         public C021Shishio(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(0, -100), 20)) { }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss, CFCID = 946, NameID = 12428)]
     public class C021NShishio : C021Shishio { public C021NShishio(WorldState ws, Actor primary) : base(ws, primary) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 946, NameID = 12428)]
     public class C021SShishio : C021Shishio { public C021SShishio(WorldState ws, Actor primary) : base(ws, primary) { } }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C021Shishio/C021Shishio.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C021Shishio/C021Shishio.cs
@@ -22,6 +22,6 @@
     [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss, CFCID = 946, NameID = 12428)]
     public class C021NShishio : C021Shishio { public C021NShishio(WorldState ws, Actor primary) : base(ws, primary) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 946, NameID = 12428)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 947, NameID = 12428)]
     public class C021SShishio : C021Shishio { public C021SShishio(WorldState ws, Actor primary) : base(ws, primary) { } }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C022Gorai/C022Gorai.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C022Gorai/C022Gorai.cs
@@ -15,6 +15,6 @@
     [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss, CFCID = 946, NameID = 12373)]
     public class C022NGorai : C022Gorai { public C022NGorai(WorldState ws, Actor primary) : base(ws, primary) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 946, NameID = 12373)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 947, NameID = 12373)]
     public class C022SGorai : C022Gorai { public C022SGorai(WorldState ws, Actor primary) : base(ws, primary) { } }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C022Gorai/C022Gorai.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C022Gorai/C022Gorai.cs
@@ -12,9 +12,9 @@
         public C022Gorai(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(300, -120), 20)) { }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss, CFCID = 946, NameID = 12373)]
     public class C022NGorai : C022Gorai { public C022NGorai(WorldState ws, Actor primary) : base(ws, primary) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 946, NameID = 12373)]
     public class C022SGorai : C022Gorai { public C022SGorai(WorldState ws, Actor primary) : base(ws, primary) { } }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C023Moko/C023Moko.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C023Moko/C023Moko.cs
@@ -15,6 +15,6 @@
     [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss, CFCID = 946, NameID = 12357)]
     public class C023NMoko : C023Moko { public C023NMoko(WorldState ws, Actor primary) : base(ws, primary) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 946, NameID = 12357)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 947, NameID = 12357)]
     public class C023SMoko : C023Moko { public C023SMoko(WorldState ws, Actor primary) : base(ws, primary) { } }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C023Moko/C023Moko.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C023Moko/C023Moko.cs
@@ -12,9 +12,9 @@
         public C023Moko(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(-200, 0), 20)) { }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.NBoss, CFCID = 946, NameID = 12357)]
     public class C023NMoko : C023Moko { public C023NMoko(WorldState ws, Actor primary) : base(ws, primary) { } }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SBoss, CFCID = 946, NameID = 12357)]
     public class C023SMoko : C023Moko { public C023SMoko(WorldState ws, Actor primary) : base(ws, primary) { } }
 }

--- a/BossMod/Modules/Endwalker/Extreme/Ex1Zodiark/Ex1Zodiark.cs
+++ b/BossMod/Modules/Endwalker/Extreme/Ex1Zodiark/Ex1Zodiark.cs
@@ -17,6 +17,7 @@
         public Ex1ZodiarkConfig() : base(90) { }
     }
 
+    [ModuleInfo(CFCID = 803, NameID = 10456)]
     public class Ex1Zodiark : BossModule
     {
         public Ex1Zodiark(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(100, 100), 20)) { }

--- a/BossMod/Modules/Endwalker/Extreme/Ex2Hydaelyn/Ex2Hydaelyn.cs
+++ b/BossMod/Modules/Endwalker/Extreme/Ex2Hydaelyn/Ex2Hydaelyn.cs
@@ -24,6 +24,7 @@
         public Ex2HydaelynConfig() : base(90) { }
     }
 
+    [ModuleInfo(CFCID = 791, NameID = 10453)]
     public class Ex2Hydaelyn : BossModule
     {
         public Ex2Hydaelyn(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(100, 100), 20)) { }

--- a/BossMod/Modules/Endwalker/Extreme/Ex3Endsinger/Ex3Endsinger.cs
+++ b/BossMod/Modules/Endwalker/Extreme/Ex3Endsinger/Ex3Endsinger.cs
@@ -34,6 +34,7 @@
         public Ex3EndsingerConfig() : base(90) { }
     }
 
+    [ModuleInfo(CFCID = 846, NameID = 10448)]
     public class Ex3Endsinger : BossModule
     {
         public Ex3Endsinger(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(100, 100), 20)) { }

--- a/BossMod/Modules/Endwalker/Extreme/Ex4Barbariccia/Ex4Barbariccia.cs
+++ b/BossMod/Modules/Endwalker/Extreme/Ex4Barbariccia/Ex4Barbariccia.cs
@@ -120,6 +120,7 @@
         public IronOut() : base(ActionID.MakeSpell(AID.IronOutAOE)) { }
     }
 
+    [ModuleInfo(CFCID = 871, NameID = 11398)]
     public class Ex4Barbariccia : BossModule
     {
         public Ex4Barbariccia(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(100, 100), 20)) { }

--- a/BossMod/Modules/Endwalker/Extreme/Ex5Rubicante/Ex5Rubicante.cs
+++ b/BossMod/Modules/Endwalker/Extreme/Ex5Rubicante/Ex5Rubicante.cs
@@ -21,6 +21,7 @@
         public Ex5RubicanteConfig() : base(90) { }
     }
 
+    [ModuleInfo(CFCID = 924, NameID = 12057)]
     public class Ex5Rubicante : BossModule
     {
         public Ex5Rubicante(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(100, 100), 20)) { }

--- a/BossMod/Modules/Endwalker/Extreme/Ex6Golbez/Ex6Golbez.cs
+++ b/BossMod/Modules/Endwalker/Extreme/Ex6Golbez/Ex6Golbez.cs
@@ -76,6 +76,7 @@
         public Ex6GolbezConfig() : base(90) { }
     }
 
+    [ModuleInfo(CFCID = 950, NameID = 12365)]
     public class Ex6Golbez : BossModule
     {
         public Ex6Golbez(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(100, 100), 15)) { }

--- a/BossMod/Modules/Endwalker/Extreme/Ex7Zeromus/Ex7Zeromus.cs
+++ b/BossMod/Modules/Endwalker/Extreme/Ex7Zeromus/Ex7Zeromus.cs
@@ -31,6 +31,7 @@
         public Ex7ZeromusConfig() : base(90) { }
     }
 
+    [ModuleInfo(CFCID = 965, NameID = 12586)]
     public class Ex7Zeromus : BossModule
     {
         public Ex7Zeromus(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(100, 100), 20)) { }

--- a/BossMod/Modules/Endwalker/HuntA/Aegeiros.cs
+++ b/BossMod/Modules/Endwalker/HuntA/Aegeiros.cs
@@ -75,6 +75,7 @@ namespace BossMod.Endwalker.HuntA.Aegeiros
         }
     }
 
+    [ModuleInfo(NotoriousMonsterID = 195)]
     public class Aegeiros : SimpleBossModule
     {
         public Aegeiros(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/HuntA/ArchEta.cs
+++ b/BossMod/Modules/Endwalker/HuntA/ArchEta.cs
@@ -54,6 +54,7 @@
         }
     }
 
+    [ModuleInfo(NotoriousMonsterID = 224)]
     public class ArchEta : SimpleBossModule
     {
         public ArchEta(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/HuntA/FanAil.cs
+++ b/BossMod/Modules/Endwalker/HuntA/FanAil.cs
@@ -56,6 +56,7 @@
         }
     }
 
+    [ModuleInfo(NotoriousMonsterID = 225)]
     public class FanAil : SimpleBossModule
     {
         public FanAil(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/HuntA/Gurangatch.cs
+++ b/BossMod/Modules/Endwalker/HuntA/Gurangatch.cs
@@ -137,6 +137,7 @@ namespace BossMod.Endwalker.HuntA.Gurangatch
         }
     }
 
+    [ModuleInfo(NotoriousMonsterID = 215)]
     public class Gurangatch : SimpleBossModule
     {
         public Gurangatch(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/HuntA/Hulder.cs
+++ b/BossMod/Modules/Endwalker/HuntA/Hulder.cs
@@ -53,6 +53,7 @@
         }
     }
 
+    [ModuleInfo(NotoriousMonsterID = 174)]
     public class Hulder : SimpleBossModule
     {
         public Hulder(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/HuntA/LunatenderQueen.cs
+++ b/BossMod/Modules/Endwalker/HuntA/LunatenderQueen.cs
@@ -74,6 +74,7 @@
         }
     }
 
+    [ModuleInfo(NotoriousMonsterID = 205)]
     public class LunatenderQueen : SimpleBossModule
     {
         public LunatenderQueen(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/HuntA/Minerva.cs
+++ b/BossMod/Modules/Endwalker/HuntA/Minerva.cs
@@ -117,6 +117,7 @@ namespace BossMod.Endwalker.HuntA.Minerva
         }
     }
 
+    [ModuleInfo(NotoriousMonsterID = 194)]
     public class Minerva : SimpleBossModule
     {
         public Minerva(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/HuntA/MoussePrincess.cs
+++ b/BossMod/Modules/Endwalker/HuntA/MoussePrincess.cs
@@ -100,6 +100,7 @@ namespace BossMod.Endwalker.HuntA.MoussePrincess
         }
     }
 
+    [ModuleInfo(NotoriousMonsterID = 204)]
     public class MoussePrincess : SimpleBossModule
     {
         public MoussePrincess(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/HuntA/Petalodus.cs
+++ b/BossMod/Modules/Endwalker/HuntA/Petalodus.cs
@@ -49,6 +49,7 @@ namespace BossMod.Endwalker.HuntA.Petalodus
         }
     }
 
+    [ModuleInfo(NotoriousMonsterID = 214)]
     public class Petalodus : SimpleBossModule
     {
         public Petalodus(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/HuntA/Storsie.cs
+++ b/BossMod/Modules/Endwalker/HuntA/Storsie.cs
@@ -74,6 +74,7 @@ namespace BossMod.Endwalker.HuntA.Storsie
         }
     }
 
+    [ModuleInfo(NotoriousMonsterID = 175)]
     public class Storsie : SimpleBossModule
     {
         public Storsie(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/HuntA/Sugriva.cs
+++ b/BossMod/Modules/Endwalker/HuntA/Sugriva.cs
@@ -133,6 +133,7 @@ namespace BossMod.Endwalker.HuntA.Sugriva
         }
     }
 
+    [ModuleInfo(NotoriousMonsterID = 185)]
     public class Sugriva : SimpleBossModule
     {
         public Sugriva(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/HuntA/Yilan.cs
+++ b/BossMod/Modules/Endwalker/HuntA/Yilan.cs
@@ -91,6 +91,7 @@ namespace BossMod.Endwalker.HuntA.Yilan
         }
     }
 
+    [ModuleInfo(NotoriousMonsterID = 184)]
     public class Yilan : SimpleBossModule
     {
         public Yilan(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/HuntS/Armstrong.cs
+++ b/BossMod/Modules/Endwalker/HuntS/Armstrong.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Dynamic;
 
 namespace BossMod.Endwalker.HuntS.Armstrong
 {
@@ -100,7 +101,7 @@ namespace BossMod.Endwalker.HuntS.Armstrong
                 .ActivateOnEnter<SoporificGas>();
         }
     }
-
+    [ModuleInfo(NotoriousMonsterID = 196)]
     public class Armstrong : SimpleBossModule
     {
         public Armstrong(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/HuntS/Burfurlur.cs
+++ b/BossMod/Modules/Endwalker/HuntS/Burfurlur.cs
@@ -96,6 +96,7 @@ namespace BossMod.Endwalker.HuntS.Burfurlur
         }
     }
 
+    [ModuleInfo(NotoriousMonsterID = 176)]
     public class Burfurlur : SimpleBossModule
     {
         public Burfurlur(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/HuntS/Ker.cs
+++ b/BossMod/Modules/Endwalker/HuntS/Ker.cs
@@ -254,6 +254,7 @@ namespace BossMod.Endwalker.HuntS.Ker
         }
     }
 
+    [ModuleInfo(NotoriousMonsterID = 181)]
     public class Ker : SimpleBossModule
     {
         public Ker(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/HuntS/KerShroud.cs
+++ b/BossMod/Modules/Endwalker/HuntS/KerShroud.cs
@@ -32,6 +32,7 @@
         }
     }
 
+    [ModuleInfo(NotoriousMonsterID = 177)]
     public class KerShroud : SimpleBossModule
     {
         public KerShroud(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/HuntS/NarrowRift.cs
+++ b/BossMod/Modules/Endwalker/HuntS/NarrowRift.cs
@@ -129,6 +129,7 @@ namespace BossMod.Endwalker.HuntS.NarrowRift
         }
     }
 
+    [ModuleInfo(NotoriousMonsterID = 226)]
     public class NarrowRift : SimpleBossModule
     {
         public NarrowRift(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/HuntS/Ophioneus.cs
+++ b/BossMod/Modules/Endwalker/HuntS/Ophioneus.cs
@@ -89,6 +89,7 @@ namespace BossMod.Endwalker.HuntS.Ophioneus
         }
     }
 
+    [ModuleInfo(NotoriousMonsterID = 216)]
     public class Ophioneus : SimpleBossModule
     {
         public Ophioneus(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/HuntS/Ruminator.cs
+++ b/BossMod/Modules/Endwalker/HuntS/Ruminator.cs
@@ -88,6 +88,7 @@ namespace BossMod.Endwalker.HuntS.Ruminator
         }
     }
 
+    [ModuleInfo(NotoriousMonsterID = 206)]
     public class Ruminator : SimpleBossModule
     {
         public Ruminator(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/HuntS/Sphatika.cs
+++ b/BossMod/Modules/Endwalker/HuntS/Sphatika.cs
@@ -150,6 +150,7 @@ namespace BossMod.Endwalker.HuntS.Sphatika
         }
     }
 
+    [ModuleInfo(NotoriousMonsterID = 186)]
     public class Sphatika : SimpleBossModule
     {
         public Sphatika(WorldState ws, Actor primary) : base(ws, primary) { }

--- a/BossMod/Modules/Endwalker/Savage/P10SPandaemonium/P10SPandaemonium.cs
+++ b/BossMod/Modules/Endwalker/Savage/P10SPandaemonium/P10SPandaemonium.cs
@@ -51,6 +51,7 @@ namespace BossMod.Endwalker.Savage.P10SPandaemonium
         public P10SPandaemoniumConfig() : base(90) { }
     }
 
+    [ModuleInfo(CFCID = 939, NameID = 12354)]
     public class P10SPandaemonium : BossModule
     {
         public P10SPandaemonium(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsRect(new(100, 92.5f), 30, 22.5f)) { }

--- a/BossMod/Modules/Endwalker/Savage/P11SThemis/P11SThemis.cs
+++ b/BossMod/Modules/Endwalker/Savage/P11SThemis/P11SThemis.cs
@@ -6,6 +6,7 @@
         public P11SThemisConfig() : base(90) { }
     }
 
+    [ModuleInfo(CFCID = 941, NameID = 12388)]
     public class P11SThemis : BossModule
     {
         public P11SThemis(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(100, 100), 20)) { }

--- a/BossMod/Modules/Endwalker/Savage/P12S1Athena/P12S1Athena.cs
+++ b/BossMod/Modules/Endwalker/Savage/P12S1Athena/P12S1Athena.cs
@@ -15,6 +15,7 @@
         public Parthenos() : base(ActionID.MakeSpell(AID.Parthenos), new AOEShapeRect(60, 8, 60)) { }
     }
 
+    [ModuleInfo(CFCID = 943, NameID = 12377)]
     public class P12S1Athena : BossModule
     {
         public P12S1Athena(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(100, 100), 20)) { }

--- a/BossMod/Modules/Endwalker/Savage/P12S2PallasAthena/P12S2PallasAthena.cs
+++ b/BossMod/Modules/Endwalker/Savage/P12S2PallasAthena/P12S2PallasAthena.cs
@@ -1,5 +1,6 @@
 ﻿namespace BossMod.Endwalker.Savage.P12S2PallasAthena
 {
+    [ModuleInfo(CFCID = 943, NameID = 12382)]
     public class P12S2PallasAthena : BossModule
     {
         public static ArenaBoundsRect DefaultBounds = new ArenaBoundsRect(new(100, 95), 20, 15);

--- a/BossMod/Modules/Endwalker/Savage/P1SErichthonios/P1S.cs
+++ b/BossMod/Modules/Endwalker/Savage/P1SErichthonios/P1S.cs
@@ -1,5 +1,6 @@
 ﻿namespace BossMod.Endwalker.Savage.P1SErichthonios
 {
+    [ModuleInfo(CFCID = 809, NameID = 10576)]
     public class P1S : BossModule
     {
         public static float InnerCircleRadius { get; } = 12; // this determines in/out flails and cells boundary

--- a/BossMod/Modules/Endwalker/Savage/P2SHippokampos/P2S.cs
+++ b/BossMod/Modules/Endwalker/Savage/P2SHippokampos/P2S.cs
@@ -16,6 +16,7 @@
         public P2SConfig() : base(90) { }
     }
 
+    [ModuleInfo(CFCID = 811, NameID = 10348)]
     public class P2S : BossModule
     {
         public P2S(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(100, 100), 20)) { }

--- a/BossMod/Modules/Endwalker/Savage/P3SPhoinix/P3S.cs
+++ b/BossMod/Modules/Endwalker/Savage/P3SPhoinix/P3S.cs
@@ -11,6 +11,7 @@
         public HeatOfCondemnation() : base(ActionID.MakeSpell(AID.HeatOfCondemnationAOE), (uint)TetherID.HeatOfCondemnation, 6) { }
     }
 
+    [ModuleInfo(CFCID = 807, NameID = 10720)]
     public class P3S : BossModule
     {
         public P3S(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(100, 100), 20)) { }

--- a/BossMod/Modules/Endwalker/Savage/P4S1Hesperos/P4S1.cs
+++ b/BossMod/Modules/Endwalker/Savage/P4S1Hesperos/P4S1.cs
@@ -13,6 +13,7 @@
         public P4S1Config() : base(90) { }
     }
 
+    [ModuleInfo(CFCID = 801, NameID = 10744)]
     public class P4S1 : BossModule
     {
         public P4S1(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(100, 100), 20)) { }

--- a/BossMod/Modules/Endwalker/Savage/P4S2Hesperos/P4S2.cs
+++ b/BossMod/Modules/Endwalker/Savage/P4S2Hesperos/P4S2.cs
@@ -13,6 +13,7 @@
         public HeartStake() : base(ActionID.MakeSpell(AID.HeartStakeSecond)) { }
     }
 
+    [ModuleInfo(CFCID = 801, NameID = 10744)]
     public class P4S2 : BossModule
     {
         // common wreath of thorns constants

--- a/BossMod/Modules/Endwalker/Savage/P5SProtoCarbuncle/P5S.cs
+++ b/BossMod/Modules/Endwalker/Savage/P5SProtoCarbuncle/P5S.cs
@@ -33,6 +33,7 @@
         public P5SConfig() : base(90) { }
     }
 
+    [ModuleInfo(CFCID = 873, NameID = 11440)]
     public class P5S : BossModule
     {
         public P5S(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(100, 100), 15)) { }

--- a/BossMod/Modules/Endwalker/Savage/P6SHegemone/P6S.cs
+++ b/BossMod/Modules/Endwalker/Savage/P6SHegemone/P6S.cs
@@ -26,6 +26,7 @@
         public P6SConfig() : base(90) { }
     }
 
+    [ModuleInfo(CFCID = 881, NameID = 11381)]
     public class P6S : BossModule
     {
         public P6S(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(100, 100), 20)) { }

--- a/BossMod/Modules/Endwalker/Savage/P7SAgdistis/P7S.cs
+++ b/BossMod/Modules/Endwalker/Savage/P7SAgdistis/P7S.cs
@@ -51,6 +51,7 @@
         public P7SConfig() : base(90) { }
     }
 
+    [ModuleInfo(CFCID = 877, NameID = 11374)]
     public class P7S : BossModule
     {
         public P7S(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(100, 100), 27)) { }

--- a/BossMod/Modules/Endwalker/Savage/P8S1Hephaistos/P8S1.cs
+++ b/BossMod/Modules/Endwalker/Savage/P8S1Hephaistos/P8S1.cs
@@ -10,6 +10,7 @@
         public AbyssalFires() : base(ActionID.MakeSpell(AID.AbyssalFires), 15) { } // TODO: verify falloff
     }
 
+    [ModuleInfo(CFCID = 884, NameID = 11399)]
     public class P8S1 : BossModule
     {
         public P8S1(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(100, 100), 20)) { }

--- a/BossMod/Modules/Endwalker/Savage/P8S2Hephaistos/P8S2.cs
+++ b/BossMod/Modules/Endwalker/Savage/P8S2Hephaistos/P8S2.cs
@@ -7,6 +7,7 @@
 
     // TODO: autoattack component
     // TODO: HC components
+    [ModuleInfo(CFCID = 884, NameID = 11399)]
     public class P8S2 : BossModule
     {
         public P8S2(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(100, 100), 20)) { }

--- a/BossMod/Modules/Endwalker/Savage/P9SKokytos/P9SKokytos.cs
+++ b/BossMod/Modules/Endwalker/Savage/P9SKokytos/P9SKokytos.cs
@@ -21,6 +21,7 @@
         public P9SKokytosConfig() : base(90) { }
     }
 
+    [ModuleInfo(CFCID = 937, NameID = 12369)]
     public class P9SKokytos : BossModule
     {
         public P9SKokytos(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(100, 100), 20)) { }

--- a/BossMod/Modules/Endwalker/TreasureHunt/GymnasiouPithekos.cs
+++ b/BossMod/Modules/Endwalker/TreasureHunt/GymnasiouPithekos.cs
@@ -96,6 +96,7 @@ namespace BossMod.Endwalker.TreasureHunt.GymnasiouPithekos
         }
     }
 
+    [ModuleInfo(CFCID = 909, NameID = 12001)]
     public class Pithekos : BossModule
     {
         public Pithekos(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(100, 100), 20)) {}

--- a/BossMod/Modules/Endwalker/TreasureHunt/LyssaChrysine.cs
+++ b/BossMod/Modules/Endwalker/TreasureHunt/LyssaChrysine.cs
@@ -146,6 +146,7 @@ namespace BossMod.Endwalker.TreasureHunt.LyssaChrysine
         }
     }
 
+    [ModuleInfo(CFCID = 909, NameID = 12024)]
     public class Lyssa : BossModule
     {
         public Lyssa(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(100, 100), 20)) {}

--- a/BossMod/Modules/Endwalker/Ultimate/DSW1/DSW1.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/DSW1/DSW1.cs
@@ -17,7 +17,7 @@ namespace BossMod.Endwalker.Ultimate.DSW1
         public HoliestHallowing() : base(ActionID.MakeSpell(AID.HoliestHallowing), "Interrupt!") { }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SerAdelphel)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SerAdelphel, CFCID = 788)]
     public class DSW1 : BossModule
     {
         private Actor? _grinnaux;

--- a/BossMod/Modules/Endwalker/Ultimate/DSW2/DSW2.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/DSW2/DSW2.cs
@@ -77,7 +77,7 @@ namespace BossMod.Endwalker.Ultimate.DSW2
         public P7AlternativeEnd() : base(ActionID.MakeSpell(AID.AlternativeEnd)) { }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.BossP2)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.BossP2, CFCID = 788)]
     public class DSW2 : BossModule
     {
         public static ArenaBoundsCircle BoundsCircle = new ArenaBoundsCircle(new (100, 100), 21); // p2, intermission

--- a/BossMod/Modules/Endwalker/Ultimate/TOP/TOP.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/TOP/TOP.cs
@@ -22,6 +22,7 @@ namespace BossMod.Endwalker.Ultimate.TOP
         public P5BlindFaith() : base(ActionID.MakeSpell(AID.BlindFaithSuccess), "Intermission") { }
     }
 
+    [ModuleInfo(CFCID = 908)]
     public class TOP : BossModule
     {
         private Actor? _opticalUnit;

--- a/BossMod/Modules/Endwalker/Unreal/Un1Ultima/Un1Ultima.cs
+++ b/BossMod/Modules/Endwalker/Unreal/Un1Ultima/Un1Ultima.cs
@@ -33,6 +33,7 @@
         }
     }
 
+    [ModuleInfo(CFCID = 825, NameID = 3632)]
     public class Un1Ultima : BossModule
     {
         public Un1Ultima(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(0, 0), 20)) { }

--- a/BossMod/Modules/Endwalker/Unreal/Un2Sephirot/Un2Sephirot.cs
+++ b/BossMod/Modules/Endwalker/Unreal/Un2Sephirot/Un2Sephirot.cs
@@ -58,7 +58,7 @@ namespace BossMod.Endwalker.Unreal.Un2Sephirot
         public P3PillarOfSeverity() : base(ActionID.MakeSpell(AID.PillarOfSeverityAOE)) { }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.BossP1)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.BossP1, CFCID = 875, NameID = 4776)]
     public class Un2Sephirot : BossModule
     {
         public Actor? BossP1() => PrimaryActor.IsDestroyed ? null : PrimaryActor;

--- a/BossMod/Modules/Endwalker/Unreal/Un3Sophia/Un3Sophia.cs
+++ b/BossMod/Modules/Endwalker/Unreal/Un3Sophia/Un3Sophia.cs
@@ -72,6 +72,7 @@
         public Un3SophiaConfig() : base(90) { }
     }
 
+    [ModuleInfo(CFCID = 926, NameID = 5199)]
     public class Un3Sophia : BossModule
     {
         public Un3Sophia(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsRect(new(0, 0), 20, 15)) { }

--- a/BossMod/Modules/Endwalker/Unreal/Un4Zurvan/Un4Zurvan.cs
+++ b/BossMod/Modules/Endwalker/Unreal/Un4Zurvan/Un4Zurvan.cs
@@ -68,7 +68,7 @@ namespace BossMod.Endwalker.Unreal.Un4Zurvan
         public Un4ZurvanConfig() : base(90) { }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.BossP1)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.BossP1, CFCID = 951, NameID = 5567)]
     public class Un4Zurvan : BossModule
     {
         private Actor? _bossP2;

--- a/BossMod/Modules/Endwalker/Unreal/Un5Thordan/Un5Thordan.cs
+++ b/BossMod/Modules/Endwalker/Unreal/Un5Thordan/Un5Thordan.cs
@@ -72,6 +72,7 @@ public class Un5ThordanConfig : CooldownPlanningConfigNode
     public Un5ThordanConfig() : base(90) { }
 }
 
+[ModuleInfo(CFCID = 963, NameID = 3632)]
 public class Un5Thordan : BossModule
 {
     public Un5Thordan(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(0, 0), 21)) { }

--- a/BossMod/Modules/ModuleRegistry.cs
+++ b/BossMod/Modules/ModuleRegistry.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿using Dalamud.Utility;
+using Lumina.Excel.GeneratedSheets;
+using Lumina.Text;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -18,6 +21,26 @@ namespace BossMod
             public Type? TetherIDType;
             public Type? IconIDType;
             public uint PrimaryActorOID;
+
+            public uint CFCID;
+            public uint ExVersion;
+            public uint ContentIcon;
+            public SeString? ContentType;
+            public SeString? InstanceName;
+            public SeString? ForayName;
+            public SeString? FateName;
+            public SeString? BossName;
+            public string HuntRank;
+
+            public bool IsUncatalogued;
+
+            public enum HuntRanks : byte
+            {
+                None = 0,
+                B = 1,
+                A = 2,
+                S = 3,
+            }
 
             public bool CooldownPlanningSupported => ConfigType?.IsSubclassOf(typeof(CooldownPlanningConfigNode)) ?? false;
 
@@ -87,7 +110,98 @@ namespace BossMod
                     return null;
                 }
 
-                return new Info(module, statesType) { ConfigType = configType, ObjectIDType = oidType, ActionIDType = aidType, StatusIDType = sidType, TetherIDType = tidType, IconIDType = iidType, PrimaryActorOID = primaryOID };
+                uint nameID = infoAttr?.NameID ?? 0;
+                uint nmID = infoAttr?.NotoriousMonsterID ?? 0;
+                uint fateID = infoAttr?.FateID ?? 0;
+                uint dynamicEventID = infoAttr?.DynamicEventID ?? 0;
+                if (nameID == 0 && nmID == 0 && fateID == 0 && dynamicEventID == 0)
+                    Service.Log($"[{nameof(ModuleRegistry)}] Module {module.Name} does not provide a Name/Notorious Monster/Fate/Dyanamic Event ID: this is needed for overworld, bozja, and multi fight instances (dungeons) to be catalogued properly. Please add one.");
+
+                uint cfcID = infoAttr?.CFCID ?? 0;
+                if (cfcID == 0)
+                    Service.Log($"[{nameof(ModuleRegistry)}] Module {module.Name} does not provide a CFC ID: this will prevent it from being catalogued properly. Please add one.");
+
+                bool uncatalogued = (cfcID == 0 && nameID == 0 && nmID == 0 && fateID == 0 && dynamicEventID == 0) || (cfcID != 0 && CFCSheet.GetRow(cfcID)!.ShortCode.RawString.IsNullOrEmpty());
+                if (uncatalogued)
+                    Service.Log($"{module.Name} {uncatalogued}");
+
+                SeString contentType = new();
+                uint contentIcon = default;
+                SeString instanceName = new();
+                uint exVersion = 69;
+                string huntRank = "";
+                SeString fateName = new();
+                SeString forayName = new();
+                SeString bossName = new();
+
+                if (cfcID != 0)
+                {
+                    var cfcRow = CFCSheet.GetRow(cfcID)!;
+                    contentType = cfcRow.ContentType?.Value?.Name ?? new SeString();
+                    exVersion = cfcRow.TerritoryType?.Value?.ExVersion.Value?.RowId ?? 0;
+                    instanceName = cfcRow.Name;
+                    // needed because bozja et al does not have a ContentType
+                    if (cfcID is 735 or 760 or 761 or 778)
+                    {
+                        contentType = Service.DataManager.GetExcelSheet<CharaCardPlayStyle>()!.GetRow(6)!.Name;
+                        contentIcon = (uint)Service.DataManager.GetExcelSheet<CharaCardPlayStyle>()!.GetRow(6)!.Icon;
+                    }
+                    else
+                        contentIcon = cfcRow.ContentType?.Value?.Icon ?? 0;
+                }
+
+                if (nameID != 0)
+                {
+                    bossName = NPCNamesSheet.GetRow(nameID)!.Singular;
+                }
+
+                if (nmID != 0)
+                {
+                    bossName = NMSheet.GetRow(nmID)!.BNpcName.Value?.Singular ?? new SeString();
+                    huntRank = Enum.Parse<HuntRanks>(NMSheet.GetRow(nmID)!.Rank.ToString()).ToString();
+                    contentType = PlayStyleSheet.GetRow(10)!.Name;
+                    contentIcon = (uint)PlayStyleSheet.GetRow(10)!.Icon;
+                    foreach (var row in NMTSheet)
+                        foreach (var prop in row.GetType().GetProperties())
+                            if (prop.GetValue(row) is uint row_nmID)
+                                exVersion = TerritorySheet.FirstOrDefault(x => x.Unknown42 == row.RowId)?.ExVersion.Value?.RowId ?? 0;
+                }
+
+                if (fateID != 0) // needs exversion
+                {
+                    contentType = ContentTypeSheet.GetRow(8)!.Name;
+                    contentIcon = ContentTypeSheet.GetRow(8)!.Icon;
+                    fateName = FateSheet.GetRow(fateID)!.Name;
+                }
+
+                if (dynamicEventID != 0) // needs exversion?
+                {
+                    contentType = PlayStyleSheet.GetRow(6)!.Name;
+                    contentIcon = (uint)PlayStyleSheet.GetRow(6)!.Icon;
+                    forayName = DynamicEventSheet.GetRow(dynamicEventID)!.Name;
+                }
+                
+                return new Info(module, statesType) {
+                    ConfigType = configType,
+                    ObjectIDType = oidType,
+                    ActionIDType = aidType,
+                    StatusIDType = sidType,
+                    TetherIDType = tidType,
+                    IconIDType = iidType,
+                    PrimaryActorOID = primaryOID,
+
+                    CFCID = cfcID,
+                    ContentType = contentType,
+                    ContentIcon = contentIcon,
+                    InstanceName = instanceName,
+                    ExVersion = exVersion,
+                    BossName = bossName, 
+                    FateName = fateName,
+                    ForayName = forayName,
+                    HuntRank = huntRank,
+
+                    IsUncatalogued = uncatalogued,
+                };
             }
 
             private Info(Type moduleType, Type statesType)
@@ -99,8 +213,28 @@ namespace BossMod
 
         private static Dictionary<uint, Info> _modules = new(); // [primary-actor-oid] = module type
 
+        private static Lumina.Excel.ExcelSheet<ContentFinderCondition> CFCSheet;
+        private static Lumina.Excel.ExcelSheet<ContentType> ContentTypeSheet;
+        private static Lumina.Excel.ExcelSheet<NotoriousMonster> NMSheet;
+        private static Lumina.Excel.ExcelSheet<Lumina.Excel.GeneratedSheets2.NotoriousMonsterTerritory> NMTSheet;
+        private static Lumina.Excel.ExcelSheet<Fate> FateSheet;
+        private static Lumina.Excel.ExcelSheet<CharaCardPlayStyle> PlayStyleSheet;
+        private static Lumina.Excel.ExcelSheet<TerritoryType> TerritorySheet;
+        private static Lumina.Excel.ExcelSheet<DynamicEvent> DynamicEventSheet;
+        private static Lumina.Excel.ExcelSheet<BNpcName> NPCNamesSheet;
+
         static ModuleRegistry()
         {
+            CFCSheet = Service.DataManager.GetExcelSheet<ContentFinderCondition>()!;
+            ContentTypeSheet = Service.DataManager.GetExcelSheet<ContentType>()!;
+            NMSheet = Service.DataManager.GetExcelSheet<NotoriousMonster>()!;
+            NMTSheet = Service.DataManager.GetExcelSheet<Lumina.Excel.GeneratedSheets2.NotoriousMonsterTerritory>()!;
+            FateSheet = Service.DataManager.GetExcelSheet<Fate>()!;
+            PlayStyleSheet = Service.DataManager.GetExcelSheet<CharaCardPlayStyle>()!;
+            TerritorySheet = Service.DataManager.GetExcelSheet<TerritoryType>()!;
+            DynamicEventSheet = Service.DataManager.GetExcelSheet<DynamicEvent>()!;
+            NPCNamesSheet = Service.DataManager.GetExcelSheet<BNpcName>()!;
+
             foreach (var t in Utils.GetDerivedTypes<BossModule>(Assembly.GetExecutingAssembly()).Where(t => !t.IsAbstract && t != typeof(DemoModule)))
             {
                 var info = Info.Build(t);
@@ -111,6 +245,33 @@ namespace BossMod
                     throw new Exception($"Two boss modules have same primary actor OID: {t.Name} and {_modules[info.PrimaryActorOID].ModuleType.Name}");
                 _modules[info.PrimaryActorOID] = info;
             }
+        }
+
+        public static bool IsFate(this KeyValuePair<uint, Info> module) => !module.Value.FateName!.RawString.IsNullOrEmpty();
+        public static bool IsHunt(this KeyValuePair<uint, Info> module) => !module.Value.HuntRank.IsNullOrEmpty();
+        public static bool IsCriticalEngagement(this KeyValuePair<uint, Info> module) => !module.Value.ForayName!.RawString.IsNullOrEmpty();
+        public static bool IsRemovedContent(this KeyValuePair<uint, Info> module)
+        {
+            var cfcRow = CFCSheet.GetRow(module.Value.CFCID);
+
+            if (cfcRow == null)
+            {
+                // Handle the case where the row is null (optional)
+                return true; // or false, depending on your logic
+            }
+
+            foreach (var prop in cfcRow.GetType().GetProperties())
+            {
+                var propValue = prop.GetValue(cfcRow);
+
+                // Check if the property value is the default value for its type
+                if (propValue != null && !propValue.Equals(default(PropertyInfo)))
+                {
+                    return false; // Property has a non-default value, module is not removed content
+                }
+            }
+
+            return true; // All properties have default values, module is considered removed content
         }
 
         public static IReadOnlyDictionary<uint, Info> RegisteredModules => _modules;

--- a/BossMod/Modules/ModuleRegistry.cs
+++ b/BossMod/Modules/ModuleRegistry.cs
@@ -121,7 +121,7 @@ namespace BossMod
                 if (cfcID == 0)
                     Service.Log($"[{nameof(ModuleRegistry)}] Module {module.Name} does not provide a CFC ID: this will prevent it from being catalogued properly. Please add one.");
 
-                bool uncatalogued = (cfcID == 0 && nameID == 0 && nmID == 0 && fateID == 0 && dynamicEventID == 0) || (cfcID != 0 && CFCSheet.GetRow(cfcID)!.ShortCode.RawString.IsNullOrEmpty());
+                bool uncatalogued = (cfcID == 0 && nameID == 0 && nmID == 0 && fateID == 0 && dynamicEventID == 0) || (cfcID != 0 && _cfcSheet.GetRow(cfcID)!.ShortCode.RawString.IsNullOrEmpty());
                 if (uncatalogued)
                     Service.Log($"{module.Name} {uncatalogued}");
 
@@ -136,7 +136,7 @@ namespace BossMod
 
                 if (cfcID != 0)
                 {
-                    var cfcRow = CFCSheet.GetRow(cfcID)!;
+                    var cfcRow = _cfcSheet.GetRow(cfcID)!;
                     contentType = cfcRow.ContentType?.Value?.Name ?? new SeString();
                     exVersion = cfcRow.TerritoryType?.Value?.ExVersion.Value?.RowId ?? 0;
                     instanceName = cfcRow.Name;
@@ -152,33 +152,33 @@ namespace BossMod
 
                 if (nameID != 0)
                 {
-                    bossName = NPCNamesSheet.GetRow(nameID)!.Singular;
+                    bossName = _npcNamesSheet.GetRow(nameID)!.Singular;
                 }
 
                 if (nmID != 0)
                 {
-                    bossName = NMSheet.GetRow(nmID)!.BNpcName.Value?.Singular ?? new SeString();
-                    huntRank = Enum.Parse<HuntRanks>(NMSheet.GetRow(nmID)!.Rank.ToString()).ToString();
-                    contentType = PlayStyleSheet.GetRow(10)!.Name;
-                    contentIcon = (uint)PlayStyleSheet.GetRow(10)!.Icon;
-                    foreach (var row in NMTSheet)
+                    bossName = _nmSheet.GetRow(nmID)!.BNpcName.Value?.Singular ?? new SeString();
+                    huntRank = Enum.Parse<HuntRanks>(_nmSheet.GetRow(nmID)!.Rank.ToString()).ToString();
+                    contentType = _playStyleSheet.GetRow(10)!.Name;
+                    contentIcon = (uint)_playStyleSheet.GetRow(10)!.Icon;
+                    foreach (var row in _nmtSheet)
                         foreach (var prop in row.GetType().GetProperties())
                             if (prop.GetValue(row) is uint row_nmID)
-                                exVersion = TerritorySheet.FirstOrDefault(x => x.Unknown42 == row.RowId)?.ExVersion.Value?.RowId ?? 0;
+                                exVersion = _territorySheet.FirstOrDefault(x => x.Unknown42 == row.RowId)?.ExVersion.Value?.RowId ?? 0;
                 }
 
                 if (fateID != 0) // needs exversion
                 {
-                    contentType = ContentTypeSheet.GetRow(8)!.Name;
-                    contentIcon = ContentTypeSheet.GetRow(8)!.Icon;
-                    fateName = FateSheet.GetRow(fateID)!.Name;
+                    contentType = _contentTypeSheet.GetRow(8)!.Name;
+                    contentIcon = _contentTypeSheet.GetRow(8)!.Icon;
+                    fateName = _fateSheet.GetRow(fateID)!.Name;
                 }
 
                 if (dynamicEventID != 0) // needs exversion?
                 {
-                    contentType = PlayStyleSheet.GetRow(6)!.Name;
-                    contentIcon = (uint)PlayStyleSheet.GetRow(6)!.Icon;
-                    forayName = DynamicEventSheet.GetRow(dynamicEventID)!.Name;
+                    contentType = _playStyleSheet.GetRow(6)!.Name;
+                    contentIcon = (uint)_playStyleSheet.GetRow(6)!.Icon;
+                    forayName = _dynamicEventSheet.GetRow(dynamicEventID)!.Name;
                 }
                 
                 return new Info(module, statesType) {
@@ -213,30 +213,30 @@ namespace BossMod
 
         private static Dictionary<uint, Info> _modules = new(); // [primary-actor-oid] = module type
 
-        private static readonly Lumina.Excel.ExcelSheet<ContentFinderCondition> CFCSheet;
-        private static readonly Lumina.Excel.ExcelSheet<ContentType> ContentTypeSheet;
-        private static readonly Lumina.Excel.ExcelSheet<NotoriousMonster> NMSheet;
-        private static readonly Lumina.Excel.ExcelSheet<Lumina.Excel.GeneratedSheets2.NotoriousMonsterTerritory> NMTSheet;
-        private static readonly Lumina.Excel.ExcelSheet<Fate> FateSheet;
-        private static readonly Lumina.Excel.ExcelSheet<CharaCardPlayStyle> PlayStyleSheet;
-        private static readonly Lumina.Excel.ExcelSheet<TerritoryType> TerritorySheet;
-        private static readonly Lumina.Excel.ExcelSheet<DynamicEvent> DynamicEventSheet;
-        private static readonly Lumina.Excel.ExcelSheet<BNpcName> NPCNamesSheet;
+        private static readonly Lumina.Excel.ExcelSheet<ContentFinderCondition> _cfcSheet;
+        private static readonly Lumina.Excel.ExcelSheet<ContentType> _contentTypeSheet;
+        private static readonly Lumina.Excel.ExcelSheet<NotoriousMonster> _nmSheet;
+        private static readonly Lumina.Excel.ExcelSheet<Lumina.Excel.GeneratedSheets2.NotoriousMonsterTerritory> _nmtSheet;
+        private static readonly Lumina.Excel.ExcelSheet<Fate> _fateSheet;
+        private static readonly Lumina.Excel.ExcelSheet<CharaCardPlayStyle> _playStyleSheet;
+        private static readonly Lumina.Excel.ExcelSheet<TerritoryType> _territorySheet;
+        private static readonly Lumina.Excel.ExcelSheet<DynamicEvent> _dynamicEventSheet;
+        private static readonly Lumina.Excel.ExcelSheet<BNpcName> _npcNamesSheet;
 
         private static readonly Dictionary<uint, Info> _uncatalogued;
         private static readonly List<uint> _expacs;
 
         static ModuleRegistry()
         {
-            CFCSheet = Service.DataManager.GetExcelSheet<ContentFinderCondition>()!;
-            ContentTypeSheet = Service.DataManager.GetExcelSheet<ContentType>()!;
-            NMSheet = Service.DataManager.GetExcelSheet<NotoriousMonster>()!;
-            NMTSheet = Service.DataManager.GetExcelSheet<Lumina.Excel.GeneratedSheets2.NotoriousMonsterTerritory>()!;
-            FateSheet = Service.DataManager.GetExcelSheet<Fate>()!;
-            PlayStyleSheet = Service.DataManager.GetExcelSheet<CharaCardPlayStyle>()!;
-            TerritorySheet = Service.DataManager.GetExcelSheet<TerritoryType>()!;
-            DynamicEventSheet = Service.DataManager.GetExcelSheet<DynamicEvent>()!;
-            NPCNamesSheet = Service.DataManager.GetExcelSheet<BNpcName>()!;
+            _cfcSheet = Service.DataManager.GetExcelSheet<ContentFinderCondition>()!;
+            _contentTypeSheet = Service.DataManager.GetExcelSheet<ContentType>()!;
+            _nmSheet = Service.DataManager.GetExcelSheet<NotoriousMonster>()!;
+            _nmtSheet = Service.DataManager.GetExcelSheet<Lumina.Excel.GeneratedSheets2.NotoriousMonsterTerritory>()!;
+            _fateSheet = Service.DataManager.GetExcelSheet<Fate>()!;
+            _playStyleSheet = Service.DataManager.GetExcelSheet<CharaCardPlayStyle>()!;
+            _territorySheet = Service.DataManager.GetExcelSheet<TerritoryType>()!;
+            _dynamicEventSheet = Service.DataManager.GetExcelSheet<DynamicEvent>()!;
+            _npcNamesSheet = Service.DataManager.GetExcelSheet<BNpcName>()!;
 
             foreach (var t in Utils.GetDerivedTypes<BossModule>(Assembly.GetExecutingAssembly()).Where(t => !t.IsAbstract && t != typeof(DemoModule)))
             {
@@ -252,9 +252,9 @@ namespace BossMod
             _modules = RegisteredModules
                 .Where(x => !x.Value.IsUncatalogued)
                 .OrderBy(x => x.Value.ExVersion)
-                .ThenBy(x => CFCSheet.GetRow(x.Value.CFCID)?.ClassJobLevelSync)
-                .ThenBy(x => CFCSheet.GetRow(x.Value.CFCID)?.ItemLevelRequired)
-                .ThenBy(x => CFCSheet.GetRow(x.Value.CFCID)?.SortKey)
+                .ThenBy(x => _cfcSheet.GetRow(x.Value.CFCID)?.ClassJobLevelSync)
+                .ThenBy(x => _cfcSheet.GetRow(x.Value.CFCID)?.ItemLevelRequired)
+                .ThenBy(x => _cfcSheet.GetRow(x.Value.CFCID)?.SortKey)
                 .ToDictionary(x => x.Key, x => x.Value);
             _uncatalogued = _modules.Where(x => x.Value.IsUncatalogued || x.Value.ExVersion == 69).Select(x => x).ToDictionary(x => x.Key, x => x.Value);
             _expacs = _modules.Where(x => x.Value.ExVersion != 69).Select(x => x.Value.ExVersion).Distinct().ToList()!;
@@ -263,21 +263,19 @@ namespace BossMod
         public static bool IsFate(this KeyValuePair<uint, Info> module) => !module.Value.FateName!.RawString.IsNullOrEmpty();
         public static bool IsHunt(this KeyValuePair<uint, Info> module) => !module.Value.HuntRank.IsNullOrEmpty();
         public static bool IsCriticalEngagement(this KeyValuePair<uint, Info> module) => !module.Value.ForayName!.RawString.IsNullOrEmpty();
+
+        // AFAIK, unreals are the only piece of content that regularly get removed. Their CFCID stays but the properties are all reverted to default.
         public static bool IsRemovedContent(this KeyValuePair<uint, Info> module)
         {
-            var cfcRow = CFCSheet.GetRow(module.Value.CFCID);
+            var cfcRow = _cfcSheet.GetRow(module.Value.CFCID);
 
             if (cfcRow == null)
-            {
-                // Handle the case where the row is null (optional)
-                return true; // or false, depending on your logic
-            }
+                return true;
 
             foreach (var prop in cfcRow.GetType().GetProperties())
             {
                 var propValue = prop.GetValue(cfcRow);
 
-                // Check if the property value is the default value for its type
                 if (propValue != null && !propValue.Equals(default(PropertyInfo)))
                 {
                     return false; // Property has a non-default value, module is not removed content

--- a/BossMod/Modules/RealmReborn/Dungeon/D01Sastasha/D010Switch.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D01Sastasha/D010Switch.cs
@@ -33,7 +33,8 @@ namespace BossMod.RealmReborn.Dungeon.D01Sastasha.D010Switch
         }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.Blue)]
+    // no name ID :(
+    [ModuleInfo(PrimaryActorOID = (uint)OID.Blue, CFCID = 4)]
     public class D010Switch : BossModule
     {
         public D010Switch(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(primary.Position, 20))

--- a/BossMod/Modules/RealmReborn/Dungeon/D03Copperbell/D031Kottos.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D03Copperbell/D031Kottos.cs
@@ -49,6 +49,7 @@
         }
     }
 
+    [ModuleInfo(CFCID = 3, NameID = 548)]
     public class D031Kottos : BossModule
     {
         public D031Kottos(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(43, -89.56f), 15)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D03Copperbell/D032IchorousIre.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D03Copperbell/D032IchorousIre.cs
@@ -42,6 +42,7 @@
         }
     }
 
+    [ModuleInfo(CFCID = 3, NameID = 554)]
     public class D032IchorousIre : BossModule
     {
         public D032IchorousIre(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(26.97f, 113.97f), 20)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D03Copperbell/D033Gyges.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D03Copperbell/D033Gyges.cs
@@ -54,6 +54,7 @@
         }
     }
 
+    [ModuleInfo(CFCID = 3, NameID = 101)]
     public class D033Gyges : BossModule
     {
         public D033Gyges(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(-100.42f, 6.67f), 20)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D05Totorak/D053Graffias.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D05Totorak/D053Graffias.cs
@@ -64,6 +64,7 @@ namespace BossMod.RealmReborn.Dungeon.D05Totorak.D053Graffias
         }
     }
 
+    [ModuleInfo(CFCID = 1, NameID = 444)]
     public class D053Graffias : BossModule
     {
         public D053Graffias(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(215, -145), 20)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D06Haukke/D061ManorClaviger.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D06Haukke/D061ManorClaviger.cs
@@ -39,6 +39,7 @@
         }
     }
 
+    [ModuleInfo(CFCID = 6, NameID = 423)]
     public class D061ManorClaviger : BossModule
     {
         public D061ManorClaviger(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(2.5f, 0), 16)) { } // TODO: really a rect, x=[-25, +20], y=[-16, +16]

--- a/BossMod/Modules/RealmReborn/Dungeon/D06Haukke/D063LadyAmandine.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D06Haukke/D063LadyAmandine.cs
@@ -59,6 +59,7 @@ namespace BossMod.RealmReborn.Dungeon.D06Haukke.D063LadyAmandine
         }
     }
 
+    [ModuleInfo(CFCID = 6, NameID = 422)]
     public class D063LadyAmandine : BossModule
     {
         public D063LadyAmandine(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(0, 4), 20)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D07Brayflox/D074Aiatar.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D07Brayflox/D074Aiatar.cs
@@ -48,6 +48,7 @@
         }
     }
 
+    [ModuleInfo(CFCID = 8, NameID = 1279)]
     public class D074Aiatar : BossModule
     {
         public D074Aiatar(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(-25, -235), 20)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D08Qarn/D081Teratotaur.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D08Qarn/D081Teratotaur.cs
@@ -109,6 +109,7 @@ namespace BossMod.RealmReborn.Dungeon.D08Qarn.D081Teratotaur
         }
     }
 
+    [ModuleInfo(CFCID = 8, NameID = 1567)]
     public class D081Teratotaur : BossModule
     {
         public D081Teratotaur(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(-70, -60), 20)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D08Qarn/D082TempleGuardian.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D08Qarn/D082TempleGuardian.cs
@@ -44,6 +44,7 @@ namespace BossMod.RealmReborn.Dungeon.D08Qarn.D082TempleGuardian
         }
     }
 
+    [ModuleInfo(CFCID = 8, NameID = 1569)]
     public class D082TempleGuardian : BossModule
     {
         public D082TempleGuardian(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(50, -10), 15)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D08Qarn/D083Adjudicator.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D08Qarn/D083Adjudicator.cs
@@ -43,6 +43,7 @@ namespace BossMod.RealmReborn.Dungeon.D08Qarn.D083Adjudicator
         }
     }
 
+    [ModuleInfo(CFCID = 8, NameID = 1570)]
     public class D083Adjudicator : BossModule
     {
         public D083Adjudicator(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(238, 0), 20)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D09Cutter/D092GiantTunnelWorm.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D09Cutter/D092GiantTunnelWorm.cs
@@ -50,6 +50,7 @@ namespace BossMod.RealmReborn.Dungeon.D09Cutter.D092GiantTunnelWorm
         }
     }
 
+    [ModuleInfo(CFCID = 12, NameID = 1589)]
     public class D092GiantTunnelWorm : BossModule
     {
         public D092GiantTunnelWorm(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(-140, 150), 20)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D09Cutter/D093Chimera.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D09Cutter/D093Chimera.cs
@@ -88,6 +88,7 @@ namespace BossMod.RealmReborn.Dungeon.D09Cutter.D093Chimera
         }
     }
 
+    [ModuleInfo(CFCID = 12, NameID = 1590)]
     public class D093Chimera : BossModule
     {
         public D093Chimera(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(-170, -200), 30)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D10StoneVigil/D101ChudoYudo.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D10StoneVigil/D101ChudoYudo.cs
@@ -44,6 +44,7 @@
         }
     }
 
+    [ModuleInfo(CFCID = 11, NameID = 1677)]
     public class D101ChudoYudo : BossModule
     {
         public D101ChudoYudo(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(0, 115), 20)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D10StoneVigil/D102Koshchei.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D10StoneVigil/D102Koshchei.cs
@@ -90,6 +90,7 @@ namespace BossMod.RealmReborn.Dungeon.D10StoneVigil.D102Koshchei
         }
     }
 
+    [ModuleInfo(CFCID = 11, NameID = 1678)]
     public class D102Koshchei : BossModule
     {
         public D102Koshchei(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(40, -80), 10)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D10StoneVigil/D103Isgebind.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D10StoneVigil/D103Isgebind.cs
@@ -74,6 +74,7 @@ namespace BossMod.RealmReborn.Dungeon.D10StoneVigil.D103Isgebind
         }
     }
 
+    [ModuleInfo(CFCID = 11, NameID = 1680)]
     public class D103Isgebind : BossModule
     {
         public D103Isgebind(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(0, -248), 20)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D11DzemaelDarkhold/D111AllSeeingEye.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D11DzemaelDarkhold/D111AllSeeingEye.cs
@@ -72,6 +72,7 @@
         }
     }
 
+    [ModuleInfo(CFCID = 13, NameID = 1397)]
     public class D111AllSeeingEye : BossModule
     {
         public D111AllSeeingEye(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(40, 70), 30)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D11DzemaelDarkhold/D113Batraal.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D11DzemaelDarkhold/D113Batraal.cs
@@ -63,6 +63,7 @@ namespace BossMod.RealmReborn.Dungeon.D11DzemaelDarkhold.D113Batraal
         }
     }
 
+    [ModuleInfo(CFCID = 13, NameID = 1396)]
     public class D113Batraal : BossModule
     {
         public D113Batraal(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(85, -180), 25)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D12AurumVale/D121Locksmith.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D12AurumVale/D121Locksmith.cs
@@ -49,6 +49,7 @@ namespace BossMod.RealmReborn.Dungeon.D12AurumVale.D121Locksmith
         }
     }
 
+    [ModuleInfo(CFCID = 5, NameID = 1534)]
     public class D121Locksmith : BossModule
     {
         public D121Locksmith(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsRect(new(35, 0), 15, 25)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D12AurumVale/D122Coincounter.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D12AurumVale/D122Coincounter.cs
@@ -54,6 +54,7 @@
         }
     }
 
+    [ModuleInfo(CFCID = 5, NameID = 1533)]
     public class D122Coincounter : BossModule
     {
         public D122Coincounter(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(-150, -150), 20)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D12AurumVale/D123MisersMistress.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D12AurumVale/D123MisersMistress.cs
@@ -47,6 +47,7 @@
         }
     }
 
+    [ModuleInfo(CFCID = 5, NameID = 1532)]
     public class D123MisersMistress : BossModule
     {
         public D123MisersMistress(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(-400, -130), 25)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D13CastrumMeridianum/D131BlackEft.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D13CastrumMeridianum/D131BlackEft.cs
@@ -50,6 +50,7 @@
     // first wave = 3x signifier + 3x laquearius
     // second wave = 2x colossus
     // third wave = 2x colossus + 2x signifier + 2x laquearius
+    [ModuleInfo(CFCID = 15, NameID = 557)]
     public class D131BlackEft : BossModule
     {
         public D131BlackEft(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(10, -40), 20)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D13CastrumMeridianum/D132MagitekVanguardF1.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D13CastrumMeridianum/D132MagitekVanguardF1.cs
@@ -64,6 +64,7 @@
         }
     }
 
+    [ModuleInfo(CFCID = 15, NameID = 2116)]
     public class D132MagitekVanguardF1 : BossModule
     {
         public D132MagitekVanguardF1(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsRect(new(-13, 31), 20, 20, 20.Degrees())) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D13CastrumMeridianum/D133Livia.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D13CastrumMeridianum/D133Livia.cs
@@ -234,6 +234,7 @@ namespace BossMod.RealmReborn.Dungeon.D13CastrumMeridianum.D133Livia
         }
     }
 
+    [ModuleInfo(CFCID = 15, NameID = 2118)]
     public class D133Livia : BossModule
     {
         public D133Livia(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(-98, -33), 20)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D14Praetorium/D141Colossus.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D14Praetorium/D141Colossus.cs
@@ -57,6 +57,7 @@
         }
     }
 
+    [ModuleInfo(CFCID = 16, NameID = 2134)]
     public class D141Colossus : BossModule
     {
         public D141Colossus(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(192, 0), 15)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D14Praetorium/D142Nero.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D14Praetorium/D142Nero.cs
@@ -71,6 +71,7 @@
         }
     }
 
+    [ModuleInfo(CFCID = 16, NameID = 2135)]
     public class D142Nero : BossModule
     {
         public D142Nero(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(-164, 0), 20)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D14Praetorium/D143Gaius.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D14Praetorium/D143Gaius.cs
@@ -112,6 +112,7 @@ namespace BossMod.RealmReborn.Dungeon.D14Praetorium.D143Gaius
         }
     }
 
+    [ModuleInfo(CFCID = 16, NameID = 2136)]
     public class D143Gaius : BossModule
     {
         public D143Gaius(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsRect(new(-562, 220), 15, 20)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D15WanderersPalace/D151KeeperOfHalidom.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D15WanderersPalace/D151KeeperOfHalidom.cs
@@ -84,6 +84,7 @@ namespace BossMod.RealmReborn.Dungeon.D15WanderersPalace.D151KeeperOfHalidom
         }
     }
 
+    [ModuleInfo(CFCID = 10, NameID = 1548)]
     public class D151KeeperOfHalidom : BossModule
     {
         public D151KeeperOfHalidom(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(125, 108), 20)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D15WanderersPalace/D152GiantBavarois.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D15WanderersPalace/D152GiantBavarois.cs
@@ -64,6 +64,7 @@
         }
     }
 
+    [ModuleInfo(CFCID = 10, NameID = 1549)]
     public class D152GiantBavarois : BossModule
     {
         public D152GiantBavarois(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(43, -232), 20)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D15WanderersPalace/D153TonberryKing.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D15WanderersPalace/D153TonberryKing.cs
@@ -32,6 +32,7 @@
         }
     }
 
+    [ModuleInfo(CFCID = 10, NameID = 1547)]
     public class D153TonberryKing : BossModule
     {
         public D153TonberryKing(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(73, -435), 30)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D16Amdapor/D161Psycheflayer.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D16Amdapor/D161Psycheflayer.cs
@@ -86,7 +86,7 @@ namespace BossMod.RealmReborn.Dungeon.D16Amdapor.D161Psycheflayer
         }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.BossP1)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.BossP1, CFCID = 14, NameID = 1689)]
     public class D161Psycheflayer : BossModule
     {
         private Actor? _bossP2;

--- a/BossMod/Modules/RealmReborn/Dungeon/D16Amdapor/D162DemonWall.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D16Amdapor/D162DemonWall.cs
@@ -71,6 +71,7 @@ namespace BossMod.RealmReborn.Dungeon.D16Amdapor.D162DemonWall
         }
     }
 
+    [ModuleInfo(CFCID = 14, NameID = 1694)]
     public class D162DemonWall : BossModule
     {
         public D162DemonWall(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsRect(new(200, -131), 10, 21)) { }

--- a/BossMod/Modules/RealmReborn/Dungeon/D16Amdapor/D163Anantaboga.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D16Amdapor/D163Anantaboga.cs
@@ -125,6 +125,7 @@ namespace BossMod.RealmReborn.Dungeon.D16Amdapor.D163Anantaboga
         }
     }
 
+    [ModuleInfo(CFCID = 14, NameID = 1696)]
     public class D163Anantaboga : BossModule
     {
         public D163Anantaboga(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(10, 0), 25)) { }

--- a/BossMod/Modules/RealmReborn/Extreme/Ex1Ultima/Ex1Ultima.cs
+++ b/BossMod/Modules/RealmReborn/Extreme/Ex1Ultima/Ex1Ultima.cs
@@ -66,6 +66,7 @@
         }
     }
 
+    [ModuleInfo(CFCID = 68, NameID = 2137)]
     public class Ex1Ultima : BossModule
     {
         public Ex1Ultima(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(0, 0), 20)) { }

--- a/BossMod/Modules/RealmReborn/Extreme/Ex2Garuda/Ex2Garuda.cs
+++ b/BossMod/Modules/RealmReborn/Extreme/Ex2Garuda/Ex2Garuda.cs
@@ -53,6 +53,7 @@ namespace BossMod.RealmReborn.Extreme.Ex2Garuda
         public GreatWhirlwind() : base(ActionID.MakeSpell(AID.GreatWhirlwind), 8) { }
     }
 
+    [ModuleInfo(CFCID = 65, NameID = 1644)]
     public class Ex2Garuda : BossModule
     {
         public List<Actor> Monoliths;

--- a/BossMod/Modules/RealmReborn/Extreme/Ex3Titan/Ex3Titan.cs
+++ b/BossMod/Modules/RealmReborn/Extreme/Ex3Titan/Ex3Titan.cs
@@ -19,6 +19,7 @@ namespace BossMod.RealmReborn.Extreme.Ex3Titan
         public Ex3TitanConfig() : base(50) { }
     }
 
+    [ModuleInfo(CFCID = 64, NameID = 1801)]
     public class Ex3Titan : BossModule
     {
         private List<Actor> _heart;

--- a/BossMod/Modules/RealmReborn/Extreme/Ex4Ifrit/Ex4Ifrit.cs
+++ b/BossMod/Modules/RealmReborn/Extreme/Ex4Ifrit/Ex4Ifrit.cs
@@ -20,6 +20,7 @@ namespace BossMod.RealmReborn.Extreme.Ex4Ifrit
         public CrimsonCyclone() : base(ActionID.MakeSpell(AID.CrimsonCyclone), new AOEShapeRect(49, 9)) { }
     }
 
+    [ModuleInfo(CFCID = 63, NameID = 1185)]
     public class Ex4Ifrit : BossModule
     {
         public List<Actor> SmallNails;

--- a/BossMod/Modules/RealmReborn/Raid/T00ADS/T00ADS.cs
+++ b/BossMod/Modules/RealmReborn/Raid/T00ADS/T00ADS.cs
@@ -66,6 +66,7 @@
         }
     }
 
+    [ModuleInfo(CFCID = 93, NameID = 1459)]
     public class T00ADS : BossModule
     {
         public T00ADS(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsRect(new(-3, 27), 7, 28)) { }

--- a/BossMod/Modules/RealmReborn/Raid/T01Caduceus/T01Caduceus.cs
+++ b/BossMod/Modules/RealmReborn/Raid/T01Caduceus/T01Caduceus.cs
@@ -123,6 +123,7 @@ namespace BossMod.RealmReborn.Raid.T01Caduceus
         public T01CaduceusConfig() : base(50) { }
     }
 
+    [ModuleInfo(CFCID = 93, NameID = 1466)]
     public class T01Caduceus : BossModule
     {
         public T01Caduceus(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsRect(new(-26, -407), 35, 43))

--- a/BossMod/Modules/RealmReborn/Raid/T02MultiADS/T02MultiADS.cs
+++ b/BossMod/Modules/RealmReborn/Raid/T02MultiADS/T02MultiADS.cs
@@ -160,7 +160,7 @@ namespace BossMod.RealmReborn.Raid.T02MultiADS
         public T02ADSConfig() : base(50) { }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.ADS)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.ADS, CFCID = 94, NameID = 1459)]
     public class T02ADS : BossModule
     {
         public T02ADS(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsRect(new(0, 77), 18, 13)) { }
@@ -179,7 +179,7 @@ namespace BossMod.RealmReborn.Raid.T02MultiADS
         }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.QuarantineNode)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.QuarantineNode, CFCID = 94, NameID = 1468)]
     public class T02QuarantineNode : BossModule
     {
         public T02QuarantineNode(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsRect(new(0, 112), 14, 13)) { }
@@ -199,7 +199,7 @@ namespace BossMod.RealmReborn.Raid.T02MultiADS
         }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.AttackNode)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.AttackNode, CFCID = 94, NameID = 1469)]
     public class T02AttackNode : BossModule
     {
         public T02AttackNode(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(-44, 94), 17)) { }
@@ -221,7 +221,7 @@ namespace BossMod.RealmReborn.Raid.T02MultiADS
         }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.SanitaryNode)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.SanitaryNode, CFCID = 94, NameID = 1470)]
     public class T02SanitaryNode : BossModule
     {
         public T02SanitaryNode(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsRect(new(-43, 52), 18, 15)) { }
@@ -240,7 +240,7 @@ namespace BossMod.RealmReborn.Raid.T02MultiADS
         }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.MonitoringNode)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.MonitoringNode, CFCID = 94, NameID = 1471)]
     public class T02MonitoringNode : BossModule
     {
         public T02MonitoringNode(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsRect(new(0, 39), 17, 15)) { }
@@ -259,7 +259,7 @@ namespace BossMod.RealmReborn.Raid.T02MultiADS
         }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.DefenseNode)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.DefenseNode, CFCID = 94, NameID = 1472)]
     public class T02DefenseNode : BossModule
     {
         public T02DefenseNode(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsRect(new(46, 52), 17, 14)) { }
@@ -279,7 +279,7 @@ namespace BossMod.RealmReborn.Raid.T02MultiADS
         }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.DisposalNode)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.DisposalNode, CFCID = 94, NameID = 1473)]
     public class T02DisposalNode : BossModule
     {
         public T02DisposalNode(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsRect(new(41, 94), 14, 20)) { }

--- a/BossMod/Modules/RealmReborn/Raid/T04Gauntlet/T04Gauntlet.cs
+++ b/BossMod/Modules/RealmReborn/Raid/T04Gauntlet/T04Gauntlet.cs
@@ -79,7 +79,7 @@ namespace BossMod.RealmReborn.Raid.T04Gauntlet
     }
 
     // helper actor is destroyed immediately on combat end (be it a wipe or a kill), and is not recreated immediately after wipe (only after interacting with terminal), making it ideal for wipe checks
-    [ModuleInfo(PrimaryActorOID = (uint)OID.DriveCylinder)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.DriveCylinder, CFCID = 96)]
     public class T04Gauntlet : BossModule
     {
         public List<Actor> P1Bugs;

--- a/BossMod/Modules/RealmReborn/Raid/T05Twintania/T05Twintania.cs
+++ b/BossMod/Modules/RealmReborn/Raid/T05Twintania/T05Twintania.cs
@@ -141,6 +141,7 @@ namespace BossMod.RealmReborn.Raid.T05Twintania
         }
     }
 
+    [ModuleInfo(CFCID = 97, NameID = 1482)]
     public class T05Twintania : BossModule
     {
         public const float NeurolinkRadius = 2;

--- a/BossMod/Modules/RealmReborn/Trial/T01IfritN/T01IfritN.cs
+++ b/BossMod/Modules/RealmReborn/Trial/T01IfritN/T01IfritN.cs
@@ -67,6 +67,7 @@ namespace BossMod.RealmReborn.Trial.T01IfritN
         }
     }
 
+    [ModuleInfo(CFCID = 56, NameID = 1185)]
     public class T01IfritN : BossModule
     {
         public T01IfritN(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(-0, 0), 20)) { }

--- a/BossMod/Modules/RealmReborn/Trial/T02TitanN/T02TitanN.cs
+++ b/BossMod/Modules/RealmReborn/Trial/T02TitanN/T02TitanN.cs
@@ -77,6 +77,7 @@ namespace BossMod.RealmReborn.Trial.T02TitanN
         }
     }
 
+    [ModuleInfo(CFCID = 57, NameID = 1801)]
     public class T02TitanN : BossModule
     {
         private List<Actor> _heart;

--- a/BossMod/Modules/RealmReborn/Trial/T03GarudaN/T03GarudaN.cs
+++ b/BossMod/Modules/RealmReborn/Trial/T03GarudaN/T03GarudaN.cs
@@ -94,6 +94,7 @@ namespace BossMod.RealmReborn.Trial.T03GarudaN
         }
     }
 
+    [ModuleInfo(CFCID = 58, NameID = 1644)]
     public class T03GarudaN : BossModule
     {
         public T03GarudaN(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(0, 0), 21)) { }

--- a/BossMod/Modules/RealmReborn/Trial/T04PortaDecumana/T04PortaDecumana1.cs
+++ b/BossMod/Modules/RealmReborn/Trial/T04PortaDecumana/T04PortaDecumana1.cs
@@ -130,6 +130,7 @@
         }
     }
 
+    [ModuleInfo(CFCID = 830, NameID = 2137)]
     public class T04PortaDecumana1 : BossModule
     {
         public T04PortaDecumana1(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(-772, -600), 20)) { }

--- a/BossMod/Modules/RealmReborn/Trial/T04PortaDecumana/T04PortaDecumana2.cs
+++ b/BossMod/Modules/RealmReborn/Trial/T04PortaDecumana/T04PortaDecumana2.cs
@@ -116,6 +116,7 @@
         }
     }
 
+    [ModuleInfo(CFCID = 830, NameID = 2137)]
     public class T04PortaDecumana2 : BossModule
     {
         public T04PortaDecumana2(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(-704, 480), 20)) { }

--- a/BossMod/Modules/RealmReborn/Trial/T05IfritH/T05IfritH.cs
+++ b/BossMod/Modules/RealmReborn/Trial/T05IfritH/T05IfritH.cs
@@ -97,6 +97,7 @@ namespace BossMod.RealmReborn.Trial.T05IfritH
         }
     }
 
+    [ModuleInfo(CFCID = 59, NameID = 1185)]
     public class T05IfritH : BossModule
     {
         private List<Actor> _nails;

--- a/BossMod/Modules/RealmReborn/Trial/T06GarudaH/T06GarudaH.cs
+++ b/BossMod/Modules/RealmReborn/Trial/T06GarudaH/T06GarudaH.cs
@@ -104,6 +104,7 @@ namespace BossMod.RealmReborn.Trial.T06GarudaH
         }
     }
 
+    [ModuleInfo(CFCID = 61, NameID = 1644)]
     public class T06GarudaH : BossModule
     {
         private List<Actor> _monoliths;

--- a/BossMod/Modules/RealmReborn/Trial/T07TitanH/T07TitanH.cs
+++ b/BossMod/Modules/RealmReborn/Trial/T07TitanH/T07TitanH.cs
@@ -138,6 +138,7 @@ namespace BossMod.RealmReborn.Trial.T07TitanH
         }
     }
 
+    [ModuleInfo(CFCID = 60, NameID = 1801)]
     public class T07TitanH : BossModule
     {
         private List<Actor> _heart;

--- a/BossMod/Modules/RealmReborn/Trial/T08ThornmarchH/T08ThornmarchH.cs
+++ b/BossMod/Modules/RealmReborn/Trial/T08ThornmarchH/T08ThornmarchH.cs
@@ -158,7 +158,7 @@ namespace BossMod.RealmReborn.Trial.T08ThornmarchH
         }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.WhiskerwallKupdiKoop)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.WhiskerwallKupdiKoop, CFCID = 66, NameID = 725)]
     public class T08ThornmarchH : BossModule
     {
         public T08ThornmarchH(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(0, 0), 21)) { }

--- a/BossMod/Modules/RealmReborn/Trial/T09WhorleaterH/T09WhorleaterH.cs
+++ b/BossMod/Modules/RealmReborn/Trial/T09WhorleaterH/T09WhorleaterH.cs
@@ -33,6 +33,7 @@ namespace BossMod.Modules.RealmReborn.Trial.T09WhorleaterH
         }
     }
 
+    [ModuleInfo(CFCID = 72, NameID = 2205)]
     public class T09WhorleaterH(WorldState ws, Actor primary) : BossModule(ws, primary, new ArenaBoundsRect(new(-0, 0), 14.5f, 20))
     {
         protected override void DrawEnemies(int pcSlot, Actor pc)

--- a/BossMod/Modules/Shadowbringers/FATE/Archaeotania.cs
+++ b/BossMod/Modules/Shadowbringers/FATE/Archaeotania.cs
@@ -170,6 +170,7 @@ namespace BossMod.Shadowbringers.FATE.Archaeotania
         }
     }
 
+    [ModuleInfo(FateID = 1432)]
     public class Archaeotania : BossModule
     {
         public Archaeotania(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(279, 249), 29)) { }

--- a/BossMod/Modules/Shadowbringers/FATE/Formidable.cs
+++ b/BossMod/Modules/Shadowbringers/FATE/Formidable.cs
@@ -53,7 +53,7 @@ namespace BossMod.Shadowbringers.FATE.Formidable
         AlteredStates = 1387, // ExpandHelper-->GiantGrenade
         ExtremeCaution = 1269, // Boss->players
     };
-   
+
     class Spincrush : Components.SelfTargetedAOEs
     {
         public Spincrush() : base(ActionID.MakeSpell(AID.Spincrush), new AOEShapeCone(15, 60.Degrees())) { }
@@ -231,10 +231,10 @@ namespace BossMod.Shadowbringers.FATE.Formidable
         {
             if ((AID)spell.Action.ID == AID.DynamicSensoryJammer)
                 casting = false;
-        }        
+        }
         public override void OnStatusGain(BossModule module, Actor actor, ActorStatus status)
         {
-              if ((SID)status.ID == SID.ExtremeCaution)
+            if ((SID)status.ID == SID.ExtremeCaution)
                 _ec.Set(module.Raid.FindSlot(actor.InstanceID));
         }
         public override void OnStatusLose(BossModule module, Actor actor, ActorStatus status)
@@ -245,15 +245,15 @@ namespace BossMod.Shadowbringers.FATE.Formidable
         public override void AddHints(BossModule module, int slot, Actor actor, TextHints hints, MovementHints? movementHints)
         {
             if (_ec[slot] != Ec)
-            hints.Add("Extreme Caution on you! STOP everything or get launched into the air!");
+                hints.Add("Extreme Caution on you! STOP everything or get launched into the air!");
         }
         public override void AddGlobalHints(BossModule module, GlobalHints hints)
         {
             if (casting)
-            hints.Add("Stop everything including auto attacks or get launched into the air");    
+                hints.Add("Stop everything including auto attacks or get launched into the air");
         }
     }
-    
+
     class FormidableStates : StateMachineBuilder
     {
         public FormidableStates(BossModule module) : base(module)
@@ -274,5 +274,6 @@ namespace BossMod.Shadowbringers.FATE.Formidable
         }
     }
 
-    public class Formidable(WorldState ws, Actor primary) : SimpleBossModule(ws, primary) {}
+    [ModuleInfo(FateID = 1464)]
+    public class Formidable(WorldState ws, Actor primary) : SimpleBossModule(ws, primary) { }
 }

--- a/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE11ShadowOfDeathHand.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE11ShadowOfDeathHand.cs
@@ -123,6 +123,7 @@
         }
     }
 
+    [ModuleInfo(CFCID = 735, DynamicEventID = 5)]
     public class CE11ShadowOfDeathHand : BossModule
     {
         public CE11ShadowOfDeathHand(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(825, 640), 20)) { }

--- a/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE12BayingOfHounds.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE12BayingOfHounds.cs
@@ -144,6 +144,7 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE12BayingOfHounds
         }
     }
 
+    [ModuleInfo(CFCID = 735, DynamicEventID = 2)]
     public class CE12BayingOfHounds : BossModule
     {
         public CE12BayingOfHounds(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(154, 785), 25)) { }

--- a/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE13KillItWithFire.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE13KillItWithFire.cs
@@ -149,6 +149,7 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE13KillItWithFire
         }
     }
 
+    [ModuleInfo(CFCID = 735, DynamicEventID = 1)]
     public class CE13KillItWithFire : BossModule
     {
         public CE13KillItWithFire(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(-90, 700), 25)) { }

--- a/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE14VigilForLost.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE14VigilForLost.cs
@@ -115,6 +115,7 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE14VigilForLost
         }
     }
 
+    [ModuleInfo(CFCID = 735, DynamicEventID = 3)]
     public class CE14VigilForLost : BossModule
     {
         public CE14VigilForLost(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(451, 830), 30)) { }

--- a/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE21FinalFurlong.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE21FinalFurlong.cs
@@ -128,6 +128,7 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE21FinalFurlong
         }
     }
 
+    [ModuleInfo(CFCID = 735, DynamicEventID = 6)]
     public class CE21FinalFurlong : BossModule
     {
         public CE21FinalFurlong(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(644, 228), 27)) { }

--- a/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE41WithDiremiteAndMain.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE41WithDiremiteAndMain.cs
@@ -191,6 +191,7 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE41WithDiremiteAndMai
         }
     }
 
+    [ModuleInfo(CFCID = 778, DynamicEventID = 21)]
     public class CE41WithDiremiteAndMain : BossModule
     {
         private List<Actor> _dimCrystals = new();

--- a/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE42FromBeyondTheGrave.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE42FromBeyondTheGrave.cs
@@ -193,6 +193,7 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE42FromBeyondTheGrave
         }
     }
 
+    [ModuleInfo(CFCID = 778, DynamicEventID = 20)]
     public class CE42FromBeyondTheGrave : BossModule
     {
         public CE42FromBeyondTheGrave(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(-60, 800), 30)) { }

--- a/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE44FamiliarFace.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE44FamiliarFace.cs
@@ -157,6 +157,7 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE44FamiliarFace
         }
     }
 
+    [ModuleInfo(CFCID = 778, DynamicEventID = 29)]
     public class CE44FamiliarFace : BossModule
     {
         public CE44FamiliarFace(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(330, 390), 30)) { }

--- a/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE51ThereWouldBeBlood.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE51ThereWouldBeBlood.cs
@@ -99,6 +99,7 @@
         }
     }
 
+    [ModuleInfo(CFCID = 778, DynamicEventID = 24)]
     public class CE51ThereWouldBeBlood : BossModule
     {
         public CE51ThereWouldBeBlood(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(-390, 230), 25)) { }

--- a/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE52TimeToBurn.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE52TimeToBurn.cs
@@ -167,6 +167,7 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE52TimeToBurn
         }
     }
 
+    [ModuleInfo(CFCID = 778, DynamicEventID = 26)]
     public class CE52TimeToBurn : BossModule
     {
         public CE52TimeToBurn(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(-550, 0), 30)) { }

--- a/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE53HereComesTheCavalry.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE53HereComesTheCavalry.cs
@@ -154,6 +154,7 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE53HereComesTheCavalr
         }
     }
 
+    [ModuleInfo(CFCID = 778, DynamicEventID = 22)]
     public class CE53HereComesTheCavalry : BossModule
     {
         public CE53HereComesTheCavalry(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(-750, 790), 25)) { }

--- a/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE54NeverCryWolf.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE54NeverCryWolf.cs
@@ -184,6 +184,7 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE54NeverCryWolf
         }
     }
 
+    [ModuleInfo(CFCID = 778, DynamicEventID = 25)]
     public class CE54NeverCryWolf : BossModule
     {
         private List<Actor> _adds = new();

--- a/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE62LooksToDieFor.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE62LooksToDieFor.cs
@@ -208,6 +208,7 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE62LooksToDieFor
         }
     }
 
+    [ModuleInfo(CFCID = 778, DynamicEventID = 30)]
     public class CE62LooksToDieFor : BossModule
     {
         public CE62LooksToDieFor(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(-200, -580), 20)) { }

--- a/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE63WornToShadow.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE63WornToShadow.cs
@@ -177,6 +177,7 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE63WornToShadow
         }
     }
 
+    [ModuleInfo(CFCID = 778, DynamicEventID = 28)]
     public class CE63WornToShadow : BossModule
     {
         public CE63WornToShadow(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(-480, -690), 30)) { }

--- a/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE64FeelingTheBurn.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE64FeelingTheBurn.cs
@@ -189,6 +189,7 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE64FeelingTheBurn
         }
     }
 
+    [ModuleInfo(CFCID = 778, DynamicEventID = 18)]
     public class CE64FeelingTheBurn : BossModule
     {
         public List<Actor> Escorts;

--- a/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS1TrinitySeeker/DRS1.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS1TrinitySeeker/DRS1.cs
@@ -32,6 +32,7 @@
         public IronRose() : base(ActionID.MakeSpell(AID.IronRose), new AOEShapeRect(50, 4)) { }
     }
 
+    [ModuleInfo(CFCID = 761, NameID = 9834)]
     public class DRS1 : BossModule
     {
         public static float BarricadeRadius = 20;

--- a/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS2Dahu/DRS2.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS2Dahu/DRS2.cs
@@ -25,6 +25,7 @@
         public HuntersClaw() : base(ActionID.MakeSpell(AID.HuntersClaw), new AOEShapeCircle(8)) { }
     }
 
+    [ModuleInfo(CFCID = 761, NameID = 9751)]
     public class DRS2 : BossModule
     {
         public DRS2(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(82, 138), 30)) { }

--- a/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS3QueensGuard/DRS3.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS3QueensGuard/DRS3.cs
@@ -45,7 +45,7 @@ namespace BossMod.Shadowbringers.Foray.DelubrumReginae.DRS3QueensGuard
         public Fracture() : base(ActionID.MakeSpell(AID.Fracture)) { }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.Knight)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.Knight, CFCID = 761, NameID = 9838)]
     public class DRS3 : BossModule
     {
         private List<Actor> _warrior;

--- a/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS4Phantom/DRS4.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS4Phantom/DRS4.cs
@@ -5,6 +5,7 @@
         public MaledictionOfAgony() : base(ActionID.MakeSpell(AID.MaledictionOfAgonyAOE)) { }
     }
 
+    [ModuleInfo(CFCID = 761, NameID = 9755)]
     public class DRS4 : BossModule
     {
         public DRS4(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(202, -370), 24)) { }

--- a/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS5TrinityAvowed/DRS5.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS5TrinityAvowed/DRS5.cs
@@ -21,6 +21,7 @@
         public GleamingArrow() : base(ActionID.MakeSpell(AID.GleamingArrow), new AOEShapeRect(60, 5)) { }
     }
 
+    [ModuleInfo(CFCID = 761, NameID = 9853)]
     public class DRS5 : BossModule
     {
         public DRS5(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsSquare(new(-272, -82), 25)) { }

--- a/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS6StygimolochLord/DRS6.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS6StygimolochLord/DRS6.cs
@@ -33,6 +33,7 @@ namespace BossMod.Shadowbringers.Foray.DelubrumReginae.DRS6StygimolochLord
     }
 
     // TODO: ManaFlame component - show reflect hints
+    [ModuleInfo(CFCID = 761, NameID = 9759)]
     public class DRS6 : BossModule
     {
         private List<Actor> _monks;

--- a/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS7Queen/DRS7.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS7Queen/DRS7.cs
@@ -53,6 +53,7 @@
         public OptimalPlayCone() : base(ActionID.MakeSpell(AID.OptimalPlayCone), new AOEShapeCone(60, 135.Degrees())) { }
     }
 
+    [ModuleInfo(CFCID = 761, NameID = 9863)]
     public class DRS7 : BossModule
     {
         public DRS7(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(-272, -415), 25)) { } // note: initially arena is square, but it quickly changes to circle

--- a/BossMod/Modules/Shadowbringers/Foray/Duel/Duel4Dabog/Duel4Dabog.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/Duel/Duel4Dabog/Duel4Dabog.cs
@@ -20,6 +20,7 @@
         public LeftArmWave() : base(ActionID.MakeSpell(AID.LeftArmWaveAOE), 24) { }
     }
 
+    [ModuleInfo(CFCID = 735, NameID = 9958)]
     public class Duel4Dabog : BossModule
     {
         public Duel4Dabog(WorldState ws, Actor primary) : base(ws, primary, new ArenaBoundsCircle(new(250, 710), 20)) { }

--- a/BossMod/Modules/Shadowbringers/HuntA/Maliktender.cs
+++ b/BossMod/Modules/Shadowbringers/HuntA/Maliktender.cs
@@ -65,5 +65,6 @@ namespace BossMod.Shadowbringers.HuntA.Maliktender
         }
     }
 
+    [ModuleInfo(NotoriousMonsterID = 124)]
     public class Maliktender(WorldState ws, Actor primary) : SimpleBossModule(ws, primary) {}
 }

--- a/BossMod/Modules/Shadowbringers/HuntA/Sugaar.cs
+++ b/BossMod/Modules/Shadowbringers/HuntA/Sugaar.cs
@@ -166,5 +166,6 @@ namespace BossMod.Shadowbringers.HuntA.Sugaar
         }
     }
 
+    [ModuleInfo(NotoriousMonsterID = 125)]
     public class Sugaar(WorldState ws, Actor primary) : SimpleBossModule(ws, primary) {}
 }

--- a/BossMod/Modules/Shadowbringers/Ultimate/TEA/TEA.cs
+++ b/BossMod/Modules/Shadowbringers/Ultimate/TEA/TEA.cs
@@ -84,7 +84,7 @@ namespace BossMod.Shadowbringers.Ultimate.TEA
         public P3DivineJudgmentRaidwide() : base(ActionID.MakeSpell(AID.DivineJudgmentRaidwide)) { }
     }
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.BossP1)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.BossP1, CFCID = 694)]
     public class TEA : BossModule
     {
         private List<Actor> _liquidHand;

--- a/BossMod/Modules/Stormblood/Ultimate/UWU/UWU.cs
+++ b/BossMod/Modules/Stormblood/Ultimate/UWU/UWU.cs
@@ -122,7 +122,7 @@ namespace BossMod.Stormblood.Ultimate.UWU
     }
 
 
-    [ModuleInfo(PrimaryActorOID = (uint)OID.Garuda)]
+    [ModuleInfo(PrimaryActorOID = (uint)OID.Garuda, CFCID = 539)]
     public class UWU : BossModule
     {
         private List<Actor> _ifrits;

--- a/BossMod/Util/UIMisc.cs
+++ b/BossMod/Util/UIMisc.cs
@@ -15,5 +15,17 @@ namespace BossMod
                 ImGui.SetTooltip("Hold shift");
             return res;
         }
+
+        public static void TextUnderlined(System.Numerics.Vector4 colour, string text)
+        {
+            var size = ImGui.CalcTextSize(text);
+            var cur = ImGui.GetCursorScreenPos();
+            cur.Y += size.Y;
+            ImGui.GetWindowDrawList().PathLineTo(cur);
+            cur.X += size.X;
+            ImGui.GetWindowDrawList().PathLineTo(cur);
+            ImGui.GetWindowDrawList().PathStroke(ImGui.ColorConvertFloat4ToU32(colour));
+            ImGui.TextColored(colour, text);
+        }
     }
 }

--- a/BossMod/Util/UIMisc.cs
+++ b/BossMod/Util/UIMisc.cs
@@ -1,4 +1,5 @@
 ﻿using ImGuiNET;
+using System.Numerics;
 
 namespace BossMod
 {
@@ -16,7 +17,7 @@ namespace BossMod
             return res;
         }
 
-        public static void TextUnderlined(System.Numerics.Vector4 colour, string text)
+        public static void TextUnderlined(Vector4 colour, string text)
         {
             var size = ImGui.CalcTextSize(text);
             var cur = ImGui.GetCursorScreenPos();


### PR DESCRIPTION
adds a modules tab to the vbm window where you can see all available modules.
added parameters you can supply to module info to designate the boss names or content ID which are then used to add more info when the module is registered

new moduleinfo parameters: cfcid (most content), nameid (bnpcname sheet for boss names), notoriousmonsterid (for hunts), fateid (fates), dynamiceventid (critical engagements)

all new parameters are optional and anything uncategorised will be displayed at the bottom of the list using the module's namespace name

most file changes are from adding the relevant moduleinfo parameters to each module

fates are always uncatalogued because there is no way to get the territory type (and thus expansion) via fateID