### PR TITLE
Fix mode toggle spam when combining AI + sticky auto actions

### DIFF
--- a/BossMod/AI/AIBehaviour.cs
+++ b/BossMod/AI/AIBehaviour.cs
@@ -62,7 +62,7 @@ namespace BossMod.AI
             if (!forbidActions)
             {
                 int actionStrategy = target.Target != null ? CommonActions.AutoActionAIFight : CommonActions.AutoActionAIIdle;
-                _autorot.ClassActions?.UpdateAutoAction(actionStrategy, _maxCastTime);
+                _autorot.ClassActions?.UpdateAutoAction(actionStrategy, _maxCastTime, false);
             }
 
             UpdateMovement(player, master, target, !forbidActions);

--- a/BossMod/Autorotation/CommonActions.cs
+++ b/BossMod/Autorotation/CommonActions.cs
@@ -191,15 +191,17 @@ namespace BossMod
             };
         }
 
-        public void UpdateAutoAction(int autoAction, float maxCastTime)
+        public void UpdateAutoAction(int autoAction, float maxCastTime, bool isUserRequested)
         {
+            var sticky = Autorot.Config.StickyAutoActions && isUserRequested;
+
             if (AutoAction != autoAction)
             {
                 Log($"Auto action set to {autoAction}");
                 AutoAction = autoAction;
-                _autoActionExpire = Autorot.Config.StickyAutoActions ? DateTime.MaxValue : Autorot.WorldState.CurrentTime.AddSeconds(1.0f);
+                _autoActionExpire = sticky ? DateTime.MaxValue : Autorot.WorldState.CurrentTime.AddSeconds(1.0f);
             }
-            else if (Autorot.Config.StickyAutoActions)
+            else if (sticky)
             {
                 Log($"Turning off auto action {autoAction}");
                 AutoAction = AutoActionNone;
@@ -229,7 +231,7 @@ namespace BossMod
 
             if (supportedAction.PlaceholderForAuto != AutoActionNone)
             {
-                UpdateAutoAction(supportedAction.PlaceholderForAuto, float.MaxValue);
+                UpdateAutoAction(supportedAction.PlaceholderForAuto, float.MaxValue, true);
                 return true;
             }
 


### PR DESCRIPTION
AI mode sets the current auto mode every frame, but this doesn't play nicely with sticky auto actions