### PR TITLE
Dancer rotation optimization

### DIFF
--- a/BossMod/Autorotation/DNC/DNCActions.cs
+++ b/BossMod/Autorotation/DNC/DNCActions.cs
@@ -133,6 +133,7 @@ namespace BossMod.DNC
         private void UpdatePlayerState()
         {
             FillCommonPlayerState(_state);
+            _state.AnimationLockDelay = MathF.Max(0.1f, _state.AnimationLockDelay);
 
             var gauge = Service.JobGauges.Get<DNCGauge>();
 

--- a/BossMod/Autorotation/DNC/DNCActions.cs
+++ b/BossMod/Autorotation/DNC/DNCActions.cs
@@ -21,12 +21,9 @@ namespace BossMod.DNC
             _state = new(autorot.Cooldowns);
             _strategy = new();
 
-            SupportedSpell(AID.StandardStep).TransformAction = () =>
-                ActionID.MakeSpell(_state.BestStandardStep);
-            SupportedSpell(AID.TechnicalStep).TransformAction = () =>
-                ActionID.MakeSpell(_state.BestTechStep);
-            SupportedSpell(AID.Improvisation).TransformAction = () =>
-                ActionID.MakeSpell(_state.BestImprov);
+            SupportedSpell(AID.StandardStep).TransformAction = () => ActionID.MakeSpell(_state.BestStandardStep);
+            SupportedSpell(AID.TechnicalStep).TransformAction = () => ActionID.MakeSpell(_state.BestTechStep);
+            SupportedSpell(AID.Improvisation).TransformAction = () => ActionID.MakeSpell(_state.BestImprov);
 
             _config.Modified += OnConfigModified;
             OnConfigModified(null, EventArgs.Empty);
@@ -86,18 +83,39 @@ namespace BossMod.DNC
         {
             if (_state.Unlocked(AID.HeadGraze))
             {
-                var interruptibleEnemy = Autorot.Hints.PotentialTargets.Find(e => e.ShouldBeInterrupted && (e.Actor.CastInfo?.Interruptible ?? false) && e.Actor.Position.InCircle(Player.Position, 25 + e.Actor.HitboxRadius + Player.HitboxRadius));
-                SimulateManualActionForAI(ActionID.MakeSpell(AID.HeadGraze), interruptibleEnemy?.Actor, interruptibleEnemy != null);
+                var interruptibleEnemy = Autorot.Hints.PotentialTargets.Find(
+                    e =>
+                        e.ShouldBeInterrupted
+                        && (e.Actor.CastInfo?.Interruptible ?? false)
+                        && e.Actor.Position.InCircle(Player.Position, 25 + e.Actor.HitboxRadius + Player.HitboxRadius)
+                );
+                SimulateManualActionForAI(
+                    ActionID.MakeSpell(AID.HeadGraze),
+                    interruptibleEnemy?.Actor,
+                    interruptibleEnemy != null
+                );
             }
             if (_state.Unlocked(AID.Peloton))
-                SimulateManualActionForAI(ActionID.MakeSpell(AID.Peloton), Player, !Player.InCombat && _state.PelotonLeft < 3 && _strategy.ForceMovementIn == 0);
+                SimulateManualActionForAI(
+                    ActionID.MakeSpell(AID.Peloton),
+                    Player,
+                    !Player.InCombat && _state.PelotonLeft < 3 && _strategy.ForceMovementIn == 0
+                );
             if (_state.Unlocked(AID.CuringWaltz))
             {
-                SimulateManualActionForAI(ActionID.MakeSpell(AID.CuringWaltz), Player, Player.InCombat && Player.HP.Cur < Player.HP.Max * 0.75f);
+                SimulateManualActionForAI(
+                    ActionID.MakeSpell(AID.CuringWaltz),
+                    Player,
+                    Player.InCombat && Player.HP.Cur < Player.HP.Max * 0.75f
+                );
             }
             if (_state.Unlocked(AID.SecondWind))
             {
-                SimulateManualActionForAI(ActionID.MakeSpell(AID.SecondWind), Player, Player.InCombat && Player.HP.Cur < Player.HP.Max * 0.5f);
+                SimulateManualActionForAI(
+                    ActionID.MakeSpell(AID.SecondWind),
+                    Player,
+                    Player.InCombat && Player.HP.Cur < Player.HP.Max * 0.5f
+                );
             }
         }
 
@@ -114,7 +132,11 @@ namespace BossMod.DNC
             _strategy.NumFan4Targets = primaryTarget == null ? 0 : NumFan4Targets(primaryTarget);
             _strategy.NumStarfallTargets = primaryTarget == null ? 0 : NumStarfallTargets(primaryTarget);
 
-            _strategy.ApplyStrategyOverrides(Autorot.Bossmods.ActiveModule?.PlanExecution?.ActiveStrategyOverrides(Autorot.Bossmods.ActiveModule.StateMachine) ?? new uint[0]);
+            _strategy.ApplyStrategyOverrides(
+                Autorot
+                    .Bossmods.ActiveModule?.PlanExecution
+                    ?.ActiveStrategyOverrides(Autorot.Bossmods.ActiveModule.StateMachine) ?? new uint[0]
+            );
         }
 
         public override Targeting SelectBetterTarget(AIHints.Enemy initial)
