### PR TITLE
level 90 MNK rotation

### DIFF
--- a/BossMod/Autorotation/Autorotation.cs
+++ b/BossMod/Autorotation/Autorotation.cs
@@ -117,7 +117,7 @@ namespace BossMod
                 {
                     Class.WAR => typeof(WAR.Actions),
                     Class.PLD => Service.ClientState.LocalPlayer?.Level <= 60 ? typeof(PLD.Actions) : null,
-                    Class.MNK => Service.ClientState.LocalPlayer?.Level <= 60 ? typeof(MNK.Actions) : null,
+                    Class.MNK => typeof(MNK.Actions),
                     Class.DRG => typeof(DRG.Actions),
                     Class.BRD => typeof(BRD.Actions),
                     Class.BLM => Service.ClientState.LocalPlayer?.Level <= 60 ? typeof(BLM.Actions) : null,

--- a/BossMod/Autorotation/MNK/MNKActions.cs
+++ b/BossMod/Autorotation/MNK/MNKActions.cs
@@ -202,6 +202,10 @@ namespace BossMod.MNK
                     )
                 : null;
 
+            SupportedSpell(AID.Thunderclap).TransformTarget = _config.SmartThunderclap
+                ? (act) => Autorot.SecondaryTarget ?? act
+                : null;
+
             _strategy.PreCombatFormShift = _config.AutoFormShift;
 
             // smart targets

--- a/BossMod/Autorotation/MNK/MNKActions.cs
+++ b/BossMod/Autorotation/MNK/MNKActions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Dalamud.Game.ClientState.JobGauge.Types;
 
 namespace BossMod.MNK
@@ -189,7 +189,7 @@ namespace BossMod.MNK
             SupportedSpell(AID.Bootshine).PlaceholderForAuto = _config.FullRotation
                 ? AutoActionST
                 : AutoActionNone;
-            SupportedSpell(AID.ShadowOfTheDestroyer).PlaceholderForAuto = _config.FullRotation
+            SupportedSpell(AID.ArmOfTheDestroyer).PlaceholderForAuto = _config.FullRotation
                 ? AutoActionAOE
                 : AutoActionNone;
 
@@ -205,6 +205,19 @@ namespace BossMod.MNK
                         )
                     )
                 : null;
+
+            SupportedSpell(AID.Thunderclap).Condition = !_config.PreventCloseDash
+                ? null
+                : (act) =>
+                {
+                    if (act == null)
+                        return false;
+
+                    return (act.Position - Player.Position).Length()
+                            - act.HitboxRadius
+                            - Player.HitboxRadius
+                        > 3;
+                };
 
             SupportedSpell(AID.Thunderclap).TransformTarget = _config.SmartThunderclap
                 ? (act) => Autorot.SecondaryTarget ?? act

--- a/BossMod/Autorotation/MNK/MNKActions.cs
+++ b/BossMod/Autorotation/MNK/MNKActions.cs
@@ -1,5 +1,5 @@
-using System;
 using Dalamud.Game.ClientState.JobGauge.Types;
+using System;
 
 namespace BossMod.MNK
 {
@@ -20,21 +20,11 @@ namespace BossMod.MNK
             _strategy = new();
 
             // upgrades
-            SupportedSpell(AID.SteelPeak).TransformAction = SupportedSpell(
-                AID.ForbiddenChakra
-            ).TransformAction = () => ActionID.MakeSpell(_state.BestForbiddenChakra);
-            SupportedSpell(AID.Meditation).TransformAction = () =>
-                ActionID.MakeSpell(
-                    _state.Chakra == 5 ? _state.BestForbiddenChakra : AID.Meditation
-                );
-            SupportedSpell(AID.HowlingFist).TransformAction = SupportedSpell(
-                AID.Enlightenment
-            ).TransformAction = () => ActionID.MakeSpell(_state.BestEnlightenment);
-            SupportedSpell(AID.ArmOfTheDestroyer).TransformAction = SupportedSpell(
-                AID.ShadowOfTheDestroyer
-            ).TransformAction = () => ActionID.MakeSpell(_state.BestShadowOfTheDestroyer);
-            SupportedSpell(AID.MasterfulBlitz).TransformAction = () =>
-                ActionID.MakeSpell(_state.BestBlitz);
+            SupportedSpell(AID.SteelPeak).TransformAction = SupportedSpell(AID.ForbiddenChakra).TransformAction = () => ActionID.MakeSpell(_state.BestForbiddenChakra);
+            SupportedSpell(AID.HowlingFist).TransformAction = SupportedSpell(AID.Enlightenment).TransformAction = () => ActionID.MakeSpell(_state.BestEnlightenment);
+            SupportedSpell(AID.Meditation).TransformAction = () => ActionID.MakeSpell(_state.Chakra == 5 ? _state.BestForbiddenChakra : AID.Meditation);
+            SupportedSpell(AID.ArmOfTheDestroyer).TransformAction = SupportedSpell(AID.ShadowOfTheDestroyer).TransformAction = () => ActionID.MakeSpell(_state.BestShadowOfTheDestroyer);
+            SupportedSpell(AID.MasterfulBlitz).TransformAction = () => ActionID.MakeSpell(_state.BestBlitz);
 
             _config.Modified += OnConfigModified;
             OnConfigModified(null, EventArgs.Empty);
@@ -46,21 +36,12 @@ namespace BossMod.MNK
         }
 
         public override CommonRotation.PlayerState GetState() => _state;
