### PR TITLE
[MNK] Optimal drift rotation

### DIFF
--- a/BossMod/Autorotation/MNK/MNKActions.cs
+++ b/BossMod/Autorotation/MNK/MNKActions.cs
@@ -65,8 +65,6 @@ namespace BossMod.MNK
                 _strategy.WindUse = CommonRotation.Strategy.OffensiveAbilityUse.Delay;
                 _strategy.BrotherhoodUse = CommonRotation.Strategy.OffensiveAbilityUse.Delay;
             }
-            if (!_config.AutoTrueNorth)
-                _strategy.TrueNorthUse = CommonRotation.Strategy.OffensiveAbilityUse.Delay;
             FillStrategyPositionals(_strategy, Rotation.GetNextPositional(_state, _strategy), _state.TrueNorthLeft > _state.GCD);
         }
 

--- a/BossMod/Autorotation/MNK/MNKActions.cs
+++ b/BossMod/Autorotation/MNK/MNKActions.cs
@@ -80,7 +80,7 @@ namespace BossMod.MNK
 
         protected override NextAction CalculateAutomaticOGCD(float deadline)
         {
-            if (Autorot.PrimaryTarget == null || AutoAction < AutoActionAIFight)
+            if (!Rotation.HaveTarget(_state, _strategy) || AutoAction < AutoActionAIFight)
                 return new();
 
             ActionID res = new();

--- a/BossMod/Autorotation/MNK/MNKActions.cs
+++ b/BossMod/Autorotation/MNK/MNKActions.cs
@@ -57,6 +57,7 @@ namespace BossMod.MNK
             _strategy.ApplyStrategyOverrides(Autorot.Bossmods.ActiveModule?.PlanExecution?.ActiveStrategyOverrides(Autorot.Bossmods.ActiveModule.StateMachine) ?? new uint[0]);
             _strategy.NumPointBlankAOETargets = autoAction == AutoActionST ? 0 : NumTargetsHitByPBAOE();
             _strategy.NumEnlightenmentTargets = Autorot.PrimaryTarget != null && autoAction != AutoActionST && _state.Unlocked(AID.HowlingFist) ? NumTargetsHitByEnlightenment(Autorot.PrimaryTarget) : 0;
+            _strategy.UseAOE = _strategy.NumPointBlankAOETargets >= 3;
             FillStrategyPositionals(_strategy, Rotation.GetNextPositional(_state, _strategy), _state.TrueNorthLeft > _state.GCD);
         }
 

--- a/BossMod/Autorotation/MNK/MNKActions.cs
+++ b/BossMod/Autorotation/MNK/MNKActions.cs
@@ -1,4 +1,4 @@
-using Dalamud.Game.ClientState.JobGauge.Types;
+﻿using Dalamud.Game.ClientState.JobGauge.Types;
 using System;
 
 namespace BossMod.MNK
