### PR TITLE
Minor MNK enhancements

### DIFF
--- a/BossMod/Autorotation/MNK/MNKActions.cs
+++ b/BossMod/Autorotation/MNK/MNKActions.cs
@@ -64,6 +64,7 @@ namespace BossMod.MNK
                 _strategy.FireUse = Rotation.Strategy.FireStrategy.Delay;
                 _strategy.WindUse = CommonRotation.Strategy.OffensiveAbilityUse.Delay;
                 _strategy.BrotherhoodUse = CommonRotation.Strategy.OffensiveAbilityUse.Delay;
+                _strategy.PerfectBalanceUse = CommonRotation.Strategy.OffensiveAbilityUse.Delay;
             }
             FillStrategyPositionals(_strategy, Rotation.GetNextPositional(_state, _strategy), _state.TrueNorthLeft > _state.GCD);
         }
@@ -138,7 +139,7 @@ namespace BossMod.MNK
             // placeholders
             SupportedSpell(AID.Bootshine).PlaceholderForAuto = _config.FullRotation ? AutoActionST : AutoActionNone;
             SupportedSpell(AID.ArmOfTheDestroyer).PlaceholderForAuto = SupportedSpell(AID.ShadowOfTheDestroyer).PlaceholderForAuto = _config.FullRotation ? AutoActionAOE : AutoActionNone;
-            SupportedSpell(AID.SnapPunch).PlaceholderForAuto = _config.FullRotation ? AutoActionFiller : AutoActionNone;
+            SupportedSpell(AID.TrueStrike).PlaceholderForAuto = _config.FillerRotation ? AutoActionFiller : AutoActionNone;
 
             // combo replacement
             SupportedSpell(AID.FourPointFury).TransformAction = _config.AOECombos ? () => ActionID.MakeSpell(Rotation.GetNextComboAction(_state, _strategy)) : null;

--- a/BossMod/Autorotation/MNK/MNKConfig.cs
+++ b/BossMod/Autorotation/MNK/MNKConfig.cs
@@ -6,6 +6,9 @@ namespace BossMod
         [PropertyDisplay("Execute optimal rotations on Bootshine (ST) or Arm of the Destroyer (AOE)")]
         public bool FullRotation = true;
 
+        [PropertyDisplay("Execute filler rotation (no automatic buff usage) on True Strike")]
+        public bool FillerRotation = true;
+
         [PropertyDisplay("Execute form-specific aoe GCD on Four-point Fury")]
         public bool AOECombos = true;
 

--- a/BossMod/Autorotation/MNK/MNKRotation.cs
+++ b/BossMod/Autorotation/MNK/MNKRotation.cs
@@ -526,6 +526,12 @@ namespace BossMod.MNK
             if (strategy.PerfectBalanceUse == Strategy.OffensiveAbilityUse.Force)
                 return true;
 
+            // with enough haste/low enough GCD (< 1.6, currently exclusive to bozja), double lunar is possible without dropping buffs
+            // via lunar -> opo -> snakes -> pb -> lunar
+            // this is the only time PB use is not directly after an opo GCD
+            if (state.Form == Form.Coeurl && state.FireLeft > deadline + state.AttackGCDTime * 3)
+                return !WillDFExpire(state, 5) && !WillDemolishExpire(state, strategy, 3);
+
             if (state.Form != Form.Raptor)
                 return false;
 
@@ -537,6 +543,10 @@ namespace BossMod.MNK
             {
                 if (!CanSolar(state, strategy))
                     return !WillDFExpire(state, 5) && !WillDemolishExpire(state, strategy, 6);
+
+                // see haste note above; delay standard even window PB2 in favor of double lunar
+                if (WillDFExpire(state, 3) && !WillDemolishExpire(state, strategy, 5))
+                    return false;
 
                 return true;
             }


### PR DESCRIPTION
1. I forgot that the filler mode I implemented was even in the last PR. People probably aren't using it since it's not documented. I changed the trigger skill for it (TS instead of snap) and added an explicit config option.
2. Explicitly disabled automatic PB use in filler mode. PB is usually automatically used at appropriate times if Riddle of Fire is or soon will be active, but that means that swapping to filler with RoF up can still result in an automatic PB that you didn't want.
3. `ShouldUsePB` can now detect double lunar windows that are only available at <1.6-ish GCD. This is just for Bozja optimization and doesn't affect the rotation in standard play.