-
         public override CommonRotation.Strategy GetStrategy() => _strategy;
 
         public override Targeting SelectBetterTarget(AIHints.Enemy initial)
         {
             // TODO: multidotting support...
-            var pos = (
-                _state.Form == Rotation.Form.Coeurl
-                    ? Rotation.GetCoeurlFormAction(
-                        _state,
-                        _strategy.NumPointBlankAOETargets,
-                        _strategy.ForbidDOTs
-                    )
-                    : AID.None
-            ) switch
+            var pos = (_state.Form == Rotation.Form.Coeurl ? Rotation.GetCoeurlFormAction(_state, _strategy.NumPointBlankAOETargets, _strategy.ForbidDOTs) : AID.None) switch
             {
                 AID.SnapPunch => Positional.Flank,
                 AID.Demolish => Positional.Rear,
@@ -73,47 +54,20 @@ namespace BossMod.MNK
         {
             UpdatePlayerState();
             FillCommonStrategy(_strategy, CommonDefinitions.IDPotionStr);
-            _strategy.ApplyStrategyOverrides(
-                Autorot
-                    .Bossmods.ActiveModule?.PlanExecution
-                    ?.ActiveStrategyOverrides(Autorot.Bossmods.ActiveModule.StateMachine)
-                    ?? new uint[0]
-            );
-            _strategy.NumPointBlankAOETargets =
-                autoAction == AutoActionST ? 0 : NumTargetsHitByPBAOE();
-            _strategy.NumEnlightenmentTargets =
-                Autorot.PrimaryTarget != null
-                && autoAction != AutoActionST
-                && _state.Unlocked(AID.HowlingFist)
-                    ? NumTargetsHitByEnlightenment(Autorot.PrimaryTarget)
-                    : 0;
-            FillStrategyPositionals(
-                _strategy,
-                Rotation.GetNextPositional(_state, _strategy),
-                _state.TrueNorthLeft > _state.GCD
-            );
+            _strategy.ApplyStrategyOverrides(Autorot.Bossmods.ActiveModule?.PlanExecution?.ActiveStrategyOverrides(Autorot.Bossmods.ActiveModule.StateMachine) ?? new uint[0]);
+            _strategy.NumPointBlankAOETargets = autoAction == AutoActionST ? 0 : NumTargetsHitByPBAOE();
+            _strategy.NumEnlightenmentTargets = Autorot.PrimaryTarget != null && autoAction != AutoActionST && _state.Unlocked(AID.HowlingFist) ? NumTargetsHitByEnlightenment(Autorot.PrimaryTarget) : 0;
+            FillStrategyPositionals(_strategy, Rotation.GetNextPositional(_state, _strategy), _state.TrueNorthLeft > _state.GCD);
         }
 
         protected override void QueueAIActions()
         {
             if (_state.Unlocked(AID.SteelPeak))
-                SimulateManualActionForAI(
-                    ActionID.MakeSpell(AID.Meditation),
-                    Player,
-                    !Player.InCombat && _state.Chakra < 5
-                );
+                SimulateManualActionForAI(ActionID.MakeSpell(AID.Meditation), Player, !Player.InCombat && _state.Chakra < 5);
             if (_state.Unlocked(AID.SecondWind))
-                SimulateManualActionForAI(
-                    ActionID.MakeSpell(AID.SecondWind),
-                    Player,
-                    Player.InCombat && Player.HP.Cur < Player.HP.Max * 0.5f
-                );
+                SimulateManualActionForAI(ActionID.MakeSpell(AID.SecondWind), Player, Player.InCombat && Player.HP.Cur < Player.HP.Max * 0.5f);
             if (_state.Unlocked(AID.Bloodbath))
-                SimulateManualActionForAI(
-                    ActionID.MakeSpell(AID.Bloodbath),
-                    Player,
-                    Player.InCombat && Player.HP.Cur < Player.HP.Max * 0.8f
-                );
+                SimulateManualActionForAI(ActionID.MakeSpell(AID.Bloodbath), Player, Player.InCombat && Player.HP.Cur < Player.HP.Max * 0.8f);
         }
 
         protected override NextAction CalculateAutomaticGCD()
@@ -147,26 +101,14 @@ namespace BossMod.MNK
             _state.Nadi = gauge.Nadi;
 
             (_state.Form, _state.FormLeft) = DetermineForm();
-            _state.DisciplinedFistLeft = StatusDetails(
-                Player,
-                SID.DisciplinedFist,
-                Player.InstanceID
-            ).Left;
+            _state.DisciplinedFistLeft = StatusDetails(Player, SID.DisciplinedFist, Player.InstanceID).Left;
             _state.LeadenFistLeft = StatusDetails(Player, SID.LeadenFist, Player.InstanceID).Left;
-            _state.PerfectBalanceLeft = StatusDetails(
-                Player,
-                SID.PerfectBalance,
-                Player.InstanceID
-            ).Left;
+            _state.PerfectBalanceLeft = StatusDetails(Player, SID.PerfectBalance, Player.InstanceID).Left;
             _state.FormShiftLeft = StatusDetails(Player, SID.FormlessFist, Player.InstanceID).Left;
             _state.FireLeft = StatusDetails(Player, SID.RiddleOfFire, Player.InstanceID).Left;
             _state.TrueNorthLeft = StatusDetails(Player, SID.TrueNorth, Player.InstanceID).Left;
 
-            _state.TargetDemolishLeft = StatusDetails(
-                Autorot.PrimaryTarget,
-                SID.Demolish,
-                Player.InstanceID
-            ).Left;
+            _state.TargetDemolishLeft = StatusDetails(Autorot.PrimaryTarget, SID.Demolish, Player.InstanceID).Left;
         }
 
         private (Rotation.Form, float) DetermineForm()
@@ -186,57 +128,24 @@ namespace BossMod.MNK
         private void OnConfigModified(object? sender, EventArgs args)
         {
             // placeholders
-            SupportedSpell(AID.Bootshine).PlaceholderForAuto = _config.FullRotation
-                ? AutoActionST
-                : AutoActionNone;
-            SupportedSpell(AID.ArmOfTheDestroyer).PlaceholderForAuto = _config.FullRotation
-                ? AutoActionAOE
-                : AutoActionNone;
+            SupportedSpell(AID.Bootshine).PlaceholderForAuto = _config.FullRotation ? AutoActionST : AutoActionNone;
+            SupportedSpell(AID.ArmOfTheDestroyer).PlaceholderForAuto = _config.FullRotation ? AutoActionAOE : AutoActionNone;
 
             // combo replacement
-            SupportedSpell(AID.FourPointFury).TransformAction = _config.AOECombos
-                ? () =>
-                    ActionID.MakeSpell(
-                        Rotation.GetNextComboAction(
-                            _state,
-                            100,
-                            false,
-                            Rotation.Strategy.NadiChoice.Automatic
-                        )
-                    )
+            SupportedSpell(AID.FourPointFury).TransformAction = _config.AOECombos ? () => ActionID.MakeSpell(Rotation.GetNextComboAction(_state, 100, false, Rotation.Strategy.NadiChoice.Automatic)) : null;
+
+            SupportedSpell(AID.Thunderclap).Condition = _config.PreventCloseDash
+                ? ((act) => act == null || !act.Position.InCircle(Player.Position, 3))
                 : null;
 
-            SupportedSpell(AID.Thunderclap).Condition = !_config.PreventCloseDash
-                ? null
-                : (act) =>
-                {
-                    if (act == null)
-                        return false;
-
-                    return (act.Position - Player.Position).Length()
-                            - act.HitboxRadius
-                            - Player.HitboxRadius
-                        > 3;
-                };
-
-            SupportedSpell(AID.Thunderclap).TransformTarget = _config.SmartThunderclap
-                ? (act) => Autorot.SecondaryTarget ?? act
-                : null;
+            SupportedSpell(AID.Thunderclap).TransformTarget = _config.SmartThunderclap ? (act) => Autorot.SecondaryTarget ?? act : null;
 
             _strategy.PreCombatFormShift = _config.AutoFormShift;
 
             // smart targets
         }
 
-        private int NumTargetsHitByPBAOE() =>
-            Autorot.Hints.NumPriorityTargetsInAOECircle(Player.Position, 5);
-
-        private int NumTargetsHitByEnlightenment(Actor primary) =>
-            Autorot.Hints.NumPriorityTargetsInAOERect(
-                Player.Position,
-                (primary.Position - Player.Position).Normalized(),
-                10,
-                _state.Unlocked(AID.Enlightenment) ? 2 : 1
-            );
+        private int NumTargetsHitByPBAOE() => Autorot.Hints.NumPriorityTargetsInAOECircle(Player.Position, 5);
+        private int NumTargetsHitByEnlightenment(Actor primary) => Autorot.Hints.NumPriorityTargetsInAOERect(Player.Position, (primary.Position - Player.Position).Normalized(), 10, _state.Unlocked(AID.Enlightenment) ? 2 : 1);
     }
 }

--- a/BossMod/Autorotation/MNK/MNKActions.cs
+++ b/BossMod/Autorotation/MNK/MNKActions.cs
@@ -114,7 +114,7 @@ namespace BossMod.MNK
 
         protected override NextAction CalculateAutomaticGCD()
         {
-            if (Autorot.PrimaryTarget == null || AutoAction < AutoActionAIFight)
+            if (AutoAction < AutoActionAIFight)
                 return new();
             var aid = Rotation.GetNextBestGCD(_state, _strategy);
             return MakeResult(aid, Autorot.PrimaryTarget);
@@ -201,6 +201,8 @@ namespace BossMod.MNK
                         )
                     )
                 : null;