@@ -41,7 +41,7 @@ namespace BossMod.MNK
         public override Targeting SelectBetterTarget(AIHints.Enemy initial)
         {
             // TODO: multidotting support...
-            var pos = (_state.Form == Rotation.Form.Coeurl ? Rotation.GetCoeurlFormAction(_state, _strategy.NumPointBlankAOETargets, _strategy.ForbidDOTs) : AID.None) switch
+            var pos = (_state.Form == Rotation.Form.Coeurl ? Rotation.GetCoeurlFormAction(_state, _strategy) : AID.None) switch
             {
                 AID.SnapPunch => Positional.Flank,
                 AID.Demolish => Positional.Rear,
@@ -132,7 +132,7 @@ namespace BossMod.MNK
             SupportedSpell(AID.ArmOfTheDestroyer).PlaceholderForAuto = _config.FullRotation ? AutoActionAOE : AutoActionNone;
 
             // combo replacement
-            SupportedSpell(AID.FourPointFury).TransformAction = _config.AOECombos ? () => ActionID.MakeSpell(Rotation.GetNextComboAction(_state, 100, false, Rotation.Strategy.NadiChoice.Automatic)) : null;
+            SupportedSpell(AID.FourPointFury).TransformAction = _config.AOECombos ? () => ActionID.MakeSpell(Rotation.GetNextComboAction(_state, _strategy)) : null;
 
             SupportedSpell(AID.Thunderclap).Condition = _config.PreventCloseDash
                 ? ((act) => act == null || !act.Position.InCircle(Player.Position, 3))

--- a/BossMod/Autorotation/MNK/MNKActions.cs
+++ b/BossMod/Autorotation/MNK/MNKActions.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Game.ClientState.JobGauge.Types;
+using Dalamud.Game.ClientState.JobGauge.Types;
 using System;
 
 namespace BossMod.MNK
@@ -129,7 +129,7 @@ namespace BossMod.MNK
         {
             // placeholders
             SupportedSpell(AID.Bootshine).PlaceholderForAuto = _config.FullRotation ? AutoActionST : AutoActionNone;
-            SupportedSpell(AID.ArmOfTheDestroyer).PlaceholderForAuto = _config.FullRotation ? AutoActionAOE : AutoActionNone;
+            SupportedSpell(AID.ArmOfTheDestroyer).PlaceholderForAuto = SupportedSpell(AID.ShadowOfTheDestroyer).PlaceholderForAuto = _config.FullRotation ? AutoActionAOE : AutoActionNone;
 
             // combo replacement
             SupportedSpell(AID.FourPointFury).TransformAction = _config.AOECombos ? () => ActionID.MakeSpell(Rotation.GetNextComboAction(_state, _strategy)) : null;

--- a/BossMod/Autorotation/MNK/MNKActions.cs
+++ b/BossMod/Autorotation/MNK/MNKActions.cs
@@ -1,4 +1,4 @@
-using Dalamud.Game.ClientState.JobGauge.Types;
+﻿using Dalamud.Game.ClientState.JobGauge.Types;
 using System;
 
 namespace BossMod.MNK
@@ -7,6 +7,7 @@ namespace BossMod.MNK
     {
         public const int AutoActionST = AutoActionFirstCustom + 0;
         public const int AutoActionAOE = AutoActionFirstCustom + 1;
+        public const int AutoActionFiller = AutoActionFirstCustom + 2;
 
         private MNKConfig _config;
         private Rotation.State _state;
@@ -58,6 +59,14 @@ namespace BossMod.MNK
             _strategy.NumPointBlankAOETargets = autoAction == AutoActionST ? 0 : NumTargetsHitByPBAOE();
             _strategy.NumEnlightenmentTargets = Autorot.PrimaryTarget != null && autoAction != AutoActionST && _state.Unlocked(AID.HowlingFist) ? NumTargetsHitByEnlightenment(Autorot.PrimaryTarget) : 0;
             _strategy.UseAOE = _strategy.NumPointBlankAOETargets >= 3;
+            if (autoAction == AutoActionFiller)
+            {
+                _strategy.FireUse = Rotation.Strategy.FireStrategy.Delay;
+                _strategy.WindUse = CommonRotation.Strategy.OffensiveAbilityUse.Delay;
+                _strategy.BrotherhoodUse = CommonRotation.Strategy.OffensiveAbilityUse.Delay;
+            }
+            if (!_config.AutoTrueNorth)
+                _strategy.TrueNorthUse = CommonRotation.Strategy.OffensiveAbilityUse.Delay;
             FillStrategyPositionals(_strategy, Rotation.GetNextPositional(_state, _strategy), _state.TrueNorthLeft > _state.GCD);
         }
 
@@ -131,6 +140,7 @@ namespace BossMod.MNK
             // placeholders
             SupportedSpell(AID.Bootshine).PlaceholderForAuto = _config.FullRotation ? AutoActionST : AutoActionNone;
             SupportedSpell(AID.ArmOfTheDestroyer).PlaceholderForAuto = SupportedSpell(AID.ShadowOfTheDestroyer).PlaceholderForAuto = _config.FullRotation ? AutoActionAOE : AutoActionNone;
+            SupportedSpell(AID.SnapPunch).PlaceholderForAuto = _config.FullRotation ? AutoActionFiller : AutoActionNone;
 
             // combo replacement
             SupportedSpell(AID.FourPointFury).TransformAction = _config.AOECombos ? () => ActionID.MakeSpell(Rotation.GetNextComboAction(_state, _strategy)) : null;

--- a/BossMod/Autorotation/MNK/MNKRotation.cs
+++ b/BossMod/Autorotation/MNK/MNKRotation.cs
@@ -471,7 +471,7 @@ namespace BossMod.MNK
                 return true;
 
             // prevent early use in standard opener
-            return state.DisciplinedFistLeft > state.GCD && strategy.FightEndIn >= deadline + 20;
+            return state.DisciplinedFistLeft > state.GCD;
         }
 
         private static bool ShouldUseRoW(State state, Strategy strategy, float deadline)
@@ -487,7 +487,7 @@ namespace BossMod.MNK
                 return true;
 
             // thebalance recommends using RoW like an oGCD dot, so we use on cooldown as long as buffs have been used first
-            return state.CD(CDGroup.RiddleOfFire) > 0 && state.CD(CDGroup.Brotherhood) > 0 && strategy.FightEndIn >= deadline + 15;
+            return state.CD(CDGroup.RiddleOfFire) > 0 && state.CD(CDGroup.Brotherhood) > 0;
         }
 
         private static bool ShouldUseBrotherhood(State state, Strategy strategy, float deadline)
@@ -504,7 +504,6 @@ namespace BossMod.MNK
 
             return !strategy.UseAOE
                 && state.CD(CDGroup.RiddleOfFire) > 0
-                && strategy.FightEndIn >= deadline + 15
                 && (
                     // opener timing mostly important as long as rof is used first, we just want to align with party buffs -
                     // the default opener is bhood after first bootshine
@@ -527,7 +526,7 @@ namespace BossMod.MNK
             if (strategy.PerfectBalanceUse == Strategy.OffensiveAbilityUse.Force)
                 return true;
 
-            if (state.Form != Form.Raptor || strategy.FightEndIn < deadline + state.AttackGCDTime * 4)
+            if (state.Form != Form.Raptor)
                 return false;
 
             // bh1 and bh3 even windows where RoF is used no earlier than 2 GCDs before this; also odd windows where

--- a/BossMod/Autorotation/MNK/MNKRotation.cs
+++ b/BossMod/Autorotation/MNK/MNKRotation.cs
@@ -135,7 +135,7 @@ namespace BossMod.MNK
 
             public void ApplyStrategyOverrides(uint[] overrides)
             {
-                if (overrides.Length >= 7)
+                if (overrides.Length >= 8)
                 {
                     DashUse = (DashStrategy)overrides[0];
                     TrueNorthUse = (OffensiveAbilityUse)overrides[1];

--- a/BossMod/Autorotation/MNK/MNKRotation.cs
+++ b/BossMod/Autorotation/MNK/MNKRotation.cs
@@ -471,7 +471,7 @@ namespace BossMod.MNK
                 return true;
 
             // prevent early use in standard opener
-            return state.DisciplinedFistLeft > state.GCD;
+            return state.DisciplinedFistLeft > state.GCD && strategy.FightEndIn >= deadline + 20;
         }
 
         private static bool ShouldUseRoW(State state, Strategy strategy, float deadline)
@@ -487,7 +487,7 @@ namespace BossMod.MNK
                 return true;
 
             // thebalance recommends using RoW like an oGCD dot, so we use on cooldown as long as buffs have been used first
-            return state.CD(CDGroup.RiddleOfFire) > 0 && state.CD(CDGroup.Brotherhood) > 0;
+            return state.CD(CDGroup.RiddleOfFire) > 0 && state.CD(CDGroup.Brotherhood) > 0 && strategy.FightEndIn >= deadline + 15;
         }
 
         private static bool ShouldUseBrotherhood(State state, Strategy strategy, float deadline)
@@ -504,6 +504,7 @@ namespace BossMod.MNK
 
             return !strategy.UseAOE
                 && state.CD(CDGroup.RiddleOfFire) > 0
+                && strategy.FightEndIn >= deadline + 15
                 && (
                     // opener timing mostly important as long as rof is used first, we just want to align with party buffs -
                     // the default opener is bhood after first bootshine
@@ -526,7 +527,7 @@ namespace BossMod.MNK
             if (strategy.PerfectBalanceUse == Strategy.OffensiveAbilityUse.Force)
                 return true;
 
-            if (state.Form != Form.Raptor)
+            if (state.Form != Form.Raptor || strategy.FightEndIn < deadline + state.AttackGCDTime * 4)
                 return false;
 
             // bh1 and bh3 even windows where RoF is used no earlier than 2 GCDs before this; also odd windows where

--- a/BossMod/Autorotation/MNK/MNKRotation.cs
+++ b/BossMod/Autorotation/MNK/MNKRotation.cs
@@ -320,7 +320,7 @@ namespace BossMod.MNK
             if (state.GCD <= 0.800f && ShouldUseRoF(state, strategy, deadline))
                 return ActionID.MakeSpell(AID.RiddleOfFire);
 
-            if (state.Form == Form.Raptor && ShouldUsePB(state, strategy, deadline))
+            if (ShouldUsePB(state, strategy, deadline))
                 return ActionID.MakeSpell(AID.PerfectBalance);
 
             if (ShouldUseBrotherhood(state, strategy, deadline))
@@ -587,13 +587,6 @@ namespace BossMod.MNK
             Strategy.NadiChoice.Solar => true,
             Strategy.NadiChoice.Lunar => false,
             _ => !state.HaveSolar
-        };
-
-        private static bool PreferLunar(State state, Strategy strategy) => strategy.NextNadi switch
-        {
-            Strategy.NadiChoice.Solar => false,
-            Strategy.NadiChoice.Lunar => true,
-            _ => state.HaveSolar
         };
     }
 }

