### PR TITLE
MNK rotation fixes

### DIFF
--- a/BossMod/Autorotation/MNK/MNKActions.cs
+++ b/BossMod/Autorotation/MNK/MNKActions.cs
@@ -1,4 +1,4 @@
-using Dalamud.Game.ClientState.JobGauge.Types;
+﻿using Dalamud.Game.ClientState.JobGauge.Types;
 using System;
 
 namespace BossMod.MNK
@@ -41,7 +41,7 @@ namespace BossMod.MNK
         public override Targeting SelectBetterTarget(AIHints.Enemy initial)
         {
             // TODO: multidotting support...
-            var pos = (_state.Form == Rotation.Form.Coeurl ? Rotation.GetCoeurlFormAction(_state, _strategy.NumPointBlankAOETargets, _strategy.ForbidDOTs) : AID.None) switch
+            var pos = (_state.Form == Rotation.Form.Coeurl ? Rotation.GetCoeurlFormAction(_state, _strategy) : AID.None) switch
             {
                 AID.SnapPunch => Positional.Flank,
                 AID.Demolish => Positional.Rear,
@@ -132,7 +132,7 @@ namespace BossMod.MNK
             SupportedSpell(AID.ArmOfTheDestroyer).PlaceholderForAuto = _config.FullRotation ? AutoActionAOE : AutoActionNone;
 
             // combo replacement
-            SupportedSpell(AID.FourPointFury).TransformAction = _config.AOECombos ? () => ActionID.MakeSpell(Rotation.GetNextComboAction(_state, 100, false, Rotation.Strategy.NadiChoice.Automatic)) : null;
+            SupportedSpell(AID.FourPointFury).TransformAction = _config.AOECombos ? () => ActionID.MakeSpell(Rotation.GetNextComboAction(_state, _strategy)) : null;
 
             SupportedSpell(AID.Thunderclap).Condition = _config.PreventCloseDash
                 ? ((act) => act == null || !act.Position.InCircle(Player.Position, 3))

--- a/BossMod/Autorotation/MNK/MNKRotation.cs
+++ b/BossMod/Autorotation/MNK/MNKRotation.cs
@@ -488,15 +488,16 @@ namespace BossMod.MNK
 
             var haveRof = state.FireLeft > state.GCD || !state.Unlocked(AID.RiddleOfFire);
 
-            // opener. this will end up being skipped for fights with a non burst pre-phase like stygimoloch lord, in which case we treat first brotherhood like any other even window
+            // opener. this will end up being skipped for fights with a non burst pre-phase like
+            // stygimoloch lord, in which case we treat first brotherhood like any other even window
             if (strategy.CombatTimer < 30)
             {
-                if (haveRof && state.LeadenFistLeft == 0)
-                    return true;
+                return haveRof && state.LeadenFistLeft == 0;
             }
             else
             {
-                // odd windows
+                // level 68+: odd windows
+                // below 68: whenever it's on cooldown
                 if (haveRof && state.LeadenFistLeft == 0 && state.TargetDemolishLeft > 12)
                     return true;
 

--- a/BossMod/Autorotation/MNK/MNKRotation.cs
+++ b/BossMod/Autorotation/MNK/MNKRotation.cs
@@ -233,10 +233,7 @@ namespace BossMod.MNK
 
             return strategy.NextNadi switch
             {
-                Strategy.NadiChoice.Automatic
-                    => strategy.CombatTimer < 30
-                        ? state.HasLunar && !state.HasSolar
-                        : !(state.HasLunar || state.HasSolar),
+                Strategy.NadiChoice.Automatic => !state.HasSolar && (strategy.CombatTimer < 30 ? state.HasLunar : !state.HasLunar),
                 Strategy.NadiChoice.Solar => true,
                 _ => false,
             };


### PR DESCRIPTION
i skipped over one part of the balance guide's explanation of the braindead looping rotation, and as a result the current version of the MNK rotation is offset from the correct version by one GCD, which causes you to miss out on brotherhood's 5% damage buff for the first Rising Phoenix in your even buff window. this isn't a huge deal but it is suboptimal.

this PR also fixes a mostly cosmetic issue with the positionals predictor. it wouldn't affect True North usage since the positional is only wrong for a brief period during GCD animation lock when you can't use True North anyway, but it is really annoying