+
+            _strategy.PreCombatFormShift = _config.AutoFormShift;
 
             // smart targets
         }

--- a/BossMod/Autorotation/MNK/MNKActions.cs
+++ b/BossMod/Autorotation/MNK/MNKActions.cs
@@ -23,6 +23,10 @@ namespace BossMod.MNK
             SupportedSpell(AID.SteelPeak).TransformAction = SupportedSpell(
                 AID.ForbiddenChakra
             ).TransformAction = () => ActionID.MakeSpell(_state.BestForbiddenChakra);
+            SupportedSpell(AID.Meditation).TransformAction = () =>
+                ActionID.MakeSpell(
+                    _state.Chakra == 5 ? _state.BestForbiddenChakra : AID.Meditation
+                );
             SupportedSpell(AID.HowlingFist).TransformAction = SupportedSpell(
                 AID.Enlightenment
             ).TransformAction = () => ActionID.MakeSpell(_state.BestEnlightenment);

--- a/BossMod/Autorotation/MNK/MNKConfig.cs
+++ b/BossMod/Autorotation/MNK/MNKConfig.cs
@@ -11,6 +11,9 @@
         [PropertyDisplay("Execute form-specific aoe GCD on Four-point Fury")]
         public bool AOECombos = true;
 
+        [PropertyDisplay("Automatic mouseover targeting for Thunderclap")]
+        public bool SmartThunderclap = true;
+
         [PropertyDisplay("Use Form Shift out of combat")]
         public bool AutoFormShift = false;
     }

--- a/BossMod/Autorotation/MNK/MNKConfig.cs
+++ b/BossMod/Autorotation/MNK/MNKConfig.cs
@@ -3,9 +3,7 @@ namespace BossMod
     [ConfigDisplay(Parent = typeof(AutorotationConfig))]
     class MNKConfig : ConfigNode
     {
-        [PropertyDisplay(
-            "Execute optimal rotations on Bootshine (ST) or Arm of the Destroyer (AOE)"
-        )]
+        [PropertyDisplay("Execute optimal rotations on Bootshine (ST) or Arm of the Destroyer (AOE)")]
         public bool FullRotation = true;
 
         [PropertyDisplay("Execute form-specific aoe GCD on Four-point Fury")]

--- a/BossMod/Autorotation/MNK/MNKConfig.cs
+++ b/BossMod/Autorotation/MNK/MNKConfig.cs
@@ -1,4 +1,4 @@
-﻿namespace BossMod
+namespace BossMod
 {
     [ConfigDisplay(Parent = typeof(AutorotationConfig))]
     class MNKConfig : ConfigNode
@@ -13,6 +13,9 @@
 
         [PropertyDisplay("Automatic mouseover targeting for Thunderclap")]
         public bool SmartThunderclap = true;
+
+        [PropertyDisplay("Delay Thunderclap if already in melee range of target")]
+        public bool PreventCloseDash = true;
 
         [PropertyDisplay("Use Form Shift out of combat")]
         public bool AutoFormShift = false;

--- a/BossMod/Autorotation/MNK/MNKConfig.cs
+++ b/BossMod/Autorotation/MNK/MNKConfig.cs
@@ -3,10 +3,15 @@
     [ConfigDisplay(Parent = typeof(AutorotationConfig))]
     class MNKConfig : ConfigNode
     {
-        [PropertyDisplay("Execute optimal rotations on Bootshine (ST) or Arm of the Destroyer (AOE)")]
+        [PropertyDisplay(
+            "Execute optimal rotations on Bootshine (ST) or Arm of the Destroyer (AOE)"
+        )]
         public bool FullRotation = true;
 
         [PropertyDisplay("Execute form-specific aoe GCD on Four-point Fury")]
         public bool AOECombos = true;
+
+        [PropertyDisplay("Use Form Shift out of combat")]
+        public bool AutoFormShift = false;
     }
 }

--- a/BossMod/Autorotation/MNK/MNKDefinitions.cs
+++ b/BossMod/Autorotation/MNK/MNKDefinitions.cs
@@ -116,7 +116,8 @@ namespace BossMod.MNK
         Mantra = 102, // applied by Mantra to targets, +10% healing taken
         TrueNorth = 1250, // applied by True North to self, ignore positionals
         Stun = 2, // applied by Leg Sweep to target
-        FormlessFist = 2513,
+        FormlessFist = 2513, // applied by Form Shift to self
+        SixSidedStar = 2514, // applied by Six-Sided Star to self
     }
 
     public static class Definitions

--- a/BossMod/Autorotation/MNK/MNKDefinitions.cs
+++ b/BossMod/Autorotation/MNK/MNKDefinitions.cs
@@ -248,7 +248,7 @@ namespace BossMod.MNK
             SupportedActions.OGCD(AID.ArmsLength, 0, CDGroup.ArmsLength, 120.0f).EffectDuration = 6;
             SupportedActions.GCD(AID.Meditation, 0);
             SupportedActions.OGCDWithCharges(AID.TrueNorth, 0, CDGroup.TrueNorth, 45.0f, 2);
-            SupportedActions.OGCDWithCharges(AID.Thunderclap, 20, CDGroup.Thunderclap, 30.0f, 2);
+            SupportedActions.OGCDWithCharges(AID.Thunderclap, 20, CDGroup.Thunderclap, 30.0f, 3);
             SupportedActions.GCD(AID.FormShift, 0);
             SupportedActions.OGCD(AID.Anatman, 0, CDGroup.Anatman, 60.0f);
             SupportedActions.OGCD(AID.LegSweep, 3, CDGroup.LegSweep, 40.0f);

--- a/BossMod/Autorotation/MNK/MNKDefinitions.cs
+++ b/BossMod/Autorotation/MNK/MNKDefinitions.cs
@@ -105,6 +105,8 @@ namespace BossMod.MNK
         OpoOpoForm = 107, // applied by Snap Punch to self
         RaptorForm = 108, // applied by Bootshine, Arm of the Destroyer to self
         CoeurlForm = 109, // applied by True Strike, Twin Snakes to self
+        RiddleOfFire = 1181, // applied by Riddle of Fire to self
+        RiddleOfWind = 2687, // applied by Riddle of Wind to self
         LeadenFist = 1861, // applied by Dragon Kick to self
         DisciplinedFist = 3001, // applied by Twin Snakes to self, damage buff
         PerfectBalance = 110, // applied by Perfect Balance to self, ignore form requirements
@@ -114,11 +116,25 @@ namespace BossMod.MNK
         Mantra = 102, // applied by Mantra to targets, +10% healing taken
         TrueNorth = 1250, // applied by True North to self, ignore positionals
         Stun = 2, // applied by Leg Sweep to target
