### PR TITLE
Support for queueing and executing ExecuteCommand

### DIFF
--- a/BossMod/Autorotation/CommonActions.cs
+++ b/BossMod/Autorotation/CommonActions.cs
@@ -21,6 +21,8 @@ namespace BossMod
             public Actor? Target;
             public Vector3 TargetPos;
             public ActionSource Source;
+            public CommandID Command;
+            public (uint, uint, uint, int) Arguments;
 
             public NextAction(ActionID action, Actor? target, Vector3 targetPos, ActionSource source)
             {
@@ -28,6 +30,14 @@ namespace BossMod
                 Target = target;
                 TargetPos = targetPos;
                 Source = source;
+            }
+
+            public static NextAction ExecuteCommand(CommandID id, uint arg1, uint arg2, uint arg3, int arg4)
+            {
+                return new NextAction() {
+                    Command = id, 
+                    Arguments = (arg1, arg2, arg3, arg4)
+                };
             }
         }
 
@@ -483,6 +493,16 @@ namespace BossMod
                 }
             }
             return (bestTarget, bestPrio);
+        }
+
+        protected unsafe NextAction StatusOff(uint statusId)
+        {
+            var p = Service.ObjectTable[Player.SpawnIndex] as Dalamud.Game.ClientState.Objects.Types.BattleChara;
+            if (p == null) return new();
+            var s = (FFXIVGame.StatusManager*)p.StatusList.Address;
+            var i = s->GetStatusIndex(statusId);
+            if (i < 0) return new();
+            return NextAction.ExecuteCommand(CommandID.StatusOff, statusId, 0, s->GetSourceId(i), 0);
         }
     }
 }

--- a/BossMod/Autorotation/CommonRotation.cs
+++ b/BossMod/Autorotation/CommonRotation.cs
@@ -29,10 +29,17 @@ namespace BossMod
             public float AttackGCDTime;
             public float SpellGCDTime;
 
+            public uint DutyAction1;
+            public uint DutyAction2;
+
             public float GCD => Cooldowns[CommonDefinitions.GCDGroup]; // 2.5 max (decreased by SkS), 0 if not on gcd
             public float SprintCD => Cooldowns[CommonDefinitions.SprintCDGroup]; // 60.0 max
             public float PotionCD => Cooldowns[CommonDefinitions.PotionCDGroup]; // variable max
             public float CD<CDGroup>(CDGroup group) where CDGroup : Enum => Cooldowns[(int)(object)group];
+            public float DutyActionCD<AID>(AID aid) where AID : Enum {
+                var id = (uint)(object)aid;
+                return id == DutyAction1 ? Cooldowns[CommonDefinitions.DutyActionCDGroup] : id == DutyAction2 ? Cooldowns[CommonDefinitions.DutyAction2CDGroup] : float.MaxValue;
+            }
 
             // check whether weaving typical ogcd off cooldown would end its animation lock by the specified deadline
             public float OGCDSlotLength => 0.6f + AnimationLockDelay; // most actions have 0.6 anim lock delay, which allows double-weaving oGCDs between GCDs

--- a/BossMod/Data/CommandID.cs
+++ b/BossMod/Data/CommandID.cs
@@ -6,4 +6,8 @@ namespace BossMod
         StatusOff = 104,
         UseLostAction = 2950
     }
+
+    public static class CIDExtensions {
+        public static bool CausesAnimationLock(this CommandID id) => id == CommandID.UseLostAction;
+    }
 }

--- a/BossMod/Data/CommandID.cs
+++ b/BossMod/Data/CommandID.cs
@@ -1,0 +1,9 @@
+namespace BossMod
+{
+    public enum CommandID : uint
+    {
+        None = 0,
+        StatusOff = 104,
+        UseLostAction = 2950
+    }
+}

--- a/BossMod/Framework/ActionManagerEx.cs
+++ b/BossMod/Framework/ActionManagerEx.cs
@@ -283,7 +283,7 @@ namespace BossMod
                     _restoreRotation = null;
             }
 
-            if (EffectiveAnimationLock <= 0 && AutoQueue.Command != CommandID.None)
+            if (AutoQueue.Command != CommandID.None && (EffectiveAnimationLock <= 0 || !AutoQueue.Command.CausesAnimationLock()))
             {
                 var delay = DateTime.Now - _lastExecCommandRequest;
                 if (delay.TotalMilliseconds > EXEC_COMMAND_RATELIMIT_MS) {

--- a/BossMod/Framework/ActionManagerEx.cs
+++ b/BossMod/Framework/ActionManagerEx.cs
@@ -112,7 +112,7 @@ namespace BossMod
         private int _restoreCntr;
 
         private DateTime _lastExecCommandRequest;
-        private static readonly uint EXEC_COMMAND_RATELIMIT_MS = 100;
+        private static readonly uint EXEC_COMMAND_RATELIMIT_MS = 250;
 
         private delegate byte ExecuteCommandDelegate(int commandId, uint a1, uint a2, uint a3, int a4);
         private readonly ExecuteCommandDelegate _executeCommand;


### PR DESCRIPTION
ExecuteCommand is required for NIN (`/statusoff`) and for swapping Lost Actions in Bozja, which is part of the optimal DRS opener for every class