### PR TITLE
"""Better""" GCD time calculation

### DIFF
--- a/BossMod/Autorotation/CommonActions.cs
+++ b/BossMod/Autorotation/CommonActions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using FFXIVGame = FFXIVClientStructs.FFXIV.Client.Game;
 
 namespace BossMod
 {
@@ -367,6 +368,12 @@ namespace BossMod
             s.AnimationLockDelay = am.EffectiveAnimationLockDelay;
             s.ComboTimeLeft = am.ComboTimeLeft;
             s.ComboLastAction = am.ComboLastMove;
+
+            // all GCD skills share the same base recast time (with some exceptions that aren't relevant here)
+            // so we can check Fast Blade (9) and Stone (119) recast timers to get effective sks and sps
+            // regardless of current class
+            s.AttackGCDTime = FFXIVGame.ActionManager.GetAdjustedRecastTime(FFXIVGame.ActionType.Action, 9) / 1000f;
+            s.SpellGCDTime = FFXIVGame.ActionManager.GetAdjustedRecastTime(FFXIVGame.ActionType.Action, 119) / 1000f;
 
             s.RaidBuffsLeft = vuln.Item1 ? vuln.Item2 : 0;
             foreach (var status in Player.Statuses.Where(s => IsDamageBuff(s.ID)))

--- a/BossMod/Autorotation/CommonRotation.cs
+++ b/BossMod/Autorotation/CommonRotation.cs
@@ -30,6 +30,10 @@ namespace BossMod
             public float PotionCD => Cooldowns[CommonDefinitions.PotionCDGroup]; // variable max
             public float CD<CDGroup>(CDGroup group) where CDGroup : Enum => Cooldowns[(int)(object)group];
 
+            // both 2.5 max (unless slowed), reduced by gear attributes and certain status effects
+            public float AttackGCDTime;
+            public float SpellGCDTime;
+
             // check whether weaving typical ogcd off cooldown would end its animation lock by the specified deadline
             public float OGCDSlotLength => 0.6f + AnimationLockDelay; // most actions have 0.6 anim lock delay, which allows double-weaving oGCDs between GCDs
             public bool CanWeave(float deadline) => AnimationLock + OGCDSlotLength <= deadline; // is it still possible to weave typical oGCD without missing deadline?

--- a/BossMod/Autorotation/SAM/SAMActions.cs
+++ b/BossMod/Autorotation/SAM/SAMActions.cs
@@ -149,7 +149,7 @@ namespace BossMod.SAM
                     ? float.MaxValue
                     : StatusDetails(Autorot.PrimaryTarget, SID.Higanbana, Player.InstanceID).Left;
 
-            _state.GCDTime = ActionManagerEx.Instance!.GCDTime();
+            _state.GCDTime = _state.AttackGCDTime;
             _state.LastTsubame =
                 _lastTsubame == default
                     ? float.MaxValue

--- a/BossMod/Autorotation/SAM/SAMRotation.cs
+++ b/BossMod/Autorotation/SAM/SAMRotation.cs
@@ -1,7 +1,5 @@
 // CONTRIB: made by xan, not checked
-using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using Dalamud.Game.ClientState.JobGauge.Enums;
 using static BossMod.CommonRotation.Strategy;
 using static BossMod.SAM.Rotation.Strategy;

--- a/BossMod/Framework/ActionManagerEx.cs
+++ b/BossMod/Framework/ActionManagerEx.cs
@@ -210,13 +210,6 @@ namespace BossMod
             return gcd->Total - gcd->Elapsed;
         }
 
-        // TODO: calculate gcd duration properly, current implementation would return 0 during downtime
-        public float GCDTime()
-        {
-            var gcd = _inst->GetRecastGroupDetail(CommonDefinitions.GCDGroup);
-            return gcd->Total;
-        }
-
         public uint GetAdjustedActionID(uint actionID) => _inst->GetAdjustedActionId(actionID);
 
         public uint GetActionStatus(ActionID action, ulong target, bool checkRecastActive = true, bool checkCastingActive = true, uint* outOptExtraInfo = null)


### PR DESCRIPTION
Ideally I would like to replace this with whatever actionmanager actually does when it looks at the recast timer for a specific skill but this works in the meantime.