+        FormlessFist = 2513,
     }
 
     public static class Definitions
     {
-        public static uint[] UnlockQuests = { 66094, 66103, 66597, 66598, 66599, 66600, 66602, 67563, 67564, 67567, 67966 };
+        public static uint[] UnlockQuests =
+        {
+            66094,
+            66103,
+            66597,
+            66598,
+            66599,
+            66600,
+            66602,
+            67563,
+            67564,
+            67567,
+            67966
+        };
 
         public static bool Unlocked(AID aid, int level, int questProgress)
         {
@@ -188,6 +204,7 @@ namespace BossMod.MNK
         }
 
         public static Dictionary<ActionID, ActionDefinition> SupportedActions;
+
         static Definitions()
         {
             SupportedActions = CommonDefinitions.CommonActionData(CommonDefinitions.IDPotionStr);
@@ -213,7 +230,13 @@ namespace BossMod.MNK
             SupportedActions.OGCD(AID.ForbiddenChakra, 3, CDGroup.SteelPeak, 1.0f);
             SupportedActions.OGCD(AID.HowlingFist, 10, CDGroup.SteelPeak, 1.0f);
             SupportedActions.OGCD(AID.Enlightenment, 10, CDGroup.SteelPeak, 1.0f);
-            SupportedActions.OGCDWithCharges(AID.PerfectBalance, 0, CDGroup.PerfectBalance, 40.0f, 2);
+            SupportedActions.OGCDWithCharges(
+                AID.PerfectBalance,
+                0,
+                CDGroup.PerfectBalance,
+                40.0f,
+                2
+            );
             SupportedActions.OGCD(AID.RiddleOfFire, 0, CDGroup.RiddleOfFire, 60.0f);
             SupportedActions.OGCD(AID.Brotherhood, 0, CDGroup.Brotherhood, 120.0f);
             SupportedActions.OGCD(AID.RiddleOfWind, 0, CDGroup.RiddleOfWind, 90.0f);

--- a/BossMod/Autorotation/MNK/MNKDefinitions.cs
+++ b/BossMod/Autorotation/MNK/MNKDefinitions.cs
@@ -122,20 +122,7 @@ namespace BossMod.MNK
 
     public static class Definitions
     {
-        public static uint[] UnlockQuests =
-        {
-            66094,
-            66103,
-            66597,
-            66598,
-            66599,
-            66600,
-            66602,
-            67563,
-            67564,
-            67567,
-            67966
-        };
+        public static uint[] UnlockQuests = { 66094, 66103, 66597, 66598, 66599, 66600, 66602, 67563, 67564, 67567, 67966 };
 
         public static bool Unlocked(AID aid, int level, int questProgress)
         {
@@ -205,7 +192,6 @@ namespace BossMod.MNK
         }
 
         public static Dictionary<ActionID, ActionDefinition> SupportedActions;
-
         static Definitions()
         {
             SupportedActions = CommonDefinitions.CommonActionData(CommonDefinitions.IDPotionStr);
@@ -231,21 +217,13 @@ namespace BossMod.MNK
             SupportedActions.OGCD(AID.ForbiddenChakra, 3, CDGroup.SteelPeak, 1.0f);
             SupportedActions.OGCD(AID.HowlingFist, 10, CDGroup.SteelPeak, 1.0f);
             SupportedActions.OGCD(AID.Enlightenment, 10, CDGroup.SteelPeak, 1.0f);
-            SupportedActions.OGCDWithCharges(
-                AID.PerfectBalance,
-                0,
-                CDGroup.PerfectBalance,
-                40.0f,
-                2
-            );
+            SupportedActions.OGCDWithCharges(AID.PerfectBalance, 0, CDGroup.PerfectBalance, 40.0f, 2);
             SupportedActions.OGCD(AID.RiddleOfFire, 0, CDGroup.RiddleOfFire, 60.0f);
             SupportedActions.OGCD(AID.Brotherhood, 0, CDGroup.Brotherhood, 120.0f);
             SupportedActions.OGCD(AID.RiddleOfWind, 0, CDGroup.RiddleOfWind, 90.0f);
             SupportedActions.OGCD(AID.SecondWind, 0, CDGroup.SecondWind, 120.0f);
             SupportedActions.OGCD(AID.Mantra, 0, CDGroup.Mantra, 90.0f).EffectDuration = 15;
-            SupportedActions
-                .OGCD(AID.RiddleOfEarth, 0, CDGroup.RiddleOfEarth, 120.0f)
-                .EffectDuration = 10;
+            SupportedActions.OGCD(AID.RiddleOfEarth, 0, CDGroup.RiddleOfEarth, 120.0f).EffectDuration = 10;
             SupportedActions.OGCD(AID.Bloodbath, 0, CDGroup.Bloodbath, 90.0f);
             SupportedActions.OGCD(AID.Feint, 10, CDGroup.Feint, 90.0f).EffectDuration = 10;
             SupportedActions.OGCD(AID.ArmsLength, 0, CDGroup.ArmsLength, 120.0f).EffectDuration = 6;

--- a/BossMod/Autorotation/MNK/MNKDefinitions.cs
+++ b/BossMod/Autorotation/MNK/MNKDefinitions.cs
@@ -241,8 +241,10 @@ namespace BossMod.MNK
             SupportedActions.OGCD(AID.Brotherhood, 0, CDGroup.Brotherhood, 120.0f);
             SupportedActions.OGCD(AID.RiddleOfWind, 0, CDGroup.RiddleOfWind, 90.0f);
             SupportedActions.OGCD(AID.SecondWind, 0, CDGroup.SecondWind, 120.0f);
-            SupportedActions.OGCD(AID.Mantra, 0, CDGroup.Mantra, 90.0f);
-            SupportedActions.OGCDWithCharges(AID.RiddleOfEarth, 0, CDGroup.RiddleOfEarth, 30.0f, 3);
+            SupportedActions.OGCD(AID.Mantra, 0, CDGroup.Mantra, 90.0f).EffectDuration = 15;
+            SupportedActions
+                .OGCD(AID.RiddleOfEarth, 0, CDGroup.RiddleOfEarth, 120.0f)
+                .EffectDuration = 10;
             SupportedActions.OGCD(AID.Bloodbath, 0, CDGroup.Bloodbath, 90.0f);
             SupportedActions.OGCD(AID.Feint, 10, CDGroup.Feint, 90.0f).EffectDuration = 10;
             SupportedActions.OGCD(AID.ArmsLength, 0, CDGroup.ArmsLength, 120.0f).EffectDuration = 6;

--- a/BossMod/Autorotation/MNK/MNKRotation.cs
+++ b/BossMod/Autorotation/MNK/MNKRotation.cs
@@ -253,7 +253,7 @@ namespace BossMod.MNK
 
                 if (
                     (
-                        strategy.CombatTimer > -20 && state.FormShiftLeft < 20
+                        strategy.CombatTimer > -20 && state.FormShiftLeft < 5
                         || strategy.PreCombatFormShift && state.FormShiftLeft < 2
                     ) && state.Unlocked(AID.FormShift)
                 )
@@ -424,7 +424,7 @@ namespace BossMod.MNK
             if (strategy.WindUse == OffensiveAbilityUse.Force)
                 return true;
 
-            // thebalance recommends using RoW as an oGCD dot, so we use on cooldown as long as RoF has been used first
+            // thebalance recommends using RoW like an oGCD dot, so we use on cooldown as long as RoF has been used first
             return state.CD(CDGroup.RiddleOfFire) > 0;
         }
 

--- a/BossMod/Autorotation/MNK/MNKRotation.cs
+++ b/BossMod/Autorotation/MNK/MNKRotation.cs
@@ -6,13 +6,7 @@ namespace BossMod.MNK
 {
     public static class Rotation
     {
-        public enum Form
-        {
-            None,
-            OpoOpo,
-            Raptor,
-            Coeurl
-        }
+        public enum Form { None, OpoOpo, Raptor, Coeurl }
 
         // full state needed for determining next action
         public class State : CommonRotation.PlayerState
@@ -39,18 +33,11 @@ namespace BossMod.MNK
                 );
 
             // upgrade paths
-            public AID BestForbiddenChakra =>
-                Unlocked(AID.ForbiddenChakra) ? AID.ForbiddenChakra : AID.SteelPeak;
-            public AID BestEnlightenment =>
-                Unlocked(AID.Enlightenment) ? AID.Enlightenment : AID.HowlingFist;
-            public AID BestShadowOfTheDestroyer =>
-                Unlocked(AID.ShadowOfTheDestroyer)
-                    ? AID.ShadowOfTheDestroyer
-                    : AID.ArmOfTheDestroyer;
-            public AID BestRisingPhoenix =>
-                Unlocked(AID.RisingPhoenix) ? AID.RisingPhoenix : AID.FlintStrike;
-            public AID BestPhantomRush =>
-                Unlocked(AID.PhantomRush) ? AID.PhantomRush : AID.TornadoKick;
+            public AID BestForbiddenChakra => Unlocked(AID.ForbiddenChakra) ? AID.ForbiddenChakra : AID.SteelPeak;
+            public AID BestEnlightenment => Unlocked(AID.Enlightenment) ? AID.Enlightenment : AID.HowlingFist;
+            public AID BestShadowOfTheDestroyer => Unlocked(AID.ShadowOfTheDestroyer) ? AID.ShadowOfTheDestroyer : AID.ArmOfTheDestroyer;
+            public AID BestRisingPhoenix => Unlocked(AID.RisingPhoenix) ? AID.RisingPhoenix : AID.FlintStrike;
+            public AID BestPhantomRush => Unlocked(AID.PhantomRush) ? AID.PhantomRush : AID.TornadoKick;
 
             public AID BestBlitz
             {
@@ -72,11 +59,9 @@ namespace BossMod.MNK
                 }
             }
 
-            public State(float[] cooldowns)
-                : base(cooldowns) { }
+            public State(float[] cooldowns) : base(cooldowns) { }
 
             public bool Unlocked(AID aid) => Definitions.Unlocked(aid, Level, UnlockProgress);
-
             public bool Unlocked(TraitID tid) => Definitions.Unlocked(tid, Level, UnlockProgress);
 
             public override string ToString()
@@ -143,7 +128,7 @@ namespace BossMod.MNK
 
             public override string ToString()
             {
-                return $"AOE={NumPointBlankAOETargets}/{NumEnlightenmentTargets}, no-dots={ForbidDOTs}, {CombatTimer}";
+                return $"AOE={NumPointBlankAOETargets}/{NumEnlightenmentTargets}, no-dots={ForbidDOTs}";
             }
 
             public void ApplyStrategyOverrides(uint[] overrides)
@@ -299,13 +284,7 @@ namespace BossMod.MNK
             )
                 return AID.SixSidedStar;
 
-            // TODO: L52+
-            return GetNextComboAction(
-                state,
-                strategy.NumPointBlankAOETargets,
-                strategy.ForbidDOTs,
-                strategy.NextNadi
-            );
+            return GetNextComboAction(state, strategy.NumPointBlankAOETargets, strategy.ForbidDOTs, strategy.NextNadi);
         }
 
         public static (Positional, bool) GetNextPositional(State state, Strategy strategy)
@@ -372,21 +351,11 @@ namespace BossMod.MNK
                 // L54 Forbidden Chakra is 340p => HF at 4+ targets
                 // L72 Enlightenment is 170p/target => at 2+ targets
                 if (state.Unlocked(AID.Enlightenment))
-                    return ActionID.MakeSpell(
-                        strategy.NumEnlightenmentTargets >= 2
-                            ? AID.Enlightenment
-                            : AID.ForbiddenChakra
-                    );
+                    return ActionID.MakeSpell(strategy.NumEnlightenmentTargets >= 2 ? AID.Enlightenment : AID.ForbiddenChakra);
                 else if (state.Unlocked(AID.ForbiddenChakra))
-                    return ActionID.MakeSpell(
-                        strategy.NumEnlightenmentTargets >= 4
-                            ? AID.HowlingFist
-                            : AID.ForbiddenChakra
-                    );
+                    return ActionID.MakeSpell(strategy.NumEnlightenmentTargets >= 4 ? AID.HowlingFist : AID.ForbiddenChakra);
                 else if (state.Unlocked(AID.HowlingFist))
-                    return ActionID.MakeSpell(
-                        strategy.NumEnlightenmentTargets >= 2 ? AID.HowlingFist : AID.SteelPeak
-                    );
+                    return ActionID.MakeSpell(strategy.NumEnlightenmentTargets >= 2 ? AID.HowlingFist : AID.SteelPeak);
                 else
                     return ActionID.MakeSpell(AID.SteelPeak);
             }