--- a/BossMod/Autorotation/MNK/MNKRotation.cs
+++ b/BossMod/Autorotation/MNK/MNKRotation.cs
@@ -388,11 +388,7 @@ namespace BossMod.MNK
                 if (canRaptor && WillDFExpire(state, state.BeastCount == 2 ? 4 : 1))
                     return Form.Raptor;
 
-                return canOpo
-                    ? Form.OpoOpo
-                    : canRaptor
-                        ? Form.Raptor
-                        : Form.Coeurl;
+                return canOpo ? Form.OpoOpo : canRaptor ? Form.Raptor : Form.Coeurl;
             }
 
             if (state.FormShiftLeft > state.GCD || state.PerfectBalanceLeft > state.GCD)
@@ -463,6 +459,7 @@ namespace BossMod.MNK
             if (strategy.FireUse == Strategy.FireStrategy.Force)
                 return true;
 
+            // prevent early use in opener. DF should otherwise be up permanently excluding downtime
             return state.DisciplinedFistLeft > state.GCD;
         }
 
@@ -496,7 +493,13 @@ namespace BossMod.MNK
 
             return strategy.NumPointBlankAOETargets < 3
                 && state.FireLeft > state.GCD
-                && state.LeadenFistLeft == 0;
+                && (
+                    // opener timing hugely important as long as rof is used first, we just want to align with party buffs -
+                    // the default opener is bhood after first bootshine
+                    state.LeadenFistLeft == 0
+                    // later uses can be asap
+                    || strategy.CombatTimer > 30
+                );
         }
 
         private static bool ShouldUsePB(State state, Strategy strategy, float deadline)