@@ -163,11 +185,7 @@ namespace BossMod.DNC
                 _state.PelotonLeft = 0;
         }
 
-        private Targeting SelectBestTarget(
-            AIHints.Enemy initial,
-            float maxDistanceFromPlayer,
-            Func<Actor, int> prio
-        )
+        private Targeting SelectBestTarget(AIHints.Enemy initial, float maxDistanceFromPlayer, Func<Actor, int> prio)
         {
             var newBest = FindBetterTargetBy(initial, maxDistanceFromPlayer, (x) => prio(x.Actor)).Target;
             return new(newBest, newBest.StayAtLongRange ? 25 : 15);
@@ -177,23 +195,27 @@ namespace BossMod.DNC
         {
             actor = null;
 
-            var target = Autorot.WorldState.Party.WithoutSlot().Exclude(Player).MaxBy(p =>
-                p.Class switch
-                {
-                    Class.SAM => 100,
-                    Class.NIN => 99,
-                    Class.MNK => 88,
-                    Class.RPR => 87,
-                    Class.DRG => 86,
-                    Class.BLM => 79,
-                    Class.SMN => 78,
-                    Class.RDM => 77,
-                    Class.MCH => 69,
-                    Class.BRD => 68,
-                    Class.DNC => 67,
-                    _ => 1
-                }
-            );
+            var target = Autorot
+                .WorldState.Party.WithoutSlot()
+                .Exclude(Player)
+                .MaxBy(
+                    p =>
+                        p.Class switch
+                        {
+                            Class.SAM => 100,
+                            Class.NIN => 99,
+                            Class.MNK => 88,
+                            Class.RPR => 87,
+                            Class.DRG => 86,
+                            Class.BLM => 79,
+                            Class.SMN => 78,
+                            Class.RDM => 77,
+                            Class.MCH => 69,
+                            Class.BRD => 68,
+                            Class.DNC => 67,
+                            _ => 1
+                        }
+                );
             if (target != null)
             {
                 actor = target;
@@ -203,16 +225,24 @@ namespace BossMod.DNC
             return false;
         }
 
-        private float StatusLeft(SID status) =>
-            StatusDetails(Player, status, Player.InstanceID).Left;
+        private float StatusLeft(SID status) => StatusDetails(Player, status, Player.InstanceID).Left;
 
-        private int NumAOETargets(Actor origin) =>
-            Autorot.Hints.NumPriorityTargetsInAOECircle(origin.Position, 5);
+        private int NumAOETargets(Actor origin) => Autorot.Hints.NumPriorityTargetsInAOECircle(origin.Position, 5);
 
         private int NumFan4Targets(Actor primary) =>
-            Autorot.Hints.NumPriorityTargetsInAOECone(Player.Position, 15, (primary.Position - Player.Position).Normalized(), 60.Degrees());
+            Autorot.Hints.NumPriorityTargetsInAOECone(
+                Player.Position,
+                15,
+                (primary.Position - Player.Position).Normalized(),
+                60.Degrees()
+            );
 
         private int NumStarfallTargets(Actor primary) =>
-            Autorot.Hints.NumPriorityTargetsInAOERect(Player.Position, (primary.Position - Player.Position).Normalized(), 25, 4);
+            Autorot.Hints.NumPriorityTargetsInAOERect(
+                Player.Position,
+                (primary.Position - Player.Position).Normalized(),
+                25,
+                4
+            );
     }
 }

--- a/BossMod/Autorotation/DNC/DNCActions.cs
+++ b/BossMod/Autorotation/DNC/DNCActions.cs
@@ -169,26 +169,7 @@ namespace BossMod.DNC
             Func<Actor, int> prio
         )
         {
-            var newBest = initial;
-            int currentPrio = prio(initial.Actor);
-            foreach (
-                var enemy in Autorot
-                    .Hints
-                    .PriorityTargets
-                    .Where(
-                        x =>
-                            x != initial
-                            && x.Actor.Position.InCircle(Player.Position, maxDistanceFromPlayer)
-                    )
-            )
-            {
-                int potential = prio(enemy.Actor);
-                if (potential > currentPrio)
-                {
-                    newBest = enemy;
-                    currentPrio = potential;
-                }
-            }
+            var newBest = FindBetterTargetBy(initial, maxDistanceFromPlayer, (x) => prio(x.Actor)).Target;
             return new(newBest, newBest.StayAtLongRange ? 25 : 15);
         }
 

--- a/BossMod/Autorotation/DNC/DNCActions.cs
+++ b/BossMod/Autorotation/DNC/DNCActions.cs
@@ -43,12 +43,8 @@ namespace BossMod.DNC
 
         private void OnConfigModified(object? sender, EventArgs args)
         {
-            SupportedSpell(AID.Cascade).PlaceholderForAuto = _config.FullRotation
-                ? AutoActionST
-                : AutoActionNone;
-            SupportedSpell(AID.Windmill).PlaceholderForAuto = _config.FullRotation
-                ? AutoActionAOE
-                : AutoActionNone;
+            SupportedSpell(AID.Cascade).PlaceholderForAuto = _config.FullRotation ? AutoActionST : AutoActionNone;
+            SupportedSpell(AID.Windmill).PlaceholderForAuto = _config.FullRotation ? AutoActionAOE : AutoActionNone;
 
             _strategy.PauseDuringImprov = _config.PauseDuringImprov;
             _strategy.AutoPartner = _config.AutoPartner;
@@ -90,47 +86,18 @@ namespace BossMod.DNC
         {
             if (_state.Unlocked(AID.HeadGraze))
             {
-                var interruptibleEnemy = Autorot
-                    .Hints
-                    .PotentialTargets
-                    .Find(
-                        e =>
-                            e.ShouldBeInterrupted
-                            && (e.Actor.CastInfo?.Interruptible ?? false)
-                            && e.Actor
-                                .Position
-                                .InCircle(
-                                    Player.Position,
-                                    25 + e.Actor.HitboxRadius + Player.HitboxRadius
-                                )
-                    );
-                SimulateManualActionForAI(
-                    ActionID.MakeSpell(AID.HeadGraze),
-                    interruptibleEnemy?.Actor,
-                    interruptibleEnemy != null
-                );
+                var interruptibleEnemy = Autorot.Hints.PotentialTargets.Find(e => e.ShouldBeInterrupted && (e.Actor.CastInfo?.Interruptible ?? false) && e.Actor.Position.InCircle(Player.Position, 25 + e.Actor.HitboxRadius + Player.HitboxRadius));
+                SimulateManualActionForAI(ActionID.MakeSpell(AID.HeadGraze), interruptibleEnemy?.Actor, interruptibleEnemy != null);
             }
             if (_state.Unlocked(AID.Peloton))
-                SimulateManualActionForAI(
-                    ActionID.MakeSpell(AID.Peloton),
-                    Player,
-                    !Player.InCombat && _state.PelotonLeft < 3 && _strategy.ForceMovementIn == 0
-                );
+                SimulateManualActionForAI(ActionID.MakeSpell(AID.Peloton), Player, !Player.InCombat && _state.PelotonLeft < 3 && _strategy.ForceMovementIn == 0);
             if (_state.Unlocked(AID.CuringWaltz))
             {
-                SimulateManualActionForAI(
-                    ActionID.MakeSpell(AID.CuringWaltz),
-                    Player,
-                    Player.InCombat && Player.HP.Cur < Player.HP.Max * 0.75f
-                );
+                SimulateManualActionForAI(ActionID.MakeSpell(AID.CuringWaltz), Player, Player.InCombat && Player.HP.Cur < Player.HP.Max * 0.75f);
             }
             if (_state.Unlocked(AID.SecondWind))
             {
-                SimulateManualActionForAI(
-                    ActionID.MakeSpell(AID.SecondWind),
-                    Player,
-                    Player.InCombat && Player.HP.Cur < Player.HP.Max * 0.5f
-                );
+                SimulateManualActionForAI(ActionID.MakeSpell(AID.SecondWind), Player, Player.InCombat && Player.HP.Cur < Player.HP.Max * 0.5f);
             }
         }
 
@@ -141,24 +108,13 @@ namespace BossMod.DNC
 
             var primaryTarget = Autorot.PrimaryTarget;
 
-            _strategy.NumDanceTargets = Autorot
-                .Hints
-                .NumPriorityTargetsInAOECircle(Player.Position, 15);
+            _strategy.NumDanceTargets = Autorot.Hints.NumPriorityTargetsInAOECircle(Player.Position, 15);
             _strategy.NumAOETargets = autoAction == AutoActionST ? 0 : NumAOETargets(Player);
-            _strategy.NumRangedAOETargets =
-                primaryTarget == null ? 0 : NumAOETargets(primaryTarget);
+            _strategy.NumRangedAOETargets = primaryTarget == null ? 0 : NumAOETargets(primaryTarget);
             _strategy.NumFan4Targets = primaryTarget == null ? 0 : NumFan4Targets(primaryTarget);
-            _strategy.NumStarfallTargets =
-                primaryTarget == null ? 0 : NumStarfallTargets(primaryTarget);
+            _strategy.NumStarfallTargets = primaryTarget == null ? 0 : NumStarfallTargets(primaryTarget);
 
-            _strategy.ApplyStrategyOverrides(
-                Autorot
-                    .Bossmods
-                    .ActiveModule
-                    ?.PlanExecution
-                    ?.ActiveStrategyOverrides(Autorot.Bossmods.ActiveModule.StateMachine)
-                    ?? new uint[0]
-            );
+            _strategy.ApplyStrategyOverrides(Autorot.Bossmods.ActiveModule?.PlanExecution?.ActiveStrategyOverrides(Autorot.Bossmods.ActiveModule.StateMachine) ?? new uint[0]);
         }
 
         public override Targeting SelectBetterTarget(AIHints.Enemy initial)
@@ -183,8 +139,7 @@ namespace BossMod.DNC
             _state.Feathers = gauge.Feathers;
             _state.IsDancing = gauge.IsDancing;
             _state.CompletedSteps = gauge.CompletedSteps;
-            _state.NextStep =
-                (gauge.CompletedSteps == 4 || gauge.NextStep == 15998) ? 0 : gauge.NextStep;
+            _state.NextStep = (gauge.CompletedSteps == 4 || gauge.NextStep == 15998) ? 0 : gauge.NextStep;
             _state.Esprit = gauge.Esprit;
 
             _state.StandardStepLeft = StatusLeft(SID.StandardStep);
@@ -195,14 +150,8 @@ namespace BossMod.DNC
             _state.ImprovisationLeft = StatusLeft(SID.Improvisation);
             _state.ImprovisedFinishLeft = StatusLeft(SID.ImprovisedFinish);
             _state.DevilmentLeft = StatusLeft(SID.Devilment);
-            _state.SymmetryLeft = MathF.Max(
-                StatusLeft(SID.SilkenSymmetry),
-                StatusLeft(SID.FlourishingSymmetry)
-            );
-            _state.FlowLeft = MathF.Max(
-                StatusLeft(SID.SilkenFlow),
-                StatusLeft(SID.FlourishingFlow)
-            );
+            _state.SymmetryLeft = MathF.Max(StatusLeft(SID.SilkenSymmetry), StatusLeft(SID.FlourishingSymmetry));
+            _state.FlowLeft = MathF.Max(StatusLeft(SID.SilkenFlow), StatusLeft(SID.FlourishingFlow));
             _state.FlourishingStarfallLeft = StatusLeft(SID.FlourishingStarfall);
             _state.ThreefoldLeft = StatusLeft(SID.ThreefoldFanDance);
             _state.FourfoldLeft = StatusLeft(SID.FourfoldFanDance);
@@ -246,29 +195,23 @@ namespace BossMod.DNC
         {
             actor = null;
 
-            var target = Autorot
-                .WorldState
-                .Party
-                .WithoutSlot()
-                .Exclude(Player)
-                .MaxBy(
-                    p =>
-                        p.Class switch
-                        {
-                            Class.SAM => 100,
-                            Class.NIN => 99,
-                            Class.MNK => 88,
-                            Class.RPR => 87,
-                            Class.DRG => 86,
-                            Class.BLM => 79,
-                            Class.SMN => 78,
-                            Class.RDM => 77,
-                            Class.MCH => 69,
-                            Class.BRD => 68,
-                            Class.DNC => 67,
-                            _ => 1
-                        }
-                );
+            var target = Autorot.WorldState.Party.WithoutSlot().Exclude(Player).MaxBy(p =>
+                p.Class switch
+                {
+                    Class.SAM => 100,
+                    Class.NIN => 99,
+                    Class.MNK => 88,
+                    Class.RPR => 87,
+                    Class.DRG => 86,
+                    Class.BLM => 79,
+                    Class.SMN => 78,
+                    Class.RDM => 77,
+                    Class.MCH => 69,
+                    Class.BRD => 68,
+                    Class.DNC => 67,
+                    _ => 1
+                }
+            );
             if (target != null)
             {
                 actor = target;
@@ -285,23 +228,9 @@ namespace BossMod.DNC
             Autorot.Hints.NumPriorityTargetsInAOECircle(origin.Position, 5);
 
         private int NumFan4Targets(Actor primary) =>
-            Autorot
-                .Hints
-                .NumPriorityTargetsInAOECone(
-                    Player.Position,
-                    15,
-                    (primary.Position - Player.Position).Normalized(),
-                    60.Degrees()
-                );
+            Autorot.Hints.NumPriorityTargetsInAOECone(Player.Position, 15, (primary.Position - Player.Position).Normalized(), 60.Degrees());
 
         private int NumStarfallTargets(Actor primary) =>
-            Autorot
-                .Hints
-                .NumPriorityTargetsInAOERect(
-                    Player.Position,
-                    (primary.Position - Player.Position).Normalized(),
-                    25,
-                    4
-                );
+            Autorot.Hints.NumPriorityTargetsInAOERect(Player.Position, (primary.Position - Player.Position).Normalized(), 25, 4);
     }
 }

--- a/BossMod/Autorotation/DNC/DNCRotation.cs
+++ b/BossMod/Autorotation/DNC/DNCRotation.cs
@@ -162,26 +162,21 @@ namespace BossMod.DNC
             )
                 return AID.StandardStep;
 
-            var canStarfall =
-                state.FlourishingStarfallLeft > state.GCD && strategy.NumStarfallTargets > 0;
+            var canStarfall = state.FlourishingStarfallLeft > state.GCD && strategy.NumStarfallTargets > 0;
             var canFlow = CanFlow(state, strategy, out var flowCombo);
             var canSymmetry = CanSymmetry(state, strategy, out var symmetryCombo);
             var combo2 = strategy.NumAOETargets > 1 ? AID.Bladeshower : AID.Fountain;
-            var haveCombo2 =
-                state.Unlocked(combo2)
-                && state.ComboLastMove == (strategy.NumAOETargets > 1 ? AID.Windmill : AID.Cascade);
+            var haveCombo2 = state.Unlocked(combo2) && state.ComboLastMove == (strategy.NumAOETargets > 1 ? AID.Windmill : AID.Cascade);
 
             // prevent starfall expiration
             if (canStarfall && state.FlourishingStarfallLeft <= state.AttackGCDTime)
                 return AID.StarfallDance;
 
             // prevent flow expiration
-            if (canFlow && state.FlowLeft <= state.AttackGCDTime && canFlow)
-                return flowCombo;
+            if (canFlow && state.FlowLeft <= state.AttackGCDTime) return flowCombo;
 
             // prevent symmetry expiration
-            if (canSymmetry && state.SymmetryLeft <= state.AttackGCDTime)
-                return symmetryCombo;
+            if (canSymmetry && state.SymmetryLeft <= state.AttackGCDTime) return symmetryCombo;
 
             // prevent saber overcap
             if (ShouldSaberDance(state, strategy, 85))
@@ -219,11 +214,9 @@ namespace BossMod.DNC
                 return AID.StandardStep;
 
             // combo 3
-            if (canFlow)
-                return flowCombo;
+            if (canFlow) return flowCombo;
             // combo 4
-            if (canSymmetry)
-                return symmetryCombo;
+            if (canSymmetry) return symmetryCombo;
 
             // (possibly buffed) standard step
             if (shouldStdStep)

--- a/BossMod/Autorotation/DNC/DNCRotation.cs
+++ b/BossMod/Autorotation/DNC/DNCRotation.cs
@@ -210,7 +210,8 @@ namespace BossMod.DNC
                 return AID.SaberDance;
 
             // unbuffed standard step - combos 3 and 4 are higher priority in raid buff window
-            if (state.TechFinishLeft == 0 && shouldStdStep)
+            // skip if tech step is around 5s cooldown or lower since std step would delay it
+            if (state.TechFinishLeft == 0 && shouldStdStep && state.CD(CDGroup.TechnicalStep) > state.GCD + 5)
                 return AID.StandardStep;
 
             // combo 3

--- a/BossMod/Autorotation/DNC/DNCRotation.cs
+++ b/BossMod/Autorotation/DNC/DNCRotation.cs
@@ -264,10 +264,17 @@ namespace BossMod.DNC
             )
                 return ActionID.MakeSpell(AID.Devilment);
 
-            if (state.CD(CDGroup.Devilment) > 55 && state.CanWeave(CDGroup.Flourish, 0.6f, deadline))
+            if (
+                state.CD(CDGroup.Devilment) > 55
+                && state.CanWeave(CDGroup.Flourish, 0.6f, deadline)
+            )
                 return ActionID.MakeSpell(AID.Flourish);
 
-            if (state.ThreefoldLeft > state.AnimationLock && strategy.NumRangedAOETargets > 0)
+            if (
+                (state.TechFinishLeft == 0 || state.CD(CDGroup.Devilment) > 0)
+                && state.ThreefoldLeft > state.AnimationLock
+                && strategy.NumRangedAOETargets > 0
+            )
                 return ActionID.MakeSpell(AID.FanDanceIII);
 
             var canF1 = ShouldSpendFeathers(state, strategy);

--- a/BossMod/Autorotation/DNC/DNCRotation.cs
+++ b/BossMod/Autorotation/DNC/DNCRotation.cs
@@ -156,10 +156,14 @@ namespace BossMod.DNC
             var shouldStdStep = ShouldStdStep(state, strategy);
 
             // priority for cdplan
-            if (strategy.StdStepUse == CommonRotation.Strategy.OffensiveAbilityUse.Force && shouldStdStep)
+            if (
+                strategy.StdStepUse == CommonRotation.Strategy.OffensiveAbilityUse.Force
+                && shouldStdStep
+            )
                 return AID.StandardStep;
 
-            var canStarfall = state.FlourishingStarfallLeft > state.GCD && strategy.NumStarfallTargets > 0;
+            var canStarfall =
+                state.FlourishingStarfallLeft > state.GCD && strategy.NumStarfallTargets > 0;
             var canFlow = CanFlow(state, strategy, out var flowCombo);
             var canSymmetry = CanSymmetry(state, strategy, out var symmetryCombo);
             var combo2 = strategy.NumAOETargets > 1 ? AID.Bladeshower : AID.Fountain;
@@ -253,30 +257,17 @@ namespace BossMod.DNC
             if (state.IsDancing)
                 return new();
 
-            if (state.RaidBuffsLeft > state.GCD)
-            {
-                if (
-                    state.Unlocked(AID.Devilment)
-                    && state.CanWeave(CDGroup.Devilment, 0.6f, deadline)
-                )
-                    return ActionID.MakeSpell(AID.Devilment);
-
-                if (
-                    state.Unlocked(AID.Flourish) && state.CanWeave(CDGroup.Flourish, 0.6f, deadline)
-                )
-                    return ActionID.MakeSpell(AID.Flourish);
-            }
-
             if (
-                state.CD(CDGroup.Devilment) >= 55
-                && state.CanWeave(CDGroup.Flourish, 0.6f, deadline)
+                state.TechFinishLeft > state.GCD
+                && state.Unlocked(AID.Devilment)
+                && state.CanWeave(CDGroup.Devilment, 0.6f, deadline)
             )
+                return ActionID.MakeSpell(AID.Devilment);
+
+            if (state.CD(CDGroup.Devilment) > 0 && state.CanWeave(CDGroup.Flourish, 0.6f, deadline))
                 return ActionID.MakeSpell(AID.Flourish);
 
-            if (
-                state.ThreefoldLeft > state.AnimationLock
-                && strategy.NumRangedAOETargets > 0
-            )
+            if (state.ThreefoldLeft > state.AnimationLock && strategy.NumRangedAOETargets > 0)
                 return ActionID.MakeSpell(AID.FanDanceIII);
 
             var canF1 = ShouldSpendFeathers(state, strategy);

--- a/BossMod/Autorotation/DNC/DNCRotation.cs
+++ b/BossMod/Autorotation/DNC/DNCRotation.cs
@@ -153,11 +153,10 @@ namespace BossMod.DNC
             if (ShouldTechStep(state, strategy))
                 return AID.TechnicalStep;
 
+            var shouldStdStep = ShouldStdStep(state, strategy);
+
             // priority for cdplan
-            if (
-                strategy.StdStepUse == CommonRotation.Strategy.OffensiveAbilityUse.Force
-                && ShouldStdStep(state, strategy)
-            )
+            if (strategy.StdStepUse == CommonRotation.Strategy.OffensiveAbilityUse.Force && shouldStdStep)
                 return AID.StandardStep;
 
             var canStarfall = state.FlourishingStarfallLeft > state.GCD && strategy.NumStarfallTargets > 0;
@@ -210,8 +209,6 @@ namespace BossMod.DNC
             // buffed saber dance
             if (state.RaidBuffsLeft > state.GCD && ShouldSaberDance(state, strategy, 50))
                 return AID.SaberDance;
-
-            var shouldStdStep = ShouldStdStep(state, strategy);
 
             // unbuffed standard step - combos 3 and 4 are higher priority in raid buff window
             if (state.TechFinishLeft == 0 && shouldStdStep)

--- a/BossMod/Autorotation/DNC/DNCRotation.cs
+++ b/BossMod/Autorotation/DNC/DNCRotation.cs
@@ -206,7 +206,7 @@ namespace BossMod.DNC
                 return AID.Tillana;
 
             // buffed saber dance
-            if (state.RaidBuffsLeft > state.GCD && ShouldSaberDance(state, strategy, 50))
+            if (state.TechFinishLeft > state.GCD && ShouldSaberDance(state, strategy, 50))
                 return AID.SaberDance;
 
             // unbuffed standard step - combos 3 and 4 are higher priority in raid buff window
@@ -344,7 +344,7 @@ namespace BossMod.DNC
             if (state.Feathers == 4 || strategy.FeatherUse == Strategy.OffensiveAbilityUse.Force)
                 return true;
 
-            return state.RaidBuffsLeft > state.AnimationLock;
+            return state.TechFinishLeft > state.AnimationLock;
         }
 
         private static bool ShouldSaberDance(State state, Strategy strategy, int minimumEsprit)

--- a/BossMod/Autorotation/DNC/DNCRotation.cs
+++ b/BossMod/Autorotation/DNC/DNCRotation.cs
@@ -264,7 +264,7 @@ namespace BossMod.DNC
             )
                 return ActionID.MakeSpell(AID.Devilment);
 
-            if (state.CD(CDGroup.Devilment) > 0 && state.CanWeave(CDGroup.Flourish, 0.6f, deadline))
+            if (state.CD(CDGroup.Devilment) > 55 && state.CanWeave(CDGroup.Flourish, 0.6f, deadline))
                 return ActionID.MakeSpell(AID.Flourish);
 
             if (state.ThreefoldLeft > state.AnimationLock && strategy.NumRangedAOETargets > 0)

--- a/BossMod/CooldownPlanner/PlanDefinitions.cs
+++ b/BossMod/CooldownPlanner/PlanDefinitions.cs
@@ -173,7 +173,6 @@ namespace BossMod
         private static ClassData DefineDNC()
         {
             var c = new ClassData(typeof(DNC.AID), DNC.Definitions.SupportedActions);
-            c.CooldownTracks.Add(new("StdStep", ActionID.MakeSpell(DNC.AID.StandardStep), 15));
             c.CooldownTracks.Add(new("Samba", ActionID.MakeSpell(DNC.AID.ShieldSamba), 56));
             c.CooldownTracks.Add(new("Waltz", ActionID.MakeSpell(DNC.AID.CuringWaltz), 52));
             c.CooldownTracks.Add(new("Improv", ActionID.MakeSpell(DNC.AID.Improvisation), 80));
@@ -181,6 +180,8 @@ namespace BossMod
             c.CooldownTracks.Add(new("Sprint", CommonDefinitions.IDSprint, 1));
             c.StrategyTracks.Add(new("Gauge", typeof(CommonRotation.Strategy.OffensiveAbilityUse)));
             c.StrategyTracks.Add(new("Feather", typeof(CommonRotation.Strategy.OffensiveAbilityUse)));
+            c.StrategyTracks.Add(new("TechStep", typeof(CommonRotation.Strategy.OffensiveAbilityUse)));
+            c.StrategyTracks.Add(new("StdStep", typeof(CommonRotation.Strategy.OffensiveAbilityUse)));
             return c;
         }
 


### PR DESCRIPTION
as mentioned in a comment, i updated DNC rotation to use the GCD priority from [this doc](https://docs.google.com/document/d/1wHgJHjby0z-E4s30IqPvIZcSFxhNJE607Y5SKSIWJeU/edit), as well as to skip standard step if technical finish is active and will expire before standard finish is usable