--- a/BossMod/Autorotation/MNK/MNKRotation.cs
+++ b/BossMod/Autorotation/MNK/MNKRotation.cs
@@ -1,34 +1,87 @@
-﻿namespace BossMod.MNK
+﻿using System.Linq;
+using Dalamud.Game.ClientState.JobGauge.Enums;
+using static BossMod.CommonRotation.Strategy;
+
+namespace BossMod.MNK
 {
     public static class Rotation
     {
-        public enum Form { None, OpoOpo, Raptor, Coeurl }
+        public enum Form
+        {
+            None,
+            OpoOpo,
+            Raptor,
+            Coeurl
+        }
 
         // full state needed for determining next action
         public class State : CommonRotation.PlayerState
         {
             public int Chakra; // 0-5
+            public BeastChakra[] BeastChakra;
+            public Nadi Nadi;
             public Form Form;
             public float FormLeft; // 0 if no form, 30 max
             public float DisciplinedFistLeft; // 15 max
             public float LeadenFistLeft; // 30 max
             public float TargetDemolishLeft; // TODO: this shouldn't be here...
+            public float PerfectBalanceLeft; // 20 max
+            public float FormShiftLeft; // 30 max
+            public float FireLeft; // 20 max
+            public float TrueNorthLeft; // 10 max
+
+            public bool HasLunar => Nadi.HasFlag(Nadi.LUNAR);
+            public bool HasSolar => Nadi.HasFlag(Nadi.SOLAR);
+
+            public int BeastCount =>
+                BeastChakra.Count(
+                    x => x != Dalamud.Game.ClientState.JobGauge.Enums.BeastChakra.NONE
+                );
 
             // upgrade paths
-            public AID BestForbiddenChakra => Unlocked(AID.ForbiddenChakra) ? AID.ForbiddenChakra : AID.SteelPeak;
-            public AID BestEnlightenment => Unlocked(AID.Enlightenment) ? AID.Enlightenment : AID.HowlingFist;
-            public AID BestShadowOfTheDestroyer => Unlocked(AID.ShadowOfTheDestroyer) ? AID.ShadowOfTheDestroyer : AID.ArmOfTheDestroyer;
-            public AID BestRisingPhoenix => Unlocked(AID.RisingPhoenix) ? AID.RisingPhoenix : AID.FlintStrike;
-            public AID BestPhantomRush => Unlocked(AID.PhantomRush) ? AID.PhantomRush : AID.TornadoKick;
+            public AID BestForbiddenChakra =>
+                Unlocked(AID.ForbiddenChakra) ? AID.ForbiddenChakra : AID.SteelPeak;
+            public AID BestEnlightenment =>
+                Unlocked(AID.Enlightenment) ? AID.Enlightenment : AID.HowlingFist;
+            public AID BestShadowOfTheDestroyer =>
+                Unlocked(AID.ShadowOfTheDestroyer)
+                    ? AID.ShadowOfTheDestroyer
+                    : AID.ArmOfTheDestroyer;
+            public AID BestRisingPhoenix =>
+                Unlocked(AID.RisingPhoenix) ? AID.RisingPhoenix : AID.FlintStrike;
+            public AID BestPhantomRush =>
+                Unlocked(AID.PhantomRush) ? AID.PhantomRush : AID.TornadoKick;
 
-            public State(float[] cooldowns) : base(cooldowns) { }
+            public AID BestBlitz
+            {
+                get
+                {
+                    if (BeastCount != 3)
+                        return AID.MasterfulBlitz;
+
+                    if (HasLunar && HasSolar)
+                        return BestPhantomRush;
+
+                    var bc = BeastChakra;
+
+                    if (bc[0] == bc[1] && bc[1] == bc[2])
+                        return AID.ElixirField;
+                    if (bc[0] != bc[1] && bc[1] != bc[2] && bc[0] != bc[2])
+                        return BestRisingPhoenix;
+                    return AID.CelestialRevolution;
+                }
+            }
+
+            public State(float[] cooldowns)
+                : base(cooldowns) { }
 
             public bool Unlocked(AID aid) => Definitions.Unlocked(aid, Level, UnlockProgress);
+
             public bool Unlocked(TraitID tid) => Definitions.Unlocked(tid, Level, UnlockProgress);
 
             public override string ToString()
             {
-                return $"RB={RaidBuffsLeft:f1}, Chakra={Chakra}, Form={Form}/{FormLeft:f1}, DFist={DisciplinedFistLeft:f1}, LFist={LeadenFistLeft:f1}, PotCD={PotionCD:f1}, GCD={GCD:f3}, ALock={AnimationLock:f3}+{AnimationLockDelay:f3}, lvl={Level}/{UnlockProgress}";
+                return $"RB={RaidBuffsLeft:f1}, N={Nadi}, BC={BeastChakra}, Chakra={Chakra}, Form={Form}/{FormLeft:f1}, DFist={DisciplinedFistLeft:f1}, LFist={LeadenFistLeft:f1}, PotCD={PotionCD:f1}, GCD={GCD:f3}, ALock={AnimationLock:f3}+{AnimationLockDelay:f3}, lvl={Level}/{UnlockProgress}";
             }
         }
 
@@ -38,23 +91,79 @@
             public int NumPointBlankAOETargets; // range 5 around self
             public int NumEnlightenmentTargets; // range 10 width 2/4 rect
 
+            public enum NadiChoice : uint
+            {
+                Automatic = 0, // lunar -> solar
+
+                [PropertyDisplay("Lunar", 0xFFDB8BCA)]
+                Lunar = 1,
+
+                [PropertyDisplay("Solar", 0xFF8EE6FA)]
+                Solar = 2
+            }
+
+            public NadiChoice NextNadi;
+
+            public OffensiveAbilityUse FireUse;
+            public OffensiveAbilityUse WindUse;
+            public OffensiveAbilityUse BrotherhoodUse;
+            public OffensiveAbilityUse PerfectBalanceUse;
+            public OffensiveAbilityUse SSSUse;
+            public OffensiveAbilityUse TrueNorthUse;
+
             public override string ToString()
             {
                 return $"AOE={NumPointBlankAOETargets}/{NumEnlightenmentTargets}, no-dots={ForbidDOTs}";
+            }
+
+            public void ApplyStrategyOverrides(uint[] overrides)
+            {
+                if (overrides.Length >= 7)
+                {
+                    TrueNorthUse = (OffensiveAbilityUse)overrides[0];
+                    NextNadi = (NadiChoice)overrides[1];
+                    FireUse = (OffensiveAbilityUse)overrides[2];
+                    WindUse = (OffensiveAbilityUse)overrides[3];
+                    BrotherhoodUse = (OffensiveAbilityUse)overrides[4];
+                    PerfectBalanceUse = (OffensiveAbilityUse)overrides[5];
+                    SSSUse = (OffensiveAbilityUse)overrides[6];
+                }
+                else
+                {
+                    TrueNorthUse = OffensiveAbilityUse.Automatic;
+                    NextNadi = NadiChoice.Automatic;
+                    FireUse = OffensiveAbilityUse.Automatic;
+                    WindUse = OffensiveAbilityUse.Automatic;
+                    BrotherhoodUse = OffensiveAbilityUse.Automatic;
+                    PerfectBalanceUse = OffensiveAbilityUse.Automatic;
+                    SSSUse = OffensiveAbilityUse.Automatic;
+                }
             }
         }
 
         public static AID GetOpoOpoFormAction(State state, int numAOETargets)
         {
             // TODO: what should we use if form is not up?..
-            return state.Unlocked(AID.ArmOfTheDestroyer) && numAOETargets >= 3 ? state.BestShadowOfTheDestroyer : state.Unlocked(AID.DragonKick) && state.LeadenFistLeft <= state.GCD ? AID.DragonKick : AID.Bootshine;
+            if (state.Unlocked(AID.ArmOfTheDestroyer) && numAOETargets >= 3)
+                return state.BestShadowOfTheDestroyer;
+
+            if (state.Unlocked(AID.DragonKick) && state.LeadenFistLeft <= state.GCD)
+                return AID.DragonKick;
+
+            return AID.Bootshine;
         }
 
         public static AID GetRaptorFormAction(State state, int numAOETargets)
         {
             // TODO: low level - consider early restart...
             // TODO: better threshold for buff reapplication...
-            return state.Unlocked(AID.FourPointFury) && numAOETargets >= 3 ? AID.FourPointFury : state.Unlocked(AID.TwinSnakes) && state.DisciplinedFistLeft < state.GCD + 7 ? AID.TwinSnakes : AID.TrueStrike;
+            if (state.Unlocked(AID.FourPointFury) && numAOETargets >= 3)
+                return AID.FourPointFury;
+
+            if (state.Unlocked(AID.TwinSnakes) && state.DisciplinedFistLeft < state.GCD + 7)
+                return AID.TwinSnakes;
+
+            return AID.TrueStrike;
         }
 
         public static AID GetCoeurlFormAction(State state, int numAOETargets, bool forbidDOTs)
@@ -62,49 +171,270 @@
             // TODO: multidot support...
             // TODO: low level - consider early restart...
             // TODO: better threshold for debuff reapplication...
-            return state.Unlocked(AID.Rockbreaker) && numAOETargets >= 3 ? AID.Rockbreaker : !forbidDOTs && state.Unlocked(AID.Demolish) && state.TargetDemolishLeft < state.GCD + 3 ? AID.Demolish : AID.SnapPunch;
+            if (state.Unlocked(AID.Rockbreaker) && numAOETargets >= 3)
+                return AID.Rockbreaker;
+
+            if (
+                !forbidDOTs
+                && state.Unlocked(AID.Demolish)
+                && state.TargetDemolishLeft < state.GCD + 3
+            )
+                return AID.Demolish;
+
+            return AID.SnapPunch;
         }
 