--- a/BossMod/Autorotation/MNK/MNKRotation.cs
+++ b/BossMod/Autorotation/MNK/MNKRotation.cs
@@ -6,13 +6,7 @@ namespace BossMod.MNK
 {
     public static class Rotation
     {
-        public enum Form
-        {
-            None,
-            OpoOpo,
-            Raptor,
-            Coeurl
-        }
+        public enum Form { None, OpoOpo, Raptor, Coeurl }
 
         // full state needed for determining next action
         public class State : CommonRotation.PlayerState
@@ -35,14 +29,12 @@ namespace BossMod.MNK
 
             public int NadiCount => (HaveLunar ? 1 : 0) + (HaveSolar ? 1 : 0);
 
-            public int BeastCount =>
-                BeastChakra.Count(x => x != Dalamud.Game.ClientState.JobGauge.Enums.BeastChakra.NONE);
+            public int BeastCount => BeastChakra.Count(x => x != Dalamud.Game.ClientState.JobGauge.Enums.BeastChakra.NONE);
 
             // upgrade paths
             public AID BestForbiddenChakra => Unlocked(AID.ForbiddenChakra) ? AID.ForbiddenChakra : AID.SteelPeak;
             public AID BestEnlightenment => Unlocked(AID.Enlightenment) ? AID.Enlightenment : AID.HowlingFist;
-            public AID BestShadowOfTheDestroyer =>
-                Unlocked(AID.ShadowOfTheDestroyer) ? AID.ShadowOfTheDestroyer : AID.ArmOfTheDestroyer;
+            public AID BestShadowOfTheDestroyer => Unlocked(AID.ShadowOfTheDestroyer) ? AID.ShadowOfTheDestroyer : AID.ArmOfTheDestroyer;
             public AID BestRisingPhoenix => Unlocked(AID.RisingPhoenix) ? AID.RisingPhoenix : AID.FlintStrike;
             public AID BestPhantomRush => Unlocked(AID.PhantomRush) ? AID.PhantomRush : AID.TornadoKick;
 
@@ -69,7 +61,6 @@ namespace BossMod.MNK
             public State(float[] cooldowns) : base(cooldowns) { }
 
             public bool Unlocked(AID aid) => Definitions.Unlocked(aid, Level, UnlockProgress);
-
             public bool Unlocked(TraitID tid) => Definitions.Unlocked(tid, Level, UnlockProgress);
 
             public override string ToString()

--- a/BossMod/Autorotation/MNK/MNKRotation.cs
+++ b/BossMod/Autorotation/MNK/MNKRotation.cs
@@ -399,7 +399,7 @@ namespace BossMod.MNK
                 if (canCoeurl && WillDemolishExpire(state, state.BeastCount == 2 ? 5 : 2))
                     return Form.Coeurl;
 
-                if (canRaptor && WillDFExpire(state, state.BeastCount == 2 ? 4 : 1))
+                if (canRaptor && WillDFExpire(state, 3 - state.BeastCount))
                     return Form.Raptor;
 
                 return canOpo ? Form.OpoOpo : canRaptor ? Form.Raptor : Form.Coeurl;

--- a/BossMod/Autorotation/MNK/MNKRotation.cs
+++ b/BossMod/Autorotation/MNK/MNKRotation.cs
@@ -429,6 +429,7 @@ namespace BossMod.MNK
         {
             if (
                 state.RangeToTarget <= 3
+                || !state.Unlocked(AID.Thunderclap)
                 || !state.CanWeave(state.CD(CDGroup.Thunderclap) - 60, 0.6f, deadline)
                 || strategy.DashUse == Strategy.DashStrategy.Forbid
             )

--- a/BossMod/Autorotation/MNK/MNKRotation.cs
+++ b/BossMod/Autorotation/MNK/MNKRotation.cs
@@ -377,8 +377,9 @@ namespace BossMod.MNK
                     canCoeurl &= chak != BeastChakra.COEURL;
                     canRaptor &= chak != BeastChakra.RAPTOR;
                 }
-                var mustLunar = false;
-                var mustSolar = false;
+                var nextNadi = strategy.NextNadi;
+                var mustLunar = nextNadi == Strategy.NadiChoice.Lunar;
+                var mustSolar = nextNadi == Strategy.NadiChoice.Solar;
                 if (state.BeastCount == 2)
                 {
                     mustLunar = state.BeastChakra[0] == state.BeastChakra[1];
@@ -496,7 +497,7 @@ namespace BossMod.MNK
                 return true;
 
             return !strategy.UseAOE
-                && state.FireLeft > state.GCD
+                && state.CD(CDGroup.RiddleOfFire) > 0
                 && (
                     // opener timing mostly important as long as rof is used first, we just want to align with party buffs -
                     // the default opener is bhood after first bootshine

--- a/BossMod/Autorotation/MNK/MNKRotation.cs
+++ b/BossMod/Autorotation/MNK/MNKRotation.cs
@@ -412,7 +412,7 @@ namespace BossMod.MNK
 
                 // pre-PB for BH2 even window means we are waiting for RoF to come off cooldown (at the latest, it will
                 // get weaved right before blitz) so use GCDs in increasing order of potency
-                if (forcedSolar || (state.FireLeft == 0 && !state.HaveSolar))
+                if (state.FireLeft == 0 && (forcedSolar || !state.HaveSolar))
                     return canRaptor ? Form.Raptor : canCoeurl ? Form.Coeurl : Form.OpoOpo;
 
                 // always use pb for opo gcds if we have the option

--- a/BossMod/Autorotation/MNK/MNKRotation.cs
+++ b/BossMod/Autorotation/MNK/MNKRotation.cs
@@ -421,9 +421,8 @@ namespace BossMod.MNK
                 //      if we try to delay both lunar/solar until RoF is up, like the standard opener (which is just BH3),
                 //      pre-PB demolish will fall off for multiple GCDs;
                 //      so early non-demo solar is the only way to prevent clipping
-                var isBH2 = state.FireLeft == 0 && !state.HaveSolar;
-
-                if (forcedSolar || isBH2)
+                var isBH2 = state.FireLeft == 0 && (forcedSolar || !state.HaveSolar);
+                if (isBH2)
                     return canRaptor ? Form.Raptor : canCoeurl ? Form.Coeurl : Form.OpoOpo;
 
                 return canOpo ? Form.OpoOpo : canCoeurl ? Form.Coeurl : Form.Raptor;

--- a/BossMod/Autorotation/MNK/MNKRotation.cs
+++ b/BossMod/Autorotation/MNK/MNKRotation.cs
@@ -515,7 +515,10 @@ namespace BossMod.MNK
             if (strategy.PerfectBalanceUse == Strategy.OffensiveAbilityUse.Force)
                 return true;
 
-            if (state.HasSolar && (WillDFExpire(state, 3) || WillDemolishExpire(state, 3)))
+            var cantSolar = state.HasSolar && strategy.NextNadi != Strategy.NadiChoice.Solar;
+
+            // next blitz has to be solar if our buffs are about to run out, but in all other cases, lunar is more damage
+            if (cantSolar && (WillDFExpire(state, 3) || WillDemolishExpire(state, 3)))
                 return false;
 
             var rofIsAligned =

--- a/BossMod/Autorotation/MNK/MNKRotation.cs
+++ b/BossMod/Autorotation/MNK/MNKRotation.cs
@@ -382,7 +382,7 @@ namespace BossMod.MNK
                         canRaptor = false;
                 }
 
-                if (canCoeurl && WillDemolishExpire(state, state.BeastCount == 2 ? 4 : 1))
+                if (canCoeurl && WillDemolishExpire(state, state.BeastCount == 2 ? 5 : 2))
                     return Form.Coeurl;
 
                 if (canRaptor && WillDFExpire(state, state.BeastCount == 2 ? 4 : 1))
@@ -515,17 +515,18 @@ namespace BossMod.MNK
             if (strategy.PerfectBalanceUse == Strategy.OffensiveAbilityUse.Force)
                 return true;
 
-            var cantSolar = state.HasSolar && strategy.NextNadi != Strategy.NadiChoice.Solar;
-
-            // next blitz has to be solar if our buffs are about to run out, but in all other cases, lunar is more damage
-            if (cantSolar && (WillDFExpire(state, 3) || WillDemolishExpire(state, 3)))
-                return false;
+            var shouldSolar = !state.HasSolar || strategy.NextNadi == Strategy.NadiChoice.Solar;
 
             var rofIsAligned =
                 state.FireLeft >= (deadline + state.AttackGCDTime * 3)
                 || ShouldUseRoF(state, strategy, deadline + state.AttackGCDTime * 3);
 
-            return rofIsAligned;
+            if (!rofIsAligned) return false;
+
+            if (WillDemolishExpire(state, 5) && shouldSolar) return true;
+            if (!WillDFExpire(state, 4) && !WillDemolishExpire(state, 5)) return true;
+
+            return false;
         }
 
         private static bool ShouldUseTrueNorth(State state, Strategy strategy)

--- a/BossMod/Autorotation/MNK/MNKRotation.cs
+++ b/BossMod/Autorotation/MNK/MNKRotation.cs
@@ -522,7 +522,9 @@ namespace BossMod.MNK
 
             // bh1 and bh3 even windows where RoF is used no earlier than 2 GCDs before this; also odd windows where
             // natural demolish happens during RoF
-            if (ShouldUseRoF(state, strategy, deadline) || state.FireLeft > deadline + state.AttackGCDTime * 3)
+            // before level 68/RoF unlock, we have nothing to plan our blitzes around, so just use PB whenever it's off cooldown
+            // as long as buffs won't fall off
+            if (ShouldUseRoF(state, strategy, deadline) || state.FireLeft > deadline + state.AttackGCDTime * 3 || !state.Unlocked(AID.RiddleOfFire))
             {
                 if (!CanSolar(state, strategy))
                     return !WillDFExpire(state, 5) && !WillDemolishExpire(state, strategy, 6);

--- a/BossMod/Autorotation/MNK/MNKRotation.cs
+++ b/BossMod/Autorotation/MNK/MNKRotation.cs
@@ -27,10 +27,9 @@ namespace BossMod.MNK
             public bool HasLunar => Nadi.HasFlag(Nadi.LUNAR);
             public bool HasSolar => Nadi.HasFlag(Nadi.SOLAR);
 
-            public int BeastCount =>
-                BeastChakra.Count(
-                    x => x != Dalamud.Game.ClientState.JobGauge.Enums.BeastChakra.NONE
-                );
+            public int NadiCount => (HasLunar ? 1 : 0) + (HasSolar ? 1 : 0);
+
+            public int BeastCount => BeastChakra.Count(x => x != Dalamud.Game.ClientState.JobGauge.Enums.BeastChakra.NONE);
 
             // upgrade paths
             public AID BestForbiddenChakra => Unlocked(AID.ForbiddenChakra) ? AID.ForbiddenChakra : AID.SteelPeak;
@@ -62,11 +61,12 @@ namespace BossMod.MNK
             public State(float[] cooldowns) : base(cooldowns) { }
 
             public bool Unlocked(AID aid) => Definitions.Unlocked(aid, Level, UnlockProgress);
+
             public bool Unlocked(TraitID tid) => Definitions.Unlocked(tid, Level, UnlockProgress);
 
             public override string ToString()
             {
-                return $"RB={RaidBuffsLeft:f1}, N={Nadi}, BC={BeastChakra}, Chakra={Chakra}, Form={Form}/{FormLeft:f1}, DFist={DisciplinedFistLeft:f1}, LFist={LeadenFistLeft:f1}, PotCD={PotionCD:f1}, GCD={GCD:f3}, ALock={AnimationLock:f3}+{AnimationLockDelay:f3}, lvl={Level}/{UnlockProgress}";
+                return $"RB={RaidBuffsLeft:f1}, Demo={TargetDemolishLeft:f1}, DF={DisciplinedFistLeft:f1}, Form={Form}/{FormLeft:f1}, LFist={LeadenFistLeft:f1}, PotCD={PotionCD:f1}, GCD={GCD:f3}, ALock={AnimationLock:f3}+{AnimationLockDelay:f3}, lvl={Level}/{UnlockProgress}";
             }
         }
 
@@ -158,10 +158,10 @@ namespace BossMod.MNK
             }
         }
 