-        public static AID GetNextComboAction(State state, int numAOETargets, bool forbidDOTs)
+        public static AID GetNextComboAction(
+            State state,
+            int numAOETargets,
+            bool forbidDOTs,
+            Strategy.NadiChoice nextNadi
+        )
         {
-            return state.Form switch
+            var form = GetEffectiveForm(state, nextNadi);
+            if (form == Form.Coeurl)
+                return GetCoeurlFormAction(state, numAOETargets, forbidDOTs);
+
+            if (form == Form.Raptor)
+                return GetRaptorFormAction(state, numAOETargets);
+
+            return GetOpoOpoFormAction(state, numAOETargets);
+        }
+
+        private static Form GetEffectiveForm(State state, Strategy.NadiChoice nextNadi)
+        {
+            if (SolarTime(state, nextNadi))
+                return state.BeastCount switch
+                {
+                    2 => Form.Coeurl,
+                    1 => Form.Raptor,
+                    _ => Form.OpoOpo
+                };
+
+            return state.Form;
+        }
+
+        private static bool SolarTime(State state, Strategy.NadiChoice nextNadi)
+        {
+            if (state.PerfectBalanceLeft <= state.GCD)
+                return false;
+            return nextNadi switch
             {
-                Form.Coeurl => GetCoeurlFormAction(state, numAOETargets, forbidDOTs),
-                Form.Raptor => GetRaptorFormAction(state, numAOETargets),
-                _ => GetOpoOpoFormAction(state, numAOETargets)
+                Strategy.NadiChoice.Automatic => state.HasLunar && !state.HasSolar,
+                Strategy.NadiChoice.Solar => true,
+                _ => false,
             };
         }
 
         public static AID GetNextBestGCD(State state, Strategy strategy)
         {
+            if (strategy.CombatTimer < 0)
+            {
+                if (state.Chakra < 5)
+                    return AID.Meditation;
+
+                if (
+                    strategy.CombatTimer > -20
+                    && state.FormShiftLeft == 0
+                    && state.Unlocked(AID.FormShift)
+                )
+                    return AID.FormShift;
+
+                return AID.None;
+            }
+
+            if (state.Unlocked(AID.SixSidedStar) && strategy.SSSUse == OffensiveAbilityUse.Force)
+                return AID.SixSidedStar;
+
+            if (state.BestBlitz != AID.MasterfulBlitz)
+                return state.BestBlitz;
+
+            if (
+                strategy.SSSUse == OffensiveAbilityUse.Automatic
+                && strategy.FightEndIn > state.GCD
+                && strategy.FightEndIn < state.GCD + 1.95
+                && state.Unlocked(AID.SixSidedStar)
+            )
+                return AID.SixSidedStar;
+
             // TODO: L52+
-            return GetNextComboAction(state, strategy.NumPointBlankAOETargets, strategy.ForbidDOTs);
+            return GetNextComboAction(
+                state,
+                strategy.NumPointBlankAOETargets,
+                strategy.ForbidDOTs,
+                strategy.NextNadi
+            );
+        }
+
+        public static (Positional, bool) GetNextPositional(State state, Strategy strategy)
+        {
+            if (strategy.NumPointBlankAOETargets >= 3)
+                return (Positional.Any, false);
+
+            var gcdsInAdvance = GetEffectiveForm(state, strategy.NextNadi) switch
+            {
+                Form.Coeurl => 0,
+                Form.Raptor => 1,
+                _ => 2
+            };
+            var willDemolish =
+                state.Unlocked(AID.Demolish)
+                && state.TargetDemolishLeft < state.GCD + 3 + (1.94 * gcdsInAdvance);
+
+            return (willDemolish ? Positional.Rear : Positional.Flank, gcdsInAdvance == 0);
         }
 
         public static ActionID GetNextBestOGCD(State state, Strategy strategy, float deadline)
         {
-            // TODO: perfect balance?.. no idea how it should be used at low level
-            // 1. potion: TODO
+            // TODO: potion
+
+            if (strategy.CombatTimer < 0 && strategy.CombatTimer > -100)
+            {
+                if (strategy.CombatTimer > -0.2 && state.RangeToTarget > 3)
+                    return ActionID.MakeSpell(AID.Thunderclap);
+
+                return new();
+            }
+
+            if (ShouldUseRoF(state, strategy, deadline))
+                return ActionID.MakeSpell(AID.RiddleOfFire);
+
+            if (ShouldUseBrotherhood(state, strategy, deadline))
+                return ActionID.MakeSpell(AID.Brotherhood);
+
+            if (ShouldUsePB(state, strategy, deadline))
+                return ActionID.MakeSpell(AID.PerfectBalance);
+
+            if (ShouldUseRoW(state, strategy, deadline))
+                return ActionID.MakeSpell(AID.RiddleOfWind);
 
             // 2. steel peek, if have chakra
-            if (state.Unlocked(AID.SteelPeak) && state.Chakra == 5 && state.CanWeave(CDGroup.SteelPeak, 0.6f, deadline))
+            if (
+                state.Unlocked(AID.SteelPeak)
+                && state.Chakra == 5
+                && state.CanWeave(CDGroup.SteelPeak, 0.6f, deadline)
+                // prevent early use in opener
+                && state.CD(CDGroup.RiddleOfFire) > 0
+            )
             {
                 // L15 Steel Peak is 180p
                 // L40 Howling Fist is 100p/target => HF at 2+ targets
                 // L54 Forbidden Chakra is 340p => HF at 4+ targets
                 // L72 Enlightenment is 170p/target => at 2+ targets
                 if (state.Unlocked(AID.Enlightenment))
-                    return ActionID.MakeSpell(strategy.NumEnlightenmentTargets >= 2 ? AID.Enlightenment : AID.ForbiddenChakra);
+                    return ActionID.MakeSpell(
+                        strategy.NumEnlightenmentTargets >= 2
+                            ? AID.Enlightenment
+                            : AID.ForbiddenChakra
+                    );
                 else if (state.Unlocked(AID.ForbiddenChakra))
-                    return ActionID.MakeSpell(strategy.NumEnlightenmentTargets >= 4 ? AID.HowlingFist : AID.ForbiddenChakra);
+                    return ActionID.MakeSpell(
+                        strategy.NumEnlightenmentTargets >= 4
+                            ? AID.HowlingFist
+                            : AID.ForbiddenChakra
+                    );
                 else if (state.Unlocked(AID.HowlingFist))
-                    return ActionID.MakeSpell(strategy.NumEnlightenmentTargets >= 2 ? AID.HowlingFist : AID.SteelPeak);
+                    return ActionID.MakeSpell(
+                        strategy.NumEnlightenmentTargets >= 2 ? AID.HowlingFist : AID.SteelPeak
+                    );
                 else
                     return ActionID.MakeSpell(AID.SteelPeak);
             }
 
+            if (
+                ShouldUseTrueNorth(state, strategy)
+                && state.CanWeave(state.CD(CDGroup.TrueNorth) - 45, 0.6f, deadline)
+                && state.GCD < 0.8
+            )
+                return ActionID.MakeSpell(AID.TrueNorth);
+
             // no suitable oGCDs...
             return new();
+        }
+
+        private static bool ShouldUseRoF(State state, Strategy strategy, float deadline)
+        {
+            if (
+                !state.Unlocked(AID.RiddleOfFire)
+                || strategy.FireUse == OffensiveAbilityUse.Delay
+                || !state.CanWeave(CDGroup.RiddleOfFire, 0.6f, deadline)
+            )
+                return false;
+
+            if (strategy.FireUse == OffensiveAbilityUse.Force)
+                return true;
+
+            if (state.GCD > 0.800)
+                return false;
+
+            if (strategy.CombatTimer < 30)
+                // use before demolish in opener
+                return state.Form == Form.Coeurl;
+            else
+                return state.Form == Form.OpoOpo;
+        }
+
+        private static bool ShouldUseRoW(State state, Strategy strategy, float deadline)
+        {
+            if (
+                !state.Unlocked(AID.RiddleOfWind)
+                || strategy.WindUse == OffensiveAbilityUse.Delay
+                || !state.CanWeave(CDGroup.RiddleOfWind, 0.6f, deadline)
+            )
+                return false;
+
+            if (strategy.WindUse == OffensiveAbilityUse.Force)
+                return true;
+
+            // thebalance recommends using RoW as an oGCD dot, so we use on cooldown as long as RoF has been used first
+            return state.CD(CDGroup.RiddleOfFire) > 0;
+        }
+
+        private static bool ShouldUseBrotherhood(State state, Strategy strategy, float deadline)
+        {
+            if (
+                !state.Unlocked(AID.Brotherhood)
+                || strategy.BrotherhoodUse == OffensiveAbilityUse.Delay
+                || !state.CanWeave(CDGroup.Brotherhood, 0.6f, deadline)
+            )
+                return false;
+
+            if (strategy.BrotherhoodUse == OffensiveAbilityUse.Force)
+                return true;
+
+            return strategy.NumPointBlankAOETargets == 0
+                && state.FireLeft > state.GCD
+                && state.LeadenFistLeft == 0;
+        }
+
+        private static bool ShouldUsePB(State state, Strategy strategy, float deadline)
+        {
+            if (
+                state.PerfectBalanceLeft > 0
+                || !state.Unlocked(AID.PerfectBalance)
+                || !state.CanWeave(state.CD(CDGroup.PerfectBalance) - 40, 0.6f, deadline)
+                || strategy.PerfectBalanceUse == OffensiveAbilityUse.Delay
+            )
+                return false;
+
+            if (strategy.PerfectBalanceUse == OffensiveAbilityUse.Force)
+                return true;
+
+            return (state.FireLeft > state.GCD || !state.Unlocked(AID.RiddleOfFire))
+                && state.LeadenFistLeft == 0;
+        }
+
+        private static bool ShouldUseTrueNorth(State state, Strategy strategy)
+        {
+            if (
+                strategy.TrueNorthUse == OffensiveAbilityUse.Delay
+                || state.TrueNorthLeft > state.AnimationLock
+            )
+                return false;
+            if (strategy.TrueNorthUse == OffensiveAbilityUse.Force)
+                return true;
+
+            return strategy.NextPositionalImminent && !strategy.NextPositionalCorrect;
         }
     }
 }

--- a/BossMod/Autorotation/MNK/MNKRotation.cs
+++ b/BossMod/Autorotation/MNK/MNKRotation.cs
@@ -248,7 +248,12 @@ namespace BossMod.MNK
             }
 
             if (!state.TargetingEnemy)
+            {
+                if (state.Chakra < 5 && state.Unlocked(AID.Meditation))
+                    return AID.Meditation;
+
                 return AID.None;
+            }
 
             if (state.Unlocked(AID.SixSidedStar) && strategy.SSSUse == OffensiveAbilityUse.Force)
                 return AID.SixSidedStar;

--- a/BossMod/Autorotation/MNK/MNKRotation.cs
+++ b/BossMod/Autorotation/MNK/MNKRotation.cs
@@ -417,7 +417,11 @@ namespace BossMod.MNK
                 return true;
 
             // someone early pulled
-            if (strategy.DashUse == Strategy.DashStrategy.Automatic && strategy.CombatTimer < 3)
+            if (
+                strategy.DashUse == Strategy.DashStrategy.Automatic
+                && strategy.CombatTimer > 0
+                && strategy.CombatTimer < 3
+            )
                 return true;
 
             return false;

--- a/BossMod/CooldownPlanner/PlanDefinitions.cs
+++ b/BossMod/CooldownPlanner/PlanDefinitions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace BossMod
@@ -132,6 +132,20 @@ namespace BossMod
         private static ClassData DefineMNK()
         {
             var c = new ClassData(typeof(MNK.AID), MNK.Definitions.SupportedActions);
+            c.CooldownTracks.Add(new("Feint", ActionID.MakeSpell(MNK.AID.Feint), 22));
+            c.CooldownTracks.Add(new("ArmsL", ActionID.MakeSpell(MNK.AID.ArmsLength), 32));
+            c.CooldownTracks.Add(new("RoE", ActionID.MakeSpell(MNK.AID.RiddleOfEarth), 64));
+            c.CooldownTracks.Add(new("Mantra", ActionID.MakeSpell(MNK.AID.Mantra), 42));
+            c.CooldownTracks.Add(new("Dash", ActionID.MakeSpell(MNK.AID.Thunderclap), 35));
+            c.StrategyTracks.Add(new("TrueN", typeof(CommonRotation.Strategy.OffensiveAbilityUse)));
+            c.StrategyTracks.Add(new("Nadi", typeof(MNK.Rotation.Strategy.NadiChoice)));
+            c.StrategyTracks.Add(new("RoF", typeof(CommonRotation.Strategy.OffensiveAbilityUse)));
+            c.StrategyTracks.Add(new("RoW", typeof(CommonRotation.Strategy.OffensiveAbilityUse)));
+            c.StrategyTracks.Add(new("BHood", typeof(CommonRotation.Strategy.OffensiveAbilityUse)));
+            c.StrategyTracks.Add(
+                new("PerfBal", typeof(CommonRotation.Strategy.OffensiveAbilityUse))
+            );
+            c.StrategyTracks.Add(new("SSS", typeof(CommonRotation.Strategy.OffensiveAbilityUse)));
             return c;
         }
 

--- a/BossMod/CooldownPlanner/PlanDefinitions.cs
+++ b/BossMod/CooldownPlanner/PlanDefinitions.cs
@@ -139,7 +139,7 @@ namespace BossMod
             c.StrategyTracks.Add(new("Dash", typeof(MNK.Rotation.Strategy.DashStrategy)));
             c.StrategyTracks.Add(new("TrueN", typeof(CommonRotation.Strategy.OffensiveAbilityUse)));
             c.StrategyTracks.Add(new("Nadi", typeof(MNK.Rotation.Strategy.NadiChoice)));
-            c.StrategyTracks.Add(new("RoF", typeof(CommonRotation.Strategy.OffensiveAbilityUse)));
+            c.StrategyTracks.Add(new("RoF", typeof(MNK.Rotation.Strategy.FireStrategy)));
             c.StrategyTracks.Add(new("RoW", typeof(CommonRotation.Strategy.OffensiveAbilityUse)));
             c.StrategyTracks.Add(new("BHood", typeof(CommonRotation.Strategy.OffensiveAbilityUse)));
             c.StrategyTracks.Add(

--- a/BossMod/CooldownPlanner/PlanDefinitions.cs
+++ b/BossMod/CooldownPlanner/PlanDefinitions.cs
@@ -136,7 +136,7 @@ namespace BossMod
             c.CooldownTracks.Add(new("ArmsL", ActionID.MakeSpell(MNK.AID.ArmsLength), 32));
             c.CooldownTracks.Add(new("RoE", ActionID.MakeSpell(MNK.AID.RiddleOfEarth), 64));
             c.CooldownTracks.Add(new("Mantra", ActionID.MakeSpell(MNK.AID.Mantra), 42));
-            c.CooldownTracks.Add(new("Dash", ActionID.MakeSpell(MNK.AID.Thunderclap), 35));
+            c.StrategyTracks.Add(new("Dash", typeof(MNK.Rotation.Strategy.DashStrategy)));
             c.StrategyTracks.Add(new("TrueN", typeof(CommonRotation.Strategy.OffensiveAbilityUse)));
             c.StrategyTracks.Add(new("Nadi", typeof(MNK.Rotation.Strategy.NadiChoice)));
             c.StrategyTracks.Add(new("RoF", typeof(CommonRotation.Strategy.OffensiveAbilityUse)));


### PR DESCRIPTION
tested on normal and savage athena. also added positionals prediction, auto true north, and planner tracks.

this performs the TheBalance "braindead" rotation using the standard Lunar Solar opener and PR on odd minutes during Riddle of Fire. Optimal Drift is superior, especially for fights with downtime, but obviously a lot more complex to implement and will require testing and a followup PR when I get it working.