-        public static AID GetOpoOpoFormAction(State state, int numAOETargets)
+        public static AID GetOpoOpoFormAction(State state, Strategy strategy)
         {
             // TODO: what should we use if form is not up?..
-            if (state.Unlocked(AID.ArmOfTheDestroyer) && numAOETargets >= 3)
+            if (state.Unlocked(AID.ArmOfTheDestroyer) && strategy.NumPointBlankAOETargets >= 3)
                 return state.BestShadowOfTheDestroyer;
 
             if (state.Unlocked(AID.DragonKick) && state.LeadenFistLeft <= state.GCD)
@@ -170,91 +170,65 @@ namespace BossMod.MNK
             return AID.Bootshine;
         }
 
-        public static AID GetRaptorFormAction(State state, int numAOETargets)
+        public static AID GetRaptorFormAction(State state, Strategy strategy)
         {
             // TODO: low level - consider early restart...
             // TODO: better threshold for buff reapplication...
-            if (state.Unlocked(AID.FourPointFury) && numAOETargets >= 3)
+            if (state.Unlocked(AID.FourPointFury) && strategy.NumPointBlankAOETargets >= 3)
                 return AID.FourPointFury;
 
-            if (state.Unlocked(AID.TwinSnakes) && state.DisciplinedFistLeft < state.GCD + 7)
+            var rotationSlotLength = state.BeastCount > 0 ? 5 : 3;
+
+            if (state.Unlocked(AID.TwinSnakes) && WillDFExpire(state, rotationSlotLength))
                 return AID.TwinSnakes;
 
             return AID.TrueStrike;
         }
 
-        public static AID GetCoeurlFormAction(State state, int numAOETargets, bool forbidDOTs)
+        public static AID GetCoeurlFormAction(State state, Strategy strategy)
         {
             // TODO: multidot support...
             // TODO: low level - consider early restart...
             // TODO: better threshold for debuff reapplication...
-            if (state.Unlocked(AID.Rockbreaker) && numAOETargets >= 3)
+            if (state.Unlocked(AID.Rockbreaker) && strategy.NumPointBlankAOETargets >= 3)
                 return AID.Rockbreaker;
 
+            // blitzes add two additional gcds, the blitz itself and the opo gcd after
+            var rotationSlotLength = state.BeastCount > 0 ? 5 : 3;
+
             if (
-                !forbidDOTs
+                !strategy.ForbidDOTs
                 && state.Unlocked(AID.Demolish)
-                && state.TargetDemolishLeft < state.GCD + 3
+                && WillDemolishExpire(state, rotationSlotLength)
             )
                 return AID.Demolish;
 
             return AID.SnapPunch;
         }
 
-        public static AID GetNextComboAction(
-            State state,
-            int numAOETargets,
-            bool forbidDOTs,
-            Strategy.NadiChoice nextNadi
-        )
+        public static AID GetNextComboAction(State state, Strategy strategy)
         {
-            var form = GetEffectiveForm(state, nextNadi);
-            if (form == Form.Coeurl)
-                return GetCoeurlFormAction(state, numAOETargets, forbidDOTs);
+            var form = GetEffectiveForm(state, strategy);
+            if (form == Form.Coeurl && state.Unlocked(AID.SnapPunch))
+                return GetCoeurlFormAction(state, strategy);
 
-            if (form == Form.Raptor)
-                return GetRaptorFormAction(state, numAOETargets);
+            if (form == Form.Raptor && state.Unlocked(AID.TrueStrike))
+                return GetRaptorFormAction(state, strategy);
 
-            return GetOpoOpoFormAction(state, numAOETargets);
-        }
-
-        private static Form GetEffectiveForm(State state, Strategy.NadiChoice nextNadi)
-        {
-            if (SolarTime(state, nextNadi))
-                return state.BeastCount switch
-                {
-                    2 => Form.Coeurl,
-                    1 => Form.Raptor,
-                    _ => Form.OpoOpo
-                };
-
-            return state.Form;
-        }
-
-        private static bool SolarTime(State state, Strategy.NadiChoice nextNadi)
-        {
-            if (state.PerfectBalanceLeft <= state.GCD)
-                return false;
-            return nextNadi switch
-            {
-                Strategy.NadiChoice.Automatic => state.HasLunar && !state.HasSolar,
-                Strategy.NadiChoice.Solar => true,
-                _ => false,
-            };
+            return GetOpoOpoFormAction(state, strategy);
         }
 
         public static AID GetNextBestGCD(State state, Strategy strategy)
         {
             if (strategy.CombatTimer < 0)
             {
-                if (state.Chakra < 5)
+                if (state.Chakra < 5 && state.Unlocked(AID.Meditation))
                     return AID.Meditation;
 
                 if (
-                    (
-                        strategy.CombatTimer > -20 && state.FormShiftLeft < 5
-                        || strategy.PreCombatFormShift && state.FormShiftLeft < 2
-                    ) && state.Unlocked(AID.FormShift)
+                    strategy.CombatTimer > -20
+                    && state.FormShiftLeft < 5
+                    && state.Unlocked(AID.FormShift)
                 )
                     return AID.FormShift;
 
@@ -267,10 +241,16 @@ namespace BossMod.MNK
                 if (state.Chakra < 5 && state.Unlocked(AID.Meditation))
                     return AID.Meditation;
 
+                if (strategy.PreCombatFormShift && state.FormShiftLeft < 2 && state.Unlocked(AID.FormShift))
+                    return AID.FormShift;
+
                 return AID.None;
             }
 
-            if (state.Unlocked(AID.SixSidedStar) && strategy.SSSUse == Strategy.OffensiveAbilityUse.Force)
+            if (
+                state.Unlocked(AID.SixSidedStar)
+                && strategy.SSSUse == Strategy.OffensiveAbilityUse.Force
+            )
                 return AID.SixSidedStar;
 
             if (state.BestBlitz != AID.MasterfulBlitz)
@@ -279,12 +259,12 @@ namespace BossMod.MNK
             if (
                 strategy.SSSUse == Strategy.OffensiveAbilityUse.Automatic
                 && strategy.FightEndIn > state.GCD
-                && strategy.FightEndIn < state.GCD + 1.95
+                && strategy.FightEndIn < state.GCD + state.AttackGCDTime
                 && state.Unlocked(AID.SixSidedStar)
             )
                 return AID.SixSidedStar;
 
-            return GetNextComboAction(state, strategy.NumPointBlankAOETargets, strategy.ForbidDOTs, strategy.NextNadi);
+            return GetNextComboAction(state, strategy);
         }
 
         public static (Positional, bool) GetNextPositional(State state, Strategy strategy)
@@ -292,17 +272,28 @@ namespace BossMod.MNK
             if (strategy.NumPointBlankAOETargets >= 3)
                 return (Positional.Any, false);
 
-            var gcdsInAdvance = GetEffectiveForm(state, strategy.NextNadi) switch
-            {
-                Form.Coeurl => 0,
-                Form.Raptor => 1,
-                _ => 2
-            };
-            var willDemolish =
-                state.Unlocked(AID.Demolish)
-                && state.TargetDemolishLeft < state.GCD + 3 + (1.94 * gcdsInAdvance);
+            var curForm = GetEffectiveForm(state, strategy);
 
-            return (willDemolish ? Positional.Rear : Positional.Flank, gcdsInAdvance == 0);
+            var gcdsUntilCoeurl = curForm switch {
+                Form.Coeurl => 3,
+                Form.Raptor => 4,
+                _ => 5
+            };
+
+            var isCastingGcd = state.AttackGCDTime - 0.500 < state.GCD;
+            var formIsPending = state.FormLeft == 1000;
+            // the previous form sticks around for about 200ms before being updated. this results in an off-by-one error
+            // in the refresh calculation that causes an annoying flickering effect in the positionals predictor.
+            // if we know a form swap is imminent, bump the predicted GCD count back.
+            // if PB is active, the current "form" is updated instantly since it's based on job gauge instead of a status effect,
+            // so skip the adjustment
+            if (isCastingGcd && !formIsPending && state.PerfectBalanceLeft == 0)
+                gcdsUntilCoeurl -= 1;
+
+            var willDemolish =
+                state.Unlocked(AID.Demolish) && WillDemolishExpire(state, gcdsUntilCoeurl);
+
+            return (willDemolish ? Positional.Rear : Positional.Flank, curForm == Form.Coeurl);
         }
 
         public static ActionID GetNextBestOGCD(State state, Strategy strategy, float deadline)
@@ -315,34 +306,32 @@ namespace BossMod.MNK
                     strategy.CombatTimer > -0.2
                     && state.RangeToTarget > 3
                     && strategy.DashUse != Strategy.DashStrategy.Forbid
+                    && state.Unlocked(AID.Thunderclap)
                 )
                     return ActionID.MakeSpell(AID.Thunderclap);
 
                 return new();
             }
 
-            if (ShouldUseRoF(state, strategy, deadline))
+            if (state.GCD <= 0.800f && ShouldUseRoF(state, strategy, deadline))
                 return ActionID.MakeSpell(AID.RiddleOfFire);
+
+            if (state.Form == Form.Raptor && ShouldUsePB(state, strategy, deadline))
+                return ActionID.MakeSpell(AID.PerfectBalance);
 
             if (ShouldUseBrotherhood(state, strategy, deadline))
                 return ActionID.MakeSpell(AID.Brotherhood);
-
-            if (ShouldUsePB(state, strategy, deadline))
-                return ActionID.MakeSpell(AID.PerfectBalance);
-
-            if (ShouldUseRoW(state, strategy, deadline))
-                return ActionID.MakeSpell(AID.RiddleOfWind);
 
             // 2. steel peek, if have chakra
             if (
                 state.Unlocked(AID.SteelPeak)
                 && state.Chakra == 5
-                && state.CanWeave(CDGroup.SteelPeak, 0.6f, deadline)
-                && (
-                    // prevent early use in opener
+                && state.CanWeave(CDGroup.SteelPeak, 0.6f, deadline) && (
+                // prevent early use in opener
                     state.CD(CDGroup.RiddleOfFire) > 0
                     || strategy.FireUse == Strategy.FireStrategy.Delay
                     || strategy.FireUse == Strategy.FireStrategy.DelayUntilBrotherhood
+                    || !state.Unlocked(AID.RiddleOfFire)
                 )
             )
             {
@@ -360,6 +349,9 @@ namespace BossMod.MNK
                     return ActionID.MakeSpell(AID.SteelPeak);
             }
 
+            if (ShouldUseRoW(state, strategy, deadline))
+                return ActionID.MakeSpell(AID.RiddleOfWind);
+
             if (
                 ShouldUseTrueNorth(state, strategy)
                 && state.CanWeave(state.CD(CDGroup.TrueNorth) - 45, 0.6f, deadline)
@@ -371,6 +363,69 @@ namespace BossMod.MNK
 
             // no suitable oGCDs...
             return new();
+        }
+
+        private static Form GetEffectiveForm(State state, Strategy strategy)
+        {
+            if (NextIsSolar(state, strategy))
+            {
+                var canCoeurl = true;
+                var canOpo = true;
+                var canRaptor = true;
+                foreach (var chak in state.BeastChakra)
+                {
+                    if (chak == BeastChakra.COEURL)
+                        canCoeurl = false;
+                    if (chak == BeastChakra.OPOOPO)
+                        canOpo = false;
+                    if (chak == BeastChakra.RAPTOR)
+                        canRaptor = false;
+                }
+
+                if (canCoeurl && WillDemolishExpire(state, state.BeastCount == 2 ? 4 : 1))
+                    return Form.Coeurl;
+
+                if (canRaptor && WillDFExpire(state, state.BeastCount == 2 ? 4 : 1))
+                    return Form.Raptor;
+
+                return canOpo
+                    ? Form.OpoOpo
+                    : canRaptor
+                        ? Form.Raptor
+                        : Form.Coeurl;
+            }
+
+            if (state.FormShiftLeft > state.GCD || state.PerfectBalanceLeft > state.GCD)
+                return Form.OpoOpo;
+
+            return state.Form;
+        }
+
+        private static bool NextIsSolar(State state, Strategy strategy)
+        {
+            if (state.PerfectBalanceLeft <= state.GCD)
+                return false;
+
+            switch (strategy.NextNadi)
+            {
+                case Strategy.NadiChoice.Solar:
+                    return true;
+                case Strategy.NadiChoice.Lunar:
+                    return false;
+                default:
+                    // don't overcap unless forced
+                    if (state.HasSolar)
+                        return false;
+                    // solar is planned since we need a demo refresh
+                    // 5 GCDs = 3 for PB, one for blitz, then opo gcd post blitz
+                    if (
+                        WillDemolishExpire(state, 5 - state.BeastCount)
+                        || WillDFExpire(state, 5 - state.BeastCount)
+                    )
+                        return true;
+                    // if we have any non opo chakra we are in solar, assume refresh has happened or is unnecessary
+                    return state.BeastChakra.Any(x => x != BeastChakra.NONE && x != BeastChakra.OPOOPO);
+            }
         }
 
         private static bool ShouldDash(State state, Strategy strategy, float deadline)
@@ -408,22 +463,7 @@ namespace BossMod.MNK
             if (strategy.FireUse == Strategy.FireStrategy.Force)
                 return true;
 
-            if (state.GCD > 0.800)
-                return false;
-
-            if (strategy.CombatTimer < 30)
-                // use before demolish in opener
-                return state.Form == Form.Coeurl;
-            else
-            {
-                var buffWait =
-                    strategy.FireUse == Strategy.FireStrategy.Automatic
-                    || state.CD(CDGroup.Brotherhood) < 4;
-
-                // cooldown alignment for braindead looping rotation
-                // TODO: implement optimal drift (it can't be that hard with math, right?)
-                return state.Form == Form.OpoOpo && buffWait;
-            }
+            return state.DisciplinedFistLeft > state.GCD;
         }
 
         private static bool ShouldUseRoW(State state, Strategy strategy, float deadline)
@@ -438,8 +478,8 @@ namespace BossMod.MNK
             if (strategy.WindUse == Strategy.OffensiveAbilityUse.Force)
                 return true;
 
-            // thebalance recommends using RoW like an oGCD dot, so we use on cooldown as long as RoF has been used first
-            return state.CD(CDGroup.RiddleOfFire) > 0;
+            // thebalance recommends using RoW like an oGCD dot, so we use on cooldown as long as buffs have been used first
+            return state.CD(CDGroup.RiddleOfFire) > 0 && state.CD(CDGroup.Brotherhood) > 0;
         }
 
         private static bool ShouldUseBrotherhood(State state, Strategy strategy, float deadline)
@@ -454,7 +494,7 @@ namespace BossMod.MNK
             if (strategy.BrotherhoodUse == Strategy.OffensiveAbilityUse.Force)
                 return true;
 
-            return strategy.NumPointBlankAOETargets == 0
+            return strategy.NumPointBlankAOETargets < 3
                 && state.FireLeft > state.GCD
                 && state.LeadenFistLeft == 0;
         }
@@ -472,8 +512,14 @@ namespace BossMod.MNK
             if (strategy.PerfectBalanceUse == Strategy.OffensiveAbilityUse.Force)
                 return true;
 
-            return (state.FireLeft > state.GCD || !state.Unlocked(AID.RiddleOfFire))
-                && state.LeadenFistLeft == 0;
+            if (state.HasSolar && (WillDFExpire(state, 3) || WillDemolishExpire(state, 3)))
+                return false;
+
+            var rofIsAligned =
+                state.FireLeft >= (deadline + state.AttackGCDTime * 3)
+                || ShouldUseRoF(state, strategy, deadline + state.AttackGCDTime * 3);
+
+            return rofIsAligned;
         }
 
         private static bool ShouldUseTrueNorth(State state, Strategy strategy)
@@ -488,5 +534,14 @@ namespace BossMod.MNK
 
             return strategy.NextPositionalImminent && !strategy.NextPositionalCorrect;
         }
+
+        private static bool WillDemolishExpire(State state, int gcds) =>
+            WillStatusExpire(state, gcds, state.TargetDemolishLeft);
+
+        private static bool WillDFExpire(State state, int gcds) =>
+            WillStatusExpire(state, gcds, state.DisciplinedFistLeft);
+
+        private static bool WillStatusExpire(State state, int gcds, float statusDuration) =>
+            statusDuration < state.GCD + (state.AttackGCDTime * gcds);
     }
 }


### PR DESCRIPTION
Optimal drift is actually a little complicated. This rotation is designed to be able to enter RoF at any point in MNK's core 3-GCD rotation and execute one to two fully buffed blitzes without losing Demolish uptime.

Log excerpt of this rotation correctly performing the weird BH2 window with a preemptive PB leading into buffed Rising Phoenix: https://gist.github.com/xanunderscore/1c7ae3cc406bbdf2daaf907538e1502f

I also tested this in DRN with 1.56 GCD just to see how it performs in suboptimal conditions and it is able to maintain uptime and perform blitzes in buff windows as I would expect, though Brotherhood is often delayed for a GCD since you can't double weave at 1.56, but autorotation can't really do anything about that.

This PR also fixes a flickering issue with the positional predictor. Additionally, it skips the Demolish timer check entirely when fighting 3 or more enemies, since otherwise the rotation repeatedly tries to use solar blitzes. This prevents you from getting all out of sync in dungeons, as entering an opener/2 minute window with only a solar nadi is a nightmare scenario for MNK.

[The Balance optimal drift infographic](https://www.thebalanceffxiv.com/img/jobs/mnk/mnkguide_0011_optimaldrifteven.png)