### PR TITLE
Swap ArenaColor to ComponentType enum

### DIFF
--- a/BossMod/BossModule/AOEShapes.cs
+++ b/BossMod/BossModule/AOEShapes.cs
@@ -6,8 +6,8 @@ namespace BossMod
     public abstract class AOEShape
     {
         public abstract bool Check(WPos position, WPos origin, Angle rotation);
-        public abstract void Draw(MiniArena arena, WPos origin, Angle rotation, uint color = ArenaColor.AOE);
-        public abstract void Outline(MiniArena arena, WPos origin, Angle rotation, uint color = ArenaColor.Danger);
+        public abstract void Draw(MiniArena arena, WPos origin, Angle rotation, ComponentType type = ComponentType.AOE);
+        public abstract void Outline(MiniArena arena, WPos origin, Angle rotation, ComponentType type = ComponentType.Danger);
         public abstract IEnumerable<IEnumerable<WPos>> Contour(WPos origin, Angle rotation, float offset = 0, float maxError = 1); // positive offset increases area, negative decreases
         public abstract Func<WPos, float> Distance(WPos origin, Angle rotation);
 
@@ -16,16 +16,16 @@ namespace BossMod
             return origin != null ? Check(position, origin.Position, origin.Rotation) : false;
         }
 
-        public void Draw(MiniArena arena, Actor? origin, uint color = ArenaColor.AOE)
+        public void Draw(MiniArena arena, Actor? origin, ComponentType type = ComponentType.AOE)
         {
             if (origin != null)
-                Draw(arena, origin.Position, origin.Rotation, color);
+                Draw(arena, origin.Position, origin.Rotation, type);
         }
 
-        public void Outline(MiniArena arena, Actor? origin, uint color = ArenaColor.Danger)
+        public void Outline(MiniArena arena, Actor? origin, ComponentType type = ComponentType.Danger)
         {
             if (origin != null)
-                Outline(arena, origin.Position, origin.Rotation, color);
+                Outline(arena, origin.Position, origin.Rotation, type);
         }
     }
 
@@ -44,8 +44,8 @@ namespace BossMod
 
         public override string ToString() => $"Cone: r={Radius:f3}, angle={HalfAngle * 2}, off={DirectionOffset}";
         public override bool Check(WPos position, WPos origin, Angle rotation) => position.InCircleCone(origin, Radius, rotation + DirectionOffset, HalfAngle);
-        public override void Draw(MiniArena arena, WPos origin, Angle rotation, uint color = ArenaColor.AOE) => arena.ZoneCone(origin, 0, Radius, rotation + DirectionOffset, HalfAngle, color);
-        public override void Outline(MiniArena arena, WPos origin, Angle rotation, uint color = ArenaColor.Danger) => arena.AddCone(origin, Radius, rotation + DirectionOffset, HalfAngle, color);
+        public override void Draw(MiniArena arena, WPos origin, Angle rotation, ComponentType type = ComponentType.AOE) => arena.ZoneCone(origin, 0, Radius, rotation + DirectionOffset, HalfAngle, type);
+        public override void Outline(MiniArena arena, WPos origin, Angle rotation, ComponentType type = ComponentType.Danger) => arena.AddCone(origin, Radius, rotation + DirectionOffset, HalfAngle, type);
         public override IEnumerable<IEnumerable<WPos>> Contour(WPos origin, Angle rotation, float offset, float maxError)
         {
             var centerOffset = offset == 0 ? 0 : offset / HalfAngle.Sin();
@@ -66,8 +66,8 @@ namespace BossMod
 
         public override string ToString() => $"Circle: r={Radius:f3}";
         public override bool Check(WPos position, WPos origin, Angle rotation = new()) => position.InCircle(origin, Radius);
-        public override void Draw(MiniArena arena, WPos origin, Angle rotation = new(), uint color = ArenaColor.AOE) => arena.ZoneCircle(origin, Radius, color);
-        public override void Outline(MiniArena arena, WPos origin, Angle rotation = new(), uint color = ArenaColor.Danger) => arena.AddCircle(origin, Radius, color);
+        public override void Draw(MiniArena arena, WPos origin, Angle rotation = new(), ComponentType type = ComponentType.AOE) => arena.ZoneCircle(origin, Radius, type);
+        public override void Outline(MiniArena arena, WPos origin, Angle rotation = new(), ComponentType type = ComponentType.Danger) => arena.AddCircle(origin, Radius, type);
         public override IEnumerable<IEnumerable<WPos>> Contour(WPos origin, Angle rotation, float offset, float maxError)
         {
             yield return CurveApprox.Circle(origin, Radius + offset, maxError);
@@ -88,11 +88,11 @@ namespace BossMod
 
         public override string ToString() => $"Donut: r={InnerRadius:f3}-{OuterRadius:f3}";
         public override bool Check(WPos position, WPos origin, Angle rotation = new()) => position.InDonut(origin, InnerRadius, OuterRadius);
-        public override void Draw(MiniArena arena, WPos origin, Angle rotation = new(), uint color = ArenaColor.AOE) => arena.ZoneDonut(origin, InnerRadius, OuterRadius, color);
-        public override void Outline(MiniArena arena, WPos origin, Angle rotation = new(), uint color = ArenaColor.Danger)
+        public override void Draw(MiniArena arena, WPos origin, Angle rotation = new(), ComponentType type = ComponentType.AOE) => arena.ZoneDonut(origin, InnerRadius, OuterRadius, type);
+        public override void Outline(MiniArena arena, WPos origin, Angle rotation = new(), ComponentType type = ComponentType.Danger)
         {
-            arena.AddCircle(origin, InnerRadius, color);
-            arena.AddCircle(origin, OuterRadius, color);
+            arena.AddCircle(origin, InnerRadius, type);
+            arena.AddCircle(origin, OuterRadius, type);
         }
         public override IEnumerable<IEnumerable<WPos>> Contour(WPos origin, Angle rotation, float offset, float maxError)
         {
@@ -119,8 +119,8 @@ namespace BossMod
 
         public override string ToString() => $"Donut sector: r={InnerRadius:f3}-{OuterRadius:f3}, angle={HalfAngle * 2}, off={DirectionOffset}";
         public override bool Check(WPos position, WPos origin, Angle rotation) => position.InDonutCone(origin, InnerRadius, OuterRadius, rotation + DirectionOffset, HalfAngle);
-        public override void Draw(MiniArena arena, WPos origin, Angle rotation, uint color = ArenaColor.AOE) => arena.ZoneCone(origin, InnerRadius, OuterRadius, rotation + DirectionOffset, HalfAngle, color);
-        public override void Outline(MiniArena arena, WPos origin, Angle rotation, uint color = ArenaColor.Danger) => arena.AddDonutCone(origin, InnerRadius, OuterRadius, rotation + DirectionOffset, HalfAngle, color);
+        public override void Draw(MiniArena arena, WPos origin, Angle rotation, ComponentType type = ComponentType.AOE) => arena.ZoneCone(origin, InnerRadius, OuterRadius, rotation + DirectionOffset, HalfAngle, type);
+        public override void Outline(MiniArena arena, WPos origin, Angle rotation, ComponentType type = ComponentType.Danger) => arena.AddDonutCone(origin, InnerRadius, OuterRadius, rotation + DirectionOffset, HalfAngle, type);
         public override IEnumerable<IEnumerable<WPos>> Contour(WPos origin, Angle rotation, float offset, float maxError)
         {
             var centerOffset = offset == 0 ? 0 : offset / HalfAngle.Sin();
@@ -147,14 +147,14 @@ namespace BossMod
 
         public override string ToString() => $"Rect: l={LengthFront:f3}+{LengthBack:f3}, w={HalfWidth * 2}, off={DirectionOffset}";
         public override bool Check(WPos position, WPos origin, Angle rotation) => position.InRect(origin, rotation + DirectionOffset, LengthFront, LengthBack, HalfWidth);
-        public override void Draw(MiniArena arena, WPos origin, Angle rotation, uint color = ArenaColor.AOE) => arena.ZoneRect(origin, rotation + DirectionOffset, LengthFront, LengthBack, HalfWidth, color);
-        public override void Outline(MiniArena arena, WPos origin, Angle rotation, uint color = ArenaColor.Danger)
+        public override void Draw(MiniArena arena, WPos origin, Angle rotation, ComponentType type = ComponentType.AOE) => arena.ZoneRect(origin, rotation + DirectionOffset, LengthFront, LengthBack, HalfWidth, type);
+        public override void Outline(MiniArena arena, WPos origin, Angle rotation, ComponentType type = ComponentType.Danger)
         {
             var direction = (rotation + DirectionOffset).ToDirection();
             var side = HalfWidth * direction.OrthoR();
             var front = origin + LengthFront * direction;
             var back = origin - LengthBack * direction;
-            arena.AddQuad(front + side, front - side, back - side, back + side, color);
+            arena.AddQuad(front + side, front - side, back - side, back + side, type);
         }
         public override IEnumerable<IEnumerable<WPos>> Contour(WPos origin, Angle rotation, float offset, float maxError)
         {
@@ -196,13 +196,13 @@ namespace BossMod
 
         public override string ToString() => $"Cross: l={Length:f3}, w={HalfWidth * 2}, off={DirectionOffset}";
         public override bool Check(WPos position, WPos origin, Angle rotation) => position.InRect(origin, rotation + DirectionOffset, Length, Length, HalfWidth) || position.InRect(origin, rotation + DirectionOffset, HalfWidth, HalfWidth, Length);
-        public override void Draw(MiniArena arena, WPos origin, Angle rotation, uint color = ArenaColor.AOE) => arena.Zone(arena.Bounds.ClipAndTriangulate(ContourPoints(origin, rotation)), color);
+        public override void Draw(MiniArena arena, WPos origin, Angle rotation, ComponentType type = ComponentType.AOE) => arena.Zone(arena.Bounds.ClipAndTriangulate(ContourPoints(origin, rotation)), type);
 
-        public override void Outline(MiniArena arena, WPos origin, Angle rotation, uint color = ArenaColor.Danger)
+        public override void Outline(MiniArena arena, WPos origin, Angle rotation, ComponentType type = ComponentType.Danger)
         {
             foreach (var p in ContourPoints(origin, rotation))
                 arena.PathLineTo(p);
-            arena.PathStroke(true, color);
+            arena.PathStroke(true, type);
         }
 
         public override IEnumerable<IEnumerable<WPos>> Contour(WPos origin, Angle rotation, float offset, float maxError)

--- a/BossMod/BossModule/ArenaColor.cs
+++ b/BossMod/BossModule/ArenaColor.cs
@@ -1,19 +1,54 @@
-﻿namespace BossMod
+﻿namespace BossMod;
+using static ComponentType;
+internal static class ArenaColor
 {
-    // common color constants (ABGR)
-    public static class ArenaColor
+    // default color constants (ABGR)
+    private static uint DefaultForType(ComponentType type)
     {
-        public const uint Background = 0xc00f0f0f;
-        public const uint Border = 0xffffffff;
-        public const uint AOE = 0x80008080;
-        public const uint SafeFromAOE = 0x80008000;
-        public const uint Danger = 0xff00ffff;
-        public const uint Safe = 0xff00ff00;
-        public const uint PC = 0xff00ff00;
-        public const uint Enemy = 0xff0000ff;
-        public const uint Object = 0xff0080ff;
-        public const uint PlayerInteresting = 0xffc0c0c0;
-        public const uint PlayerGeneric = 0xff808080;
-        public const uint Vulnerable = 0xffff00ff;
+        return type switch
+        {
+            Unspecified => 0,
+            Background => 0xc00f0f0f,
+            Border => 0xffffffff,
+            AOE => 0x80008080,
+            SafeFromAOE => 0x80008000,
+            Danger => 0xff00ffff,
+            Safe => 0xff00ff00,
+            Hint => 0x40008080,
+
+            ActorYou => 0xff00ff00,
+            ActorEnemy => 0xff0000ff,
+            ActorObject => 0xff0080ff,
+            PlayerInteresting => 0xffc0c0c0,
+            PlayerGeneric => 0xff808080,
+            ActorVulnerable => 0xffff00ff,
+
+            WaymarkA1 => 0xff964ee5,
+            WaymarkB2 => 0xff11a2c6,
+            WaymarkC3 => 0xffe29f30,
+            WaymarkD4 => 0xffbc567a,
+
+            TetherMoveToward => 0xffffff00,
+            TetherMoveAway => 0xff00ffff,
+            TetherDontMove => 0xffff00ff,
+
+            // Reddish Actor
+            ActorA => 0xff8080ff,
+            // Gold Actor
+            ActorB => 0xff40c0c0,
+            // Blue Actor
+            ActorC => 0xffff8040,
+            // Purple Actor
+            ActorD => 0xffff80ff,
+            // Light Green Actor
+            ActorE => 0xff80ff80,
+
+            _ => 0xff0000ff,
+        };
+    }
+
+    internal static uint ForType(ComponentType type)
+    {
+        return DefaultForType(type);
     }
 }

--- a/BossMod/BossModule/BossComponent.cs
+++ b/BossMod/BossModule/BossComponent.cs
@@ -14,9 +14,9 @@ namespace BossMod
         }
 
         // list of actor-specific "movement hints" (arrow start/end pos + color)
-        public class MovementHints : List<(WPos, WPos, uint)>
+        public class MovementHints : List<(WPos, WPos, ComponentType)>
         {
-            public void Add(WPos from, WPos to, uint color) => base.Add((from, to, color));
+            public void Add(WPos from, WPos to, ComponentType type) => base.Add((from, to, type));
         }
 
         // list of global hints
@@ -39,7 +39,7 @@ namespace BossMod
         public virtual void AddHints(BossModule module, int slot, Actor actor, TextHints hints, MovementHints? movementHints) { } // gather any relevant pieces of advice for specified raid member
         public virtual void AddGlobalHints(BossModule module, GlobalHints hints) { } // gather any relevant pieces of advice for whole raid
         public virtual void AddAIHints(BossModule module, int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints) { } // gather AI hints for specified raid member
-        public virtual PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor) => PlayerPriority.Irrelevant; // determine how particular party member should be drawn; if custom color is left untouched, standard color is selected
+        public virtual PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType customType) => PlayerPriority.Irrelevant; // determine how particular party member should be drawn; if custom color is left untouched, standard color is selected
         public virtual void DrawArenaBackground(BossModule module, int pcSlot, Actor pc, MiniArena arena) { } // called at the beginning of arena draw, good place to draw aoe zones
         public virtual void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena) { } // called after arena background and borders are drawn, good place to draw actors, tethers, etc.
 

--- a/BossMod/BossModule/BossModuleMainWindow.cs
+++ b/BossMod/BossModule/BossModuleMainWindow.cs
@@ -84,8 +84,9 @@ namespace BossMod
             if (arrows == null || arrows.Count == 0 || Camera.Instance == null)
                 return;
 
-            foreach ((var start, var end, uint color) in arrows)
+            foreach ((var start, var end, ComponentType type) in arrows)
             {
+                uint color = ArenaColor.ForType(type);
                 Vector3 start3 = new(start.X, y, start.Z);
                 Vector3 end3 = new(end.X, y, end.Z);
                 Camera.Instance.DrawWorldLine(start3, end3, color);

--- a/BossMod/BossModule/ComponentType.cs
+++ b/BossMod/BossModule/ComponentType.cs
@@ -1,0 +1,36 @@
+﻿namespace BossMod;
+
+public enum ComponentType
+{
+    // This shouldn't be used. If existing types do not cover a component, add a new type and color in ArenaColor.
+    Unspecified,
+    Background,
+    Border,
+    AOE,
+    SafeFromAOE,
+    Danger,
+    Safe,
+    Hint,
+
+    ActorYou,
+    ActorEnemy,
+    ActorObject,
+    PlayerInteresting,
+    PlayerGeneric,
+    ActorVulnerable,
+
+    WaymarkA1,
+    WaymarkB2,
+    WaymarkC3,
+    WaymarkD4,
+
+    TetherMoveToward,
+    TetherMoveAway,
+    TetherDontMove,
+
+    ActorA,
+    ActorB,
+    ActorC,
+    ActorD,
+    ActorE,
+}

--- a/BossMod/BossModule/MiniArena.cs
+++ b/BossMod/BossModule/MiniArena.cs
@@ -55,7 +55,7 @@ namespace BossMod
             {
                 foreach (var p in Bounds.ClipPoly)
                     PathLineTo(p);
-                PathFillConvex(ArenaColor.Background);
+                PathFillConvex(ComponentType.Background);
             }
         }
 
@@ -83,66 +83,66 @@ namespace BossMod
         }
 
         // unclipped primitive rendering that accept world-space positions; thin convenience wrappers around drawlist api
-        public void AddLine(WPos a, WPos b, uint color, float thickness = 1)
+        public void AddLine(WPos a, WPos b, ComponentType componentType, float thickness = 1)
         {
-            ImGui.GetWindowDrawList().AddLine(WorldPositionToScreenPosition(a), WorldPositionToScreenPosition(b), color, thickness);
+            ImGui.GetWindowDrawList().AddLine(WorldPositionToScreenPosition(a), WorldPositionToScreenPosition(b), ArenaColor.ForType(componentType), thickness);
         }
 
-        public void AddTriangle(WPos p1, WPos p2, WPos p3, uint color, float thickness = 1)
+        public void AddTriangle(WPos p1, WPos p2, WPos p3, ComponentType componentType, float thickness = 1)
         {
-            ImGui.GetWindowDrawList().AddTriangle(WorldPositionToScreenPosition(p1), WorldPositionToScreenPosition(p2), WorldPositionToScreenPosition(p3), color, thickness);
+            ImGui.GetWindowDrawList().AddTriangle(WorldPositionToScreenPosition(p1), WorldPositionToScreenPosition(p2), WorldPositionToScreenPosition(p3), ArenaColor.ForType(componentType), thickness);
         }
 
-        public void AddTriangleFilled(WPos p1, WPos p2, WPos p3, uint color)
+        public void AddTriangleFilled(WPos p1, WPos p2, WPos p3, ComponentType componentType)
         {
-            ImGui.GetWindowDrawList().AddTriangleFilled(WorldPositionToScreenPosition(p1), WorldPositionToScreenPosition(p2), WorldPositionToScreenPosition(p3), color);
+            ImGui.GetWindowDrawList().AddTriangleFilled(WorldPositionToScreenPosition(p1), WorldPositionToScreenPosition(p2), WorldPositionToScreenPosition(p3), ArenaColor.ForType(componentType));
         }
 
-        public void AddQuad(WPos p1, WPos p2, WPos p3, WPos p4, uint color, float thickness = 1)
+        public void AddQuad(WPos p1, WPos p2, WPos p3, WPos p4, ComponentType componentType, float thickness = 1)
         {
-            ImGui.GetWindowDrawList().AddQuad(WorldPositionToScreenPosition(p1), WorldPositionToScreenPosition(p2), WorldPositionToScreenPosition(p3), WorldPositionToScreenPosition(p4), color, thickness);
+            ImGui.GetWindowDrawList().AddQuad(WorldPositionToScreenPosition(p1), WorldPositionToScreenPosition(p2), WorldPositionToScreenPosition(p3), WorldPositionToScreenPosition(p4), ArenaColor.ForType(componentType), thickness);
         }
 
-        public void AddQuadFilled(WPos p1, WPos p2, WPos p3, WPos p4, uint color)
+        public void AddQuadFilled(WPos p1, WPos p2, WPos p3, WPos p4, ComponentType componentType)
         {
-            ImGui.GetWindowDrawList().AddQuadFilled(WorldPositionToScreenPosition(p1), WorldPositionToScreenPosition(p2), WorldPositionToScreenPosition(p3), WorldPositionToScreenPosition(p4), color);
+            ImGui.GetWindowDrawList().AddQuadFilled(WorldPositionToScreenPosition(p1), WorldPositionToScreenPosition(p2), WorldPositionToScreenPosition(p3), WorldPositionToScreenPosition(p4), ArenaColor.ForType(componentType));
         }
 
-        public void AddCircle(WPos center, float radius, uint color, float thickness = 1)
+        public void AddCircle(WPos center, float radius, ComponentType componentType, float thickness = 1)
         {
-            ImGui.GetWindowDrawList().AddCircle(WorldPositionToScreenPosition(center), radius / Bounds.HalfSize * ScreenHalfSize, color, 0, thickness);
+            ImGui.GetWindowDrawList().AddCircle(WorldPositionToScreenPosition(center), radius / Bounds.HalfSize * ScreenHalfSize, ArenaColor.ForType(componentType), 0, thickness);
         }
 
-        public void AddCircleFilled(WPos center, float radius, uint color)
+        public void AddCircleFilled(WPos center, float radius, ComponentType componentType)
         {
-            ImGui.GetWindowDrawList().AddCircleFilled(WorldPositionToScreenPosition(center), radius / Bounds.HalfSize * ScreenHalfSize, color);
+            ImGui.GetWindowDrawList().AddCircleFilled(WorldPositionToScreenPosition(center), radius / Bounds.HalfSize * ScreenHalfSize, ArenaColor.ForType(componentType));
         }
 
-        public void AddCone(WPos center, float radius, Angle centerDirection, Angle halfAngle, uint color, float thickness = 1)
+        public void AddCone(WPos center, float radius, Angle centerDirection, Angle halfAngle, ComponentType componentType, float thickness = 1)
         {
             var sCenter = WorldPositionToScreenPosition(center);
             float sDir = MathF.PI / 2 - centerDirection.Rad + _cameraAzimuth;
             var drawlist = ImGui.GetWindowDrawList();
             drawlist.PathLineTo(sCenter);
             drawlist.PathArcTo(sCenter, radius / Bounds.HalfSize * ScreenHalfSize, sDir - halfAngle.Rad, sDir + halfAngle.Rad);
-            drawlist.PathStroke(color, ImDrawFlags.Closed, thickness);
+            drawlist.PathStroke(ArenaColor.ForType(componentType), ImDrawFlags.Closed, thickness);
         }
 
-        public void AddDonutCone(WPos center, float innerRadius, float outerRadius, Angle centerDirection, Angle halfAngle, uint color, float thickness = 1)
+        public void AddDonutCone(WPos center, float innerRadius, float outerRadius, Angle centerDirection, Angle halfAngle, ComponentType componentType, float thickness = 1)
         {
             var sCenter = WorldPositionToScreenPosition(center);
             float sDir = MathF.PI / 2 - centerDirection.Rad + _cameraAzimuth;
             var drawlist = ImGui.GetWindowDrawList();
             drawlist.PathArcTo(sCenter, innerRadius / Bounds.HalfSize * ScreenHalfSize, sDir + halfAngle.Rad, sDir - halfAngle.Rad);
             drawlist.PathArcTo(sCenter, outerRadius / Bounds.HalfSize * ScreenHalfSize, sDir - halfAngle.Rad, sDir + halfAngle.Rad);
-            drawlist.PathStroke(color, ImDrawFlags.Closed, thickness);
+            drawlist.PathStroke(ArenaColor.ForType(componentType), ImDrawFlags.Closed, thickness);
         }
 
-        public void AddPolygon(IEnumerable<WPos> vertices, uint color, float thickness = 1)
+        public void AddPolygon(IEnumerable<WPos> vertices, ComponentType componentType, float thickness = 1)
         {
             foreach (var p in vertices)
                 PathLineTo(p);
-            PathStroke(true, color, thickness);
+            PathStroke(true, componentType, thickness);
         }
 
         // path api: add new point to path; this adds new edge from last added point, or defines first vertex if path is empty
@@ -157,56 +157,56 @@ namespace BossMod
             ImGui.GetWindowDrawList().PathArcTo(WorldPositionToScreenPosition(center), radius / Bounds.HalfSize * ScreenHalfSize, MathF.PI / 2 - amin + _cameraAzimuth, MathF.PI / 2 - amax + _cameraAzimuth);
         }
 
-        public void PathStroke(bool closed, uint color, float thickness = 1)
+        public void PathStroke(bool closed, ComponentType componentType, float thickness = 1)
         {
-            ImGui.GetWindowDrawList().PathStroke(color, closed ? ImDrawFlags.Closed : ImDrawFlags.None, thickness);
+            ImGui.GetWindowDrawList().PathStroke(ArenaColor.ForType(componentType), closed ? ImDrawFlags.Closed : ImDrawFlags.None, thickness);
         }
 
-        public void PathFillConvex(uint color)
+        public void PathFillConvex(ComponentType componentType)
         {
-            ImGui.GetWindowDrawList().PathFillConvex(color);
+            ImGui.GetWindowDrawList().PathFillConvex(ArenaColor.ForType(componentType));
         }
 
         // draw clipped & triangulated zone
-        public void Zone(List<(WPos, WPos, WPos)> triangulation, uint color)
+        public void Zone(List<(WPos, WPos, WPos)> triangulation, ComponentType componentType)
         {
             var drawlist = ImGui.GetWindowDrawList();
             var restoreFlags = drawlist.Flags;
             drawlist.Flags &= ~ImDrawListFlags.AntiAliasedFill;
             foreach (var (p1, p2, p3) in triangulation)
-                drawlist.AddTriangleFilled(WorldPositionToScreenPosition(p1), WorldPositionToScreenPosition(p2), WorldPositionToScreenPosition(p3), color);
+                drawlist.AddTriangleFilled(WorldPositionToScreenPosition(p1), WorldPositionToScreenPosition(p2), WorldPositionToScreenPosition(p3), ArenaColor.ForType(componentType));
             drawlist.Flags = restoreFlags;
         }
 
         // draw zones - these are filled primitives clipped to various borders
-        public void ZoneCone(WPos center, float innerRadius, float outerRadius, Angle centerDirection, Angle halfAngle, uint color) => Zone(Bounds.ClipAndTriangulateCone(center, innerRadius, outerRadius, centerDirection, halfAngle), color);
-        public void ZoneCircle(WPos center, float radius, uint color) => Zone(Bounds.ClipAndTriangulateCircle(center, radius), color);
-        public void ZoneDonut(WPos center, float innerRadius, float outerRadius, uint color) => Zone(Bounds.ClipAndTriangulateDonut(center, innerRadius, outerRadius), color);
-        public void ZoneTri(WPos a, WPos b, WPos c, uint color) => Zone(Bounds.ClipAndTriangulateTri(a, b, c), color);
-        public void ZoneIsoscelesTri(WPos apex, WDir height, WDir halfBase, uint color) => Zone(Bounds.ClipAndTriangulateIsoscelesTri(apex, height, halfBase), color);
-        public void ZoneIsoscelesTri(WPos apex, Angle direction, Angle halfAngle, float height, uint color) => Zone(Bounds.ClipAndTriangulateIsoscelesTri(apex, direction, halfAngle, height), color);
-        public void ZoneRect(WPos origin, WDir direction, float lenFront, float lenBack, float halfWidth, uint color) => Zone(Bounds.ClipAndTriangulateRect(origin, direction, lenFront, lenBack, halfWidth), color);
-        public void ZoneRect(WPos origin, Angle direction, float lenFront, float lenBack, float halfWidth, uint color) => Zone(Bounds.ClipAndTriangulateRect(origin, direction, lenFront, lenBack, halfWidth), color);
-        public void ZoneRect(WPos start, WPos end, float halfWidth, uint color) => Zone(Bounds.ClipAndTriangulateRect(start, end, halfWidth), color);
+        public void ZoneCone(WPos center, float innerRadius, float outerRadius, Angle centerDirection, Angle halfAngle, ComponentType componentType) => Zone(Bounds.ClipAndTriangulateCone(center, innerRadius, outerRadius, centerDirection, halfAngle), componentType);
+        public void ZoneCircle(WPos center, float radius, ComponentType componentType) => Zone(Bounds.ClipAndTriangulateCircle(center, radius), componentType);
+        public void ZoneDonut(WPos center, float innerRadius, float outerRadius, ComponentType componentType) => Zone(Bounds.ClipAndTriangulateDonut(center, innerRadius, outerRadius), componentType);
+        public void ZoneTri(WPos a, WPos b, WPos c, ComponentType componentType) => Zone(Bounds.ClipAndTriangulateTri(a, b, c), componentType);
+        public void ZoneIsoscelesTri(WPos apex, WDir height, WDir halfBase, ComponentType componentType) => Zone(Bounds.ClipAndTriangulateIsoscelesTri(apex, height, halfBase), componentType);
+        public void ZoneIsoscelesTri(WPos apex, Angle direction, Angle halfAngle, float height, ComponentType componentType) => Zone(Bounds.ClipAndTriangulateIsoscelesTri(apex, direction, halfAngle, height), componentType);
+        public void ZoneRect(WPos origin, WDir direction, float lenFront, float lenBack, float halfWidth, ComponentType componentType) => Zone(Bounds.ClipAndTriangulateRect(origin, direction, lenFront, lenBack, halfWidth), componentType);
+        public void ZoneRect(WPos origin, Angle direction, float lenFront, float lenBack, float halfWidth, ComponentType componentType) => Zone(Bounds.ClipAndTriangulateRect(origin, direction, lenFront, lenBack, halfWidth), componentType);
+        public void ZoneRect(WPos start, WPos end, float halfWidth, ComponentType componentType) => Zone(Bounds.ClipAndTriangulateRect(start, end, halfWidth), componentType);
 
-        public void TextScreen(Vector2 center, string text, uint color, float fontSize = 17)
+        public void TextScreen(Vector2 center, string text, ComponentType componentType, float fontSize = 17)
         {
             var size = ImGui.CalcTextSize(text) * Config.ArenaScale;
-            ImGui.GetWindowDrawList().AddText(ImGui.GetFont(), fontSize * Config.ArenaScale, center - size / 2, color, text);
+            ImGui.GetWindowDrawList().AddText(ImGui.GetFont(), fontSize * Config.ArenaScale, center - size / 2, ArenaColor.ForType(componentType), text);
         }
 
-        public void TextWorld(WPos center, string text, uint color, float fontSize = 17)
+        public void TextWorld(WPos center, string text, ComponentType componentType, float fontSize = 17)
         {
-            TextScreen(WorldPositionToScreenPosition(center), text, color, fontSize);
+            TextScreen(WorldPositionToScreenPosition(center), text, componentType, fontSize);
         }
 
         // high level utilities
         // draw arena border
-        public void Border(uint color)
+        public void Border(ComponentType componentType)
         {
             foreach (var p in Bounds.ClipPoly)
                 PathLineTo(p);
-            PathStroke(true, color, 2);
+            PathStroke(true, componentType, 2);
         }
 
         public void CardinalNames()
@@ -214,38 +214,38 @@ namespace BossMod
             var offCenter = ScreenHalfSize + ScreenMarginSize / 2;
             var offS = RotatedCoords(new(0, offCenter));
             var offE = RotatedCoords(new(offCenter, 0));
-            TextScreen(ScreenCenter - offS, "N", ArenaColor.Border);
-            TextScreen(ScreenCenter + offS, "S", ArenaColor.Border);
-            TextScreen(ScreenCenter + offE, "E", ArenaColor.Border);
-            TextScreen(ScreenCenter - offE, "W", ArenaColor.Border);
+            TextScreen(ScreenCenter - offS, "N", ComponentType.Border);
+            TextScreen(ScreenCenter + offS, "S", ComponentType.Border);
+            TextScreen(ScreenCenter + offE, "E", ComponentType.Border);
+            TextScreen(ScreenCenter - offE, "W", ComponentType.Border);
         }
 
         // draw actor representation
-        public void Actor(WPos position, Angle rotation, uint color)
+        public void Actor(WPos position, Angle rotation, ComponentType componentType)
         {
             var dir = rotation.ToDirection();
             var normal = dir.OrthoR();
             if (Bounds.Contains(position))
             {
-                AddTriangleFilled(position + 0.7f * dir, position - 0.35f * dir + 0.433f * normal, position - 0.35f * dir - 0.433f * normal, color);
+                AddTriangleFilled(position + 0.7f * dir, position - 0.35f * dir + 0.433f * normal, position - 0.35f * dir - 0.433f * normal, componentType);
             }
             else
             {
                 position = Bounds.ClampToBounds(position);
-                AddTriangle(position + 0.7f * dir, position - 0.35f * dir + 0.433f * normal, position - 0.35f * dir - 0.433f * normal, color);
+                AddTriangle(position + 0.7f * dir, position - 0.35f * dir + 0.433f * normal, position - 0.35f * dir - 0.433f * normal, componentType);
             }
         }
 
-        public void Actor(Actor? actor, uint color, bool allowDeadAndUntargetable = false)
+        public void Actor(Actor? actor, ComponentType componentType, bool allowDeadAndUntargetable = false)
         {
             if (actor != null && !actor.IsDestroyed && (allowDeadAndUntargetable || actor.IsTargetable && !actor.IsDead))
-                Actor(actor.Position, actor.Rotation, color);
+                Actor(actor.Position, actor.Rotation, componentType);
         }
 
-        public void Actors(IEnumerable<Actor> actors, uint color, bool allowDeadAndUntargetable = false)
+        public void Actors(IEnumerable<Actor> actors, ComponentType componentType, bool allowDeadAndUntargetable = false)
         {
             foreach (var a in actors)
-                Actor(a, color, allowDeadAndUntargetable);
+                Actor(a, componentType, allowDeadAndUntargetable);
         }
 
         public void End()

--- a/BossMod/Components/Adds.cs
+++ b/BossMod/Components/Adds.cs
@@ -24,7 +24,7 @@ namespace BossMod.Components
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
-            arena.Actors(_actors, ArenaColor.Enemy);
+            arena.Actors(_actors, ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Components/BaitAway.cs
+++ b/BossMod/Components/BaitAway.cs
@@ -66,7 +66,7 @@ namespace BossMod.Components
                 hints.Add("GTFO from baited aoe!");
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return ActiveBaitsOn(player).Any() ? BaiterPriority : PlayerPriority.Irrelevant;
         }
@@ -126,7 +126,7 @@ namespace BossMod.Components
             base.DrawArenaForeground(module, pcSlot, pc, arena);
             if (DrawTethers)
                 foreach (var b in ActiveBaits)
-                    arena.AddLine(b.Source.Position, b.Target.Position, ArenaColor.Danger);
+                    arena.AddLine(b.Source.Position, b.Target.Position, ComponentType.Danger);
         }
 
         public override void OnTethered(BossModule module, Actor source, ActorTetherInfo tether)

--- a/BossMod/Components/DirectionalParry.cs
+++ b/BossMod/Components/DirectionalParry.cs
@@ -90,16 +90,16 @@ namespace BossMod.Components
         private void DrawParry(MiniArena arena, Actor actor, Angle offset, Side active, Side imminent, Side check)
         {
             if (active.HasFlag(check))
-                DrawParry(arena, actor, offset, ArenaColor.Enemy);
+                DrawParry(arena, actor, offset, ComponentType.ActorEnemy);
             else if (imminent.HasFlag(check))
-                DrawParry(arena, actor, offset, ArenaColor.Danger);
+                DrawParry(arena, actor, offset, ComponentType.Danger);
         }
 
-        private void DrawParry(MiniArena arena, Actor actor, Angle offset, uint color)
+        private void DrawParry(MiniArena arena, Actor actor, Angle offset, ComponentType type)
         {
             var dir = actor.Rotation + offset;
             arena.PathArcTo(actor.Position, 1.5f, (dir - 45.Degrees()).Rad, (dir + 45.Degrees()).Rad);
-            arena.PathStroke(false, color);
+            arena.PathStroke(false, type);
         }
 
         private int ActorState(ulong instanceID) => _actorStates.GetValueOrDefault(instanceID, 0);

--- a/BossMod/Components/Exaflare.cs
+++ b/BossMod/Components/Exaflare.cs
@@ -18,8 +18,8 @@ namespace BossMod.Components
         }
 
         public AOEShape Shape { get; private init; }
-        public uint ImminentColor = ArenaColor.Danger;
-        public uint FutureColor = ArenaColor.AOE;
+        public ComponentType ImminentType = ComponentType.Danger;
+        public ComponentType FutureType = ComponentType.AOE;
         protected List<Line> Lines = new();
 
         public bool Active => Lines.Count > 0;
@@ -33,9 +33,9 @@ namespace BossMod.Components
         public override IEnumerable<AOEInstance> ActiveAOEs(BossModule module, int slot, Actor actor)
         {
             foreach (var (c, t) in FutureAOEs(module.WorldState.CurrentTime))
-                yield return new(Shape, c, activation: t, color: FutureColor);
+                yield return new(Shape, c, activation: t, type: FutureType);
             foreach (var (c, t) in ImminentAOEs())
-                yield return new(Shape, c, activation: t, color: ImminentColor);
+                yield return new(Shape, c, activation: t, type: ImminentType);
         }
 
         protected IEnumerable<(WPos, DateTime)> ImminentAOEs() => Lines.Where(l => l.ExplosionsLeft > 0).Select(l => (l.Next, l.NextExplosion));

--- a/BossMod/Components/ForcedMarch.cs
+++ b/BossMod/Components/ForcedMarch.cs
@@ -36,8 +36,8 @@ namespace BossMod.Components
         {
             foreach (var m in ForcedMovements(module, pc))
             {
-                arena.AddLine(m.from, m.to, ArenaColor.Danger);
-                arena.Actor(m.to, m.dir, ArenaColor.Danger);
+                arena.AddLine(m.from, m.to, ComponentType.Danger);
+                arena.Actor(m.to, m.dir, ComponentType.Danger);
             }
         }
 

--- a/BossMod/Components/Gaze.cs
+++ b/BossMod/Components/Gaze.cs
@@ -70,14 +70,14 @@ namespace BossMod.Components
                 var dl = ImGui.GetWindowDrawList();
                 dl.PathArcTo(eyeCenter - new Vector2(0, _eyeOffsetV), _eyeOuterR, MathF.PI / 2 + _eyeHalfAngle, MathF.PI / 2 - _eyeHalfAngle);
                 dl.PathArcTo(eyeCenter + new Vector2(0, _eyeOffsetV), _eyeOuterR, -MathF.PI / 2 + _eyeHalfAngle, -MathF.PI / 2 - _eyeHalfAngle);
-                dl.PathFillConvex(danger ? ArenaColor.Enemy : ArenaColor.PC);
-                dl.AddCircleFilled(eyeCenter, _eyeInnerR, ArenaColor.Border);
+                dl.PathFillConvex(ArenaColor.ForType(danger ? ComponentType.ActorEnemy : ComponentType.ActorYou));
+                dl.AddCircleFilled(eyeCenter, _eyeInnerR, ArenaColor.ForType(ComponentType.Border));
 
                 if (eye.Risky)
                 {
                     var (min, max) = Inverted ? (45, 315) : (-45, 45);
                     arena.PathArcTo(pc.Position, 1, (pc.Rotation + eye.Forward + min.Degrees()).Rad, (pc.Rotation + eye.Forward + max.Degrees()).Rad);
-                    arena.PathStroke(false, ArenaColor.Enemy);
+                    arena.PathStroke(false, ComponentType.ActorEnemy);
                 }
             }
         }

--- a/BossMod/Components/GenericAOEs.cs
+++ b/BossMod/Components/GenericAOEs.cs
@@ -13,16 +13,16 @@ namespace BossMod.Components
             public WPos Origin;
             public Angle Rotation;
             public DateTime Activation;
-            public uint Color;
+            public ComponentType Type;
             public bool Risky;
 
-            public AOEInstance(AOEShape shape, WPos origin, Angle rotation = new(), DateTime activation = new(), uint color = ArenaColor.AOE, bool risky = true)
+            public AOEInstance(AOEShape shape, WPos origin, Angle rotation = new(), DateTime activation = new(), ComponentType type = ComponentType.AOE, bool risky = true)
             {
                 Shape = shape;
                 Origin = origin;
                 Rotation = rotation;
                 Activation = activation;
-                Color = color;
+                Type = type;
                 Risky = risky;
             }
 
@@ -54,7 +54,7 @@ namespace BossMod.Components
         public override void DrawArenaBackground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var c in ActiveAOEs(module, pcSlot, pc))
-                c.Shape.Draw(arena, c.Origin, c.Rotation, c.Color);
+                c.Shape.Draw(arena, c.Origin, c.Rotation, c.Type);
         }
     }
 
@@ -63,7 +63,7 @@ namespace BossMod.Components
     {
         public AOEShape Shape { get; private init; }
         public int MaxCasts; // used for staggered aoes, when showing all active would be pointless
-        public uint Color = ArenaColor.AOE; // can be customized if needed
+        public ComponentType Type = ComponentType.AOE; // can be customized if needed
         public bool Risky = true; // can be customized if needed
         private List<Actor> _casters = new();
         public IReadOnlyList<Actor> Casters => _casters;
@@ -77,7 +77,7 @@ namespace BossMod.Components
 
         public override IEnumerable<AOEInstance> ActiveAOEs(BossModule module, int slot, Actor actor)
         {
-            return ActiveCasters.Select(c => new AOEInstance(Shape, c.Position, c.CastInfo!.Rotation, c.CastInfo.FinishAt, Color, Risky));
+            return ActiveCasters.Select(c => new AOEInstance(Shape, c.Position, c.CastInfo!.Rotation, c.CastInfo.FinishAt, Type, Risky));
         }
 
         public override void OnCastStarted(BossModule module, Actor caster, ActorCastInfo spell)
@@ -131,7 +131,7 @@ namespace BossMod.Components
     {
         public AOEShapeCircle Shape { get; private init; }
         public int MaxCasts { get; private init; } // used for staggered aoes, when showing all active would be pointless
-        public uint Color = ArenaColor.AOE; // can be customized if needed
+        public ComponentType Type = ComponentType.AOE; // can be customized if needed
         public bool Risky = true; // can be customized if needed
         private List<Actor> _casters = new();
         public IReadOnlyList<Actor> Casters => _casters;
@@ -146,7 +146,7 @@ namespace BossMod.Components
         public override IEnumerable<AOEInstance> ActiveAOEs(BossModule module, int slot, Actor actor)
         {
             foreach (var c in ActiveCasters)
-                yield return new(Shape, c.CastInfo!.LocXZ, c.CastInfo.Rotation, c.CastInfo.FinishAt, Color, Risky);
+                yield return new(Shape, c.CastInfo!.LocXZ, c.CastInfo.Rotation, c.CastInfo.FinishAt, Type, Risky);
         }
 
         public override void OnCastStarted(BossModule module, Actor caster, ActorCastInfo spell)

--- a/BossMod/Components/Knockback.cs
+++ b/BossMod/Components/Knockback.cs
@@ -49,8 +49,8 @@ namespace BossMod.Components
         {
             if (from != to)
             {
-                arena.Actor(to, rot, ArenaColor.Danger);
-                arena.AddLine(from, to, ArenaColor.Danger);
+                arena.Actor(to, rot, ComponentType.Danger);
+                arena.AddLine(from, to, ComponentType.Danger);
             }
         }
         public static void DrawKnockback(Actor actor, WPos adjPos, MiniArena arena) => DrawKnockback(actor.Position, adjPos, actor.Rotation, arena);

--- a/BossMod/Components/LineOfSightAOE.cs
+++ b/BossMod/Components/LineOfSightAOE.cs
@@ -82,9 +82,9 @@ namespace BossMod.Components
             // TODO: reconsider, this looks like shit...
             if (Origin != null)
             {
-                arena.ZoneDonut(Origin.Value, MaxRange, 1000, ArenaColor.SafeFromAOE);
+                arena.ZoneDonut(Origin.Value, MaxRange, 1000, ComponentType.SafeFromAOE);
                 foreach (var v in Visibility)
-                    arena.ZoneCone(Origin.Value, v.Distance, 1000, v.Dir, v.HalfWidth, ArenaColor.SafeFromAOE);
+                    arena.ZoneCone(Origin.Value, v.Distance, 1000, v.Dir, v.HalfWidth, ComponentType.SafeFromAOE);
             }
         }
     }

--- a/BossMod/Components/Protean.cs
+++ b/BossMod/Components/Protean.cs
@@ -22,7 +22,7 @@ namespace BossMod.Components
                 hints.Add("GTFO from protean!");
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             var playerProteanSource = player != pc ? ActiveAOEs(module).FirstOrDefault(st => st.target == player).source : null;
             return playerProteanSource == null ? PlayerPriority.Irrelevant : IsPlayerClipped(playerProteanSource, player, pc) ? PlayerPriority.Danger : PlayerPriority.Normal;

--- a/BossMod/Components/RotatingAOE.cs
+++ b/BossMod/Components/RotatingAOE.cs
@@ -19,8 +19,8 @@ namespace BossMod.Components
         );
 
         public List<Sequence> Sequences = new();
-        public uint ImminentColor = ArenaColor.Danger;
-        public uint FutureColor = ArenaColor.AOE;
+        public ComponentType ImminentType = ComponentType.Danger;
+        public ComponentType FutureType = ComponentType.AOE;
 
         public override IEnumerable<AOEInstance> ActiveAOEs(BossModule module, int slot, Actor actor)
         {
@@ -34,14 +34,14 @@ namespace BossMod.Components
                 {
                     rot += s.Increment;
                     time = time.AddSeconds(s.SecondsBetweenActivations);
-                    yield return new(s.Shape, s.Origin, rot, time, FutureColor);
+                    yield return new(s.Shape, s.Origin, rot, time, FutureType);
                 }
             }
 
             // imminent AOEs
             foreach (var s in Sequences)
                 if (s.NumRemainingCasts > 0)
-                    yield return new(s.Shape, s.Origin, s.Rotation, s.NextActivation, ImminentColor);
+                    yield return new(s.Shape, s.Origin, s.Rotation, s.NextActivation, ImminentType);
         }
 
         public void AdvanceSequence(int index, DateTime currentTime, bool removeWhenFinished = true)

--- a/BossMod/Components/SharedTankbuster.cs
+++ b/BossMod/Components/SharedTankbuster.cs
@@ -54,7 +54,7 @@ namespace BossMod.Components
             }
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return Target == player ? PlayerPriority.Interesting : PlayerPriority.Irrelevant;
         }

--- a/BossMod/Components/StackSpread.cs
+++ b/BossMod/Components/StackSpread.cs
@@ -157,13 +157,13 @@ namespace BossMod.Components
             }
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             var shouldSpread = IsSpreadTarget(player);
             var shouldStack = IsStackTarget(player);
             var shouldAvoid = !shouldSpread && !shouldStack && ActiveStacks.Any(s => s.ForbiddenPlayers[playerSlot]);
             if (shouldAvoid)
-                customColor = ArenaColor.Vulnerable;
+                type = ComponentType.ActorVulnerable;
             return shouldAvoid || shouldSpread ? PlayerPriority.Danger
                 : shouldStack ? PlayerPriority.Interesting
                 : Active ? PlayerPriority.Normal : PlayerPriority.Irrelevant;
@@ -174,15 +174,15 @@ namespace BossMod.Components
             if (!AlwaysShowSpreads && Spreads.FindIndex(s => s.Target == pc) is var iSpread && iSpread >= 0)
             {
                 // draw only own circle - no one should be inside, this automatically resolves mechanic for us
-                arena.AddCircle(pc.Position, Spreads[iSpread].Radius, ArenaColor.Danger);
+                arena.AddCircle(pc.Position, Spreads[iSpread].Radius, ComponentType.Danger);
             }
             else
             {
                 // draw spread and stack circles
                 foreach (var s in ActiveStacks)
-                    arena.AddCircle(s.Target.Position, s.Radius, ArenaColor.Safe);
+                    arena.AddCircle(s.Target.Position, s.Radius, ComponentType.Safe);
                 foreach (var s in ActiveSpreads)
-                    arena.AddCircle(s.Target.Position, s.Radius, ArenaColor.Danger);
+                    arena.AddCircle(s.Target.Position, s.Radius, ComponentType.Danger);
             }
         }
     }

--- a/BossMod/Components/TankbusterTether.cs
+++ b/BossMod/Components/TankbusterTether.cs
@@ -60,7 +60,7 @@ namespace BossMod.Components
             }
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             if (_tetheredPlayers[playerSlot])
                 return PlayerPriority.Danger;
@@ -78,8 +78,8 @@ namespace BossMod.Components
             // show tethered targets with circles
             foreach (var side in _tethers)
             {
-                arena.AddLine(side.Enemy.Position, side.Player.Position, side.Player.Role == Role.Tank ? ArenaColor.Safe : ArenaColor.Danger);
-                arena.AddCircle(side.Player.Position, Radius, ArenaColor.Danger);
+                arena.AddLine(side.Enemy.Position, side.Player.Position, side.Player.Role == Role.Tank ? ComponentType.Safe : ComponentType.Danger);
+                arena.AddCircle(side.Player.Position, Radius, ComponentType.Danger);
             }
         }
 

--- a/BossMod/Components/Towers.cs
+++ b/BossMod/Components/Towers.cs
@@ -31,7 +31,7 @@ namespace BossMod.Components
         public List<Tower> Towers = new();
 
         // default tower styling
-        public static void DrawTower(MiniArena arena, WPos pos, float radius, bool safe) => arena.AddCircle(pos, radius, safe ? ArenaColor.Safe : ArenaColor.Danger, 2);
+        public static void DrawTower(MiniArena arena, WPos pos, float radius, bool safe) => arena.AddCircle(pos, radius, safe ? ComponentType.Safe : ComponentType.Danger, 2);
 
         public GenericTowers(ActionID aid = default) : base(aid) { }
 

--- a/BossMod/Components/WildCharge.cs
+++ b/BossMod/Components/WildCharge.cs
@@ -75,7 +75,7 @@ namespace BossMod.Components
                 var dir = target.Position - Source.Position;
                 var length = FixedLength > 0 ? FixedLength : dir.Length();
                 dir = dir.Normalized();
-                arena.ZoneRect(Source.Position, dir, length, 0, HalfWidth, PlayerRoles[pcSlot] == PlayerRole.Avoid ? ArenaColor.AOE : ArenaColor.SafeFromAOE);
+                arena.ZoneRect(Source.Position, dir, length, 0, HalfWidth, PlayerRoles[pcSlot] == PlayerRole.Avoid ? ComponentType.AOE : ComponentType.SafeFromAOE);
             }
         }
 

--- a/BossMod/Debug/DebugCollision.cs
+++ b/BossMod/Debug/DebugCollision.cs
@@ -369,7 +369,7 @@ namespace BossMod
         private void DrawObject(CollisionObjectBase* obj)
         {
             var type = obj->Vtbl->GetObjectType(obj);
-            foreach (var n3 in _tree.Node($"{type} {(nint)obj:X}, layers={obj->LayerMask:X8}, refs={obj->NumRefs}", color: _slaveShapes.Contains((nint)obj) ? ArenaColor.Safe : 0xffffffff, select: MakeSelect(() => VisualizeObject(obj), obj)))
+            foreach (var n3 in _tree.Node($"{type} {(nint)obj:X}, layers={obj->LayerMask:X8}, refs={obj->NumRefs}", color: _slaveShapes.Contains((nint)obj) ? 0xff00ff00 : 0xffffffff, select: MakeSelect(() => VisualizeObject(obj), obj)))
             {
                 switch (type)
                 {
@@ -526,12 +526,12 @@ namespace BossMod
             _drawExtra = (sel, (nint)ctx);
         };
 
-        private void VisualizeSphere(Vector4 sphere) => Camera.Instance?.DrawWorldSphere(new(sphere.X, sphere.Y, sphere.Z), sphere.W, ArenaColor.Safe);
-        private void VisualizeAABB(Vector3 min, Vector3 max) => Camera.Instance?.DrawWorldOBB(min, max, SharpDX.Matrix.Identity, ArenaColor.Safe);
-        private void VisualizeOBB(Vector3 min, Vector3 max, CollisionObjectShape* obj) => Camera.Instance?.DrawWorldOBB(min, max, obj->World.M, ArenaColor.Safe);
-        private void VisualizeVertex(Vector3 v, CollisionObjectShape* obj) => Camera.Instance?.DrawWorldSphere(SharpDX.Vector3.TransformCoordinate(new(v.X, v.Y, v.Z), obj->World.M).ToSystem(), 0.1f, ArenaColor.Danger);
+        private void VisualizeSphere(Vector4 sphere) => Camera.Instance?.DrawWorldSphere(new(sphere.X, sphere.Y, sphere.Z), sphere.W, 0xff00ff00);
+        private void VisualizeAABB(Vector3 min, Vector3 max) => Camera.Instance?.DrawWorldOBB(min, max, SharpDX.Matrix.Identity, 0xff00ff00);
+        private void VisualizeOBB(Vector3 min, Vector3 max, CollisionObjectShape* obj) => Camera.Instance?.DrawWorldOBB(min, max, obj->World.M, 0xff00ff00);
+        private void VisualizeVertex(Vector3 v, CollisionObjectShape* obj) => Camera.Instance?.DrawWorldSphere(SharpDX.Vector3.TransformCoordinate(new(v.X, v.Y, v.Z), obj->World.M).ToSystem(), 0.1f, 0xff00ffff);
 
-        private void VisualizePrimitive(CollisionShapePCBData* data, int iPrim, CollisionObjectShape* obj, uint color = ArenaColor.Danger)
+        private void VisualizePrimitive(CollisionShapePCBData* data, int iPrim, CollisionObjectShape* obj, uint color = 0xff00ffff)
         {
             var pRaw = (float*)(data + 1);
             var pCompr = (ushort*)(pRaw + 3 * data->NumVertsRaw);
@@ -549,7 +549,7 @@ namespace BossMod
             Camera.Instance?.DrawWorldLine(w3, w1, color);
         }
 
-        private void VisualizeShape(CollisionShapePCBData* data, CollisionObjectShape* obj, uint color = ArenaColor.Danger)
+        private void VisualizeShape(CollisionShapePCBData* data, CollisionObjectShape* obj, uint color = 0xff00ffff)
         {
             for (int i = 0; i < data->NumPrims; ++i)
                 VisualizePrimitive(data, i, obj, color);
@@ -572,7 +572,7 @@ namespace BossMod
                             {
                                 var elem = castObj->Elements + i;
                                 if (elem->Shape != null && elem->Shape->Shape != null && (nint)elem->Shape->Shape->Vtbl == _typeinfoCollisionShapePCB && elem->Shape->Shape->Data != null)
-                                    VisualizeShape(elem->Shape->Shape->Data, elem->Shape, ArenaColor.Safe);
+                                    VisualizeShape(elem->Shape->Shape->Data, elem->Shape, 0xff00ff00);
                             }
                         }
                     }
@@ -581,25 +581,25 @@ namespace BossMod
                     {
                         var castObj = (CollisionObjectShape*)obj;
                         if (castObj->Shape != null && (nint)castObj->Shape->Vtbl == _typeinfoCollisionShapePCB && castObj->Shape->Data != null)
-                            VisualizeShape(castObj->Shape->Data, castObj, _slaveShapes.Contains((nint)obj) ? ArenaColor.Safe : ArenaColor.Danger);
+                            VisualizeShape(castObj->Shape->Data, castObj, _slaveShapes.Contains((nint)obj) ? 0xff00ff00 : 0xff00ffff);
                     }
                     break;
                 case CollisionObjectType.Box:
                     {
                         var castObj = (CollisionObjectBox*)obj;
-                        Camera.Instance?.DrawWorldOBB(new(-1), new(+1), castObj->World.M, ArenaColor.Enemy);
+                        Camera.Instance?.DrawWorldOBB(new(-1), new(+1), castObj->World.M, 0xff0000ff);
                     }
                     break;
                 case CollisionObjectType.Cylinder:
                     {
                         var castObj = (CollisionObjectCylinder*)obj;
-                        Camera.Instance?.DrawWorldUnitCylinder(castObj->World.M, ArenaColor.Enemy);
+                        Camera.Instance?.DrawWorldUnitCylinder(castObj->World.M, 0xff0000ff);
                     }
                     break;
                 case CollisionObjectType.Sphere:
                     {
                         var castObj = (CollisionObjectSphere*)obj;
-                        Camera.Instance?.DrawWorldSphere(castObj->Translation, castObj->Scale.X, ArenaColor.Enemy);
+                        Camera.Instance?.DrawWorldSphere(castObj->Translation, castObj->Scale.X, 0xff0000ff);
                     }
                     break;
                 case CollisionObjectType.Plane:
@@ -611,10 +611,10 @@ namespace BossMod
                         var b = SharpDX.Vector3.TransformCoordinate(new(-1, -1, 0), m).ToSystem();
                         var c = SharpDX.Vector3.TransformCoordinate(new(+1, -1, 0), m).ToSystem();
                         var d = SharpDX.Vector3.TransformCoordinate(new(+1, +1, 0), m).ToSystem();
-                        Camera.Instance?.DrawWorldLine(a, b, ArenaColor.Enemy);
-                        Camera.Instance?.DrawWorldLine(b, c, ArenaColor.Enemy);
-                        Camera.Instance?.DrawWorldLine(c, d, ArenaColor.Enemy);
-                        Camera.Instance?.DrawWorldLine(d, a, ArenaColor.Enemy);
+                        Camera.Instance?.DrawWorldLine(a, b, 0xff0000ff);
+                        Camera.Instance?.DrawWorldLine(b, c, 0xff0000ff);
+                        Camera.Instance?.DrawWorldLine(c, d, 0xff0000ff);
+                        Camera.Instance?.DrawWorldLine(d, a, 0xff0000ff);
                     }
                     break;
             }

--- a/BossMod/Debug/DebugGraphics.cs
+++ b/BossMod/Debug/DebugGraphics.cs
@@ -293,12 +293,12 @@ namespace BossMod
             for (int ix = -mx; ix <= mx; ++ix)
             {
                 var x = _overlayCenter.X + ix * _overlayStep.X;
-                Camera.Instance.DrawWorldLine(new(x, y, _overlayCenter.Y - _overlayMaxOffset.Y), new(x, y, _overlayCenter.Y + _overlayMaxOffset.Y), ArenaColor.PC);
+                Camera.Instance.DrawWorldLine(new(x, y, _overlayCenter.Y - _overlayMaxOffset.Y), new(x, y, _overlayCenter.Y + _overlayMaxOffset.Y), 0xff00ff00);
             }
             for (int iz = -mz; iz <= mz; ++iz)
             {
                 var z = _overlayCenter.Y + iz * _overlayStep.Y;
-                Camera.Instance.DrawWorldLine(new(_overlayCenter.X - _overlayMaxOffset.X, y, z), new(_overlayCenter.X + _overlayMaxOffset.X, y, z), ArenaColor.PC);
+                Camera.Instance.DrawWorldLine(new(_overlayCenter.X - _overlayMaxOffset.X, y, z), new(_overlayCenter.X + _overlayMaxOffset.X, y, z), 0xff00ff00);
             }
         }
 

--- a/BossMod/Modules/DemoModule.cs
+++ b/BossMod/Modules/DemoModule.cs
@@ -9,7 +9,7 @@
                 hints.Add("Hint", false);
                 hints.Add("Risk");
                 if (movementHints != null)
-                    movementHints.Add(actor.Position, actor.Position + new WDir(10, 10), ArenaColor.Danger);
+                    movementHints.Add(actor.Position, actor.Position + new WDir(10, 10), ComponentType.Danger);
             }
 
             public override void AddGlobalHints(BossModule module, GlobalHints hints)
@@ -19,12 +19,12 @@
 
             public override void DrawArenaBackground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
             {
-                arena.ZoneCircle(module.Bounds.Center, 10, ArenaColor.AOE);
+                arena.ZoneCircle(module.Bounds.Center, 10, ComponentType.AOE);
             }
 
             public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
             {
-                arena.Actor(module.Bounds.Center, 0.Degrees(), ArenaColor.PC);
+                arena.Actor(module.Bounds.Center, 0.Degrees(), ComponentType.ActorYou);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Alliance/A10Lions/A10Lions.cs
+++ b/BossMod/Modules/Endwalker/Alliance/A10Lions/A10Lions.cs
@@ -40,8 +40,8 @@ namespace BossMod.Endwalker.Alliance.A10Lions
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
-            Arena.Actor(_lioness, ArenaColor.Enemy);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
+            Arena.Actor(_lioness, ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/Endwalker/Alliance/A11Byregot/Hammers.cs
+++ b/BossMod/Modules/Endwalker/Alliance/A11Byregot/Hammers.cs
@@ -24,9 +24,9 @@ namespace BossMod.Endwalker.Alliance.A11Byregot
                 for (int x = -2; x <= 2; ++x)
                 {
                     if (CellDangerous(x, z, true))
-                        yield return new(_shape, CellCenter(module, x, z), color: ArenaColor.AOE);
+                        yield return new(_shape, CellCenter(module, x, z), type: ComponentType.AOE);
                     else if (CellDangerous(x, z, false))
-                        yield return new(_shape, CellCenter(module, x, z), color: ArenaColor.SafeFromAOE);
+                        yield return new(_shape, CellCenter(module, x, z), type: ComponentType.SafeFromAOE);
                 }
             }
         }
@@ -36,14 +36,14 @@ namespace BossMod.Endwalker.Alliance.A11Byregot
             if (!Active)
                 return;
 
-            arena.AddLine(module.Bounds.Center + new WDir(-15, -25), module.Bounds.Center + new WDir(-15, +25), ArenaColor.Border);
-            arena.AddLine(module.Bounds.Center + new WDir( -5, -25), module.Bounds.Center + new WDir( -5, +25), ArenaColor.Border);
-            arena.AddLine(module.Bounds.Center + new WDir( +5, -25), module.Bounds.Center + new WDir( +5, +25), ArenaColor.Border);
-            arena.AddLine(module.Bounds.Center + new WDir(+15, -25), module.Bounds.Center + new WDir(+15, +25), ArenaColor.Border);
-            arena.AddLine(module.Bounds.Center + new WDir(-25, -15), module.Bounds.Center + new WDir(+25, -15), ArenaColor.Border);
-            arena.AddLine(module.Bounds.Center + new WDir(-25,  -5), module.Bounds.Center + new WDir(+25,  -5), ArenaColor.Border);
-            arena.AddLine(module.Bounds.Center + new WDir(-25,  +5), module.Bounds.Center + new WDir(+25,  +5), ArenaColor.Border);
-            arena.AddLine(module.Bounds.Center + new WDir(-25, +15), module.Bounds.Center + new WDir(+25, +15), ArenaColor.Border);
+            arena.AddLine(module.Bounds.Center + new WDir(-15, -25), module.Bounds.Center + new WDir(-15, +25), ComponentType.Border);
+            arena.AddLine(module.Bounds.Center + new WDir( -5, -25), module.Bounds.Center + new WDir( -5, +25), ComponentType.Border);
+            arena.AddLine(module.Bounds.Center + new WDir( +5, -25), module.Bounds.Center + new WDir( +5, +25), ComponentType.Border);
+            arena.AddLine(module.Bounds.Center + new WDir(+15, -25), module.Bounds.Center + new WDir(+15, +25), ComponentType.Border);
+            arena.AddLine(module.Bounds.Center + new WDir(-25, -15), module.Bounds.Center + new WDir(+25, -15), ComponentType.Border);
+            arena.AddLine(module.Bounds.Center + new WDir(-25,  -5), module.Bounds.Center + new WDir(+25,  -5), ComponentType.Border);
+            arena.AddLine(module.Bounds.Center + new WDir(-25,  +5), module.Bounds.Center + new WDir(+25,  +5), ComponentType.Border);
+            arena.AddLine(module.Bounds.Center + new WDir(-25, +15), module.Bounds.Center + new WDir(+25, +15), ComponentType.Border);
         }
 
         public override void OnCastStarted(BossModule module, Actor caster, ActorCastInfo spell)

--- a/BossMod/Modules/Endwalker/Alliance/A12Rhalgr/A12Rhalgr.cs
+++ b/BossMod/Modules/Endwalker/Alliance/A12Rhalgr/A12Rhalgr.cs
@@ -41,7 +41,7 @@
             Arena.PathLineTo(new(-45.5f, 297));
             Arena.PathLineTo(new(-34, 271.5f));
             Arena.PathLineTo(new(-37, 245));
-            Arena.PathStroke(true, ArenaColor.Border);
+            Arena.PathStroke(true, ComponentType.Border);
         }
     }
 }

--- a/BossMod/Modules/Endwalker/Alliance/A13Azeyma/WildfireWard.cs
+++ b/BossMod/Modules/Endwalker/Alliance/A13Azeyma/WildfireWard.cs
@@ -18,7 +18,7 @@ namespace BossMod.Endwalker.Alliance.A13Azeyma
 
         public override void DrawArenaBackground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
-            arena.ZoneTri(_tri[0], _tri[1], _tri[2], ArenaColor.SafeFromAOE);
+            arena.ZoneTri(_tri[0], _tri[1], _tri[2], ComponentType.SafeFromAOE);
         }
     }
 }

--- a/BossMod/Modules/Endwalker/Alliance/A14Naldthal/FarAboveDeepBelow.cs
+++ b/BossMod/Modules/Endwalker/Alliance/A14Naldthal/FarAboveDeepBelow.cs
@@ -62,7 +62,7 @@ namespace BossMod.Endwalker.Alliance.A14Naldthal
 
         public override IEnumerable<AOEInstance> ActiveAOEs(BossModule module, int slot, Actor actor) => _casters.Select(c => new AOEInstance(_shape, c.CastInfo!.LocXZ, default, c.CastInfo.FinishAt));
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return _real && _targets.Contains(player) ? PlayerPriority.Danger : PlayerPriority.Irrelevant;
         }
@@ -71,7 +71,7 @@ namespace BossMod.Endwalker.Alliance.A14Naldthal
         {
             if (_real)
                 foreach (var t in _targets)
-                    arena.AddCircle(t.Position, _shape.Radius, ArenaColor.Danger);
+                    arena.AddCircle(t.Position, _shape.Radius, ComponentType.Danger);
         }
 
         public override void OnCastStarted(BossModule module, Actor caster, ActorCastInfo spell)

--- a/BossMod/Modules/Endwalker/Alliance/A22AlthykNymeia/A22AlthykNymeia.cs
+++ b/BossMod/Modules/Endwalker/Alliance/A22AlthykNymeia/A22AlthykNymeia.cs
@@ -31,8 +31,8 @@ namespace BossMod.Endwalker.Alliance.A22AlthykNymeia
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
-            Arena.Actor(_nymeia, ArenaColor.Enemy);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
+            Arena.Actor(_nymeia, ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Dryad.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Dryad.cs
@@ -77,8 +77,8 @@ namespace BossMod.Endwalker.Criterion.C01ASS.C010Dryad
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.NOdqan), ArenaColor.Enemy);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.NOdqan), ComponentType.ActorEnemy);
         }
     }
 
@@ -89,8 +89,8 @@ namespace BossMod.Endwalker.Criterion.C01ASS.C010Dryad
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.SOdqan), ArenaColor.Enemy);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.SOdqan), ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Udumbara.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C010Trash/C010Udumbara.cs
@@ -77,8 +77,8 @@ namespace BossMod.Endwalker.Criterion.C01ASS.C010Udumbara
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.NSapria), ArenaColor.Enemy);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.NSapria), ComponentType.ActorEnemy);
         }
     }
 
@@ -89,8 +89,8 @@ namespace BossMod.Endwalker.Criterion.C01ASS.C010Udumbara
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.SSapria), ArenaColor.Enemy);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.SSapria), ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C011Silkie/PuffTethers.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C011Silkie/PuffTethers.cs
@@ -8,7 +8,7 @@ namespace BossMod.Endwalker.Criterion.C01ASS.C011Silkie
         private PuffTracker? _tracker;
         private SlipperySoap.Color _bossColor;
 
-        private static uint _hintColor = 0x40008080;
+        private static ComponentType _hintType = ComponentType.Hint;
 
         public PuffTethers(bool originAtBoss)
         {
@@ -56,24 +56,24 @@ namespace BossMod.Endwalker.Criterion.C01ASS.C011Silkie
             var moveAngle = Angle.FromDirection(moveDir);
             if (yellow)
             {
-                C011Silkie.ShapeYellow.Draw(module.Arena, movePos, moveAngle + 45.Degrees(), _hintColor);
-                C011Silkie.ShapeYellow.Draw(module.Arena, movePos, moveAngle + 135.Degrees(), _hintColor);
-                C011Silkie.ShapeYellow.Draw(module.Arena, movePos, moveAngle - 135.Degrees(), _hintColor);
-                C011Silkie.ShapeYellow.Draw(module.Arena, movePos, moveAngle - 45.Degrees(), _hintColor);
+                C011Silkie.ShapeYellow.Draw(module.Arena, movePos, moveAngle + 45.Degrees(), _hintType);
+                C011Silkie.ShapeYellow.Draw(module.Arena, movePos, moveAngle + 135.Degrees(), _hintType);
+                C011Silkie.ShapeYellow.Draw(module.Arena, movePos, moveAngle - 135.Degrees(), _hintType);
+                C011Silkie.ShapeYellow.Draw(module.Arena, movePos, moveAngle - 45.Degrees(), _hintType);
             }
             else
             {
-                C011Silkie.ShapeBlue.Draw(module.Arena, movePos, moveAngle, _hintColor);
+                C011Silkie.ShapeBlue.Draw(module.Arena, movePos, moveAngle, _hintType);
             }
 
             var bossOrigin = _originAtBoss ? module.PrimaryActor.Position : module.Bounds.Center;
             switch (_bossColor)
             {
                 case SlipperySoap.Color.Green:
-                    C011Silkie.ShapeGreen.Draw(module.Arena, bossOrigin, new(), _hintColor);
+                    C011Silkie.ShapeGreen.Draw(module.Arena, bossOrigin, new(), _hintType);
                     break;
                 case SlipperySoap.Color.Blue:
-                    C011Silkie.ShapeBlue.Draw(module.Arena, bossOrigin, new(), _hintColor);
+                    C011Silkie.ShapeBlue.Draw(module.Arena, bossOrigin, new(), _hintType);
                     break;
             }
         }
@@ -83,7 +83,7 @@ namespace BossMod.Endwalker.Criterion.C01ASS.C011Silkie
             var source = puffs.Find(p => p.Tether.Target == player.InstanceID);
             if (source != null)
             {
-                module.Arena.AddLine(source.Position, player.Position, ArenaColor.Danger);
+                module.Arena.AddLine(source.Position, player.Position, ComponentType.Danger);
             }
         }
     }

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C011Silkie/PuffTracker.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C011Silkie/PuffTracker.cs
@@ -10,9 +10,9 @@ namespace BossMod.Endwalker.Criterion.C01ASS.C011Silkie
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
-            arena.Actors(BracingPuffs, 0xff80ff80, true);
-            arena.Actors(ChillingPuffs, 0xffff8040, true);
-            arena.Actors(FizzlingPuffs, 0xff40c0c0, true);
+            arena.Actors(BracingPuffs, ComponentType.ActorE, true);
+            arena.Actors(ChillingPuffs, ComponentType.ActorC, true);
+            arena.Actors(FizzlingPuffs, ComponentType.ActorB, true);
         }
 
         public override void OnStatusGain(BossModule module, Actor actor, ActorStatus status)

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C011Silkie/SlipperySoap.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C011Silkie/SlipperySoap.cs
@@ -65,7 +65,7 @@ namespace BossMod.Endwalker.Criterion.C01ASS.C011Silkie
         public override void DrawArenaBackground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (_chargeTarget != null)
-                _chargeShape.Draw(arena, module.PrimaryActor.Position, _chargeDir, ArenaColor.SafeFromAOE);
+                _chargeShape.Draw(arena, module.PrimaryActor.Position, _chargeDir, ComponentType.SafeFromAOE);
         }
 
         public override void OnStatusGain(BossModule module, Actor actor, ActorStatus status)

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C012Gladiator/CurseOfTheMonument.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C012Gladiator/CurseOfTheMonument.cs
@@ -32,7 +32,7 @@ namespace BossMod.Endwalker.Criterion.C01ASS.C012Gladiator
             base.DrawArenaForeground(module, pcSlot, pc, arena);
             if (!IsSpreadTarget(pc))
                 foreach (var t in ActiveTowers(_second[pcSlot]))
-                    arena.AddCircle(t.Position, _towerRadius, ArenaColor.Safe, 2);
+                    arena.AddCircle(t.Position, _towerRadius, ComponentType.Safe, 2);
         }
 
         public override void OnStatusGain(BossModule module, Actor actor, ActorStatus status)

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C012Gladiator/WrathOfRuin.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C012Gladiator/WrathOfRuin.cs
@@ -28,7 +28,7 @@ namespace BossMod.Endwalker.Criterion.C01ASS.C012Gladiator
         {
             if (Active)
                 foreach (var c in SafeCenters(module, _debuffs[pcSlot]))
-                    arena.ZoneRect(c, new WDir(1, 0), _shape.HalfWidth, _shape.HalfWidth, _shape.HalfWidth, ArenaColor.SafeFromAOE);
+                    arena.ZoneRect(c, new WDir(1, 0), _shape.HalfWidth, _shape.HalfWidth, _shape.HalfWidth, ComponentType.SafeFromAOE);
         }
 
         public override void OnStatusGain(BossModule module, Actor actor, ActorStatus status)

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C013Shadowcaster/CrypticFlames.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C013Shadowcaster/CrypticFlames.cs
@@ -23,7 +23,7 @@ namespace BossMod.Endwalker.Criterion.C01ASS.C013Shadowcaster
             {
                 var dir = l.laser.Rotation.ToDirection();
                 var extent = 2 * dir * dir.Dot(module.Bounds.Center - l.laser.Position);
-                var color = l.order != _playerOrder[pcSlot] ? ArenaColor.Enemy : order == CurrentBreakOrder ? ArenaColor.Safe : ArenaColor.Danger;
+                var color = l.order != _playerOrder[pcSlot] ? ComponentType.ActorEnemy : order == CurrentBreakOrder ? ComponentType.Safe : ComponentType.Danger;
                 arena.AddLine(l.laser.Position, l.laser.Position + extent, color, 2);
             }
         }

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C013Shadowcaster/FiresteelStrike.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C013Shadowcaster/FiresteelStrike.cs
@@ -34,10 +34,10 @@ namespace BossMod.Endwalker.Criterion.C01ASS.C013Shadowcaster
             }
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             if (NumJumps < 2)
-                return base.CalcPriority(module, pcSlot, pc, playerSlot, player, ref customColor);
+                return base.CalcPriority(module, pcSlot, pc, playerSlot, player, ref type);
             else if (NumCleaves < _jumpTargets.Count)
                 return player == _jumpTargets[NumCleaves] ? PlayerPriority.Danger : PlayerPriority.Normal;
             else
@@ -49,7 +49,7 @@ namespace BossMod.Endwalker.Criterion.C01ASS.C013Shadowcaster
             if (NumJumps >= 2 && NumCleaves < _jumpTargets.Count)
             {
                 var target = _jumpTargets[NumCleaves];
-                _cleaveShape.Draw(arena, module.PrimaryActor.Position, Angle.FromDirection(target.Position - module.PrimaryActor.Position), target == pc || _interceptors.Contains(pc) ? ArenaColor.SafeFromAOE : ArenaColor.AOE);
+                _cleaveShape.Draw(arena, module.PrimaryActor.Position, Angle.FromDirection(target.Position - module.PrimaryActor.Position), target == pc || _interceptors.Contains(pc) ? ComponentType.SafeFromAOE : ComponentType.AOE);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C013Shadowcaster/InfernWave.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C013Shadowcaster/InfernWave.cs
@@ -97,7 +97,7 @@ namespace BossMod.Endwalker.Criterion.C01ASS.C013Shadowcaster
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var b in ActiveBeacons())
-                arena.Actor(b.Source, ArenaColor.Object, true);
+                arena.Actor(b.Source, ComponentType.ActorObject, true);
         }
 
         public override void OnEventCast(BossModule module, Actor caster, ActorCastEvent spell)

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C013Shadowcaster/Portals.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C013Shadowcaster/Portals.cs
@@ -83,7 +83,7 @@ namespace BossMod.Endwalker.Criterion.C01ASS.C013Shadowcaster
             {
                 foreach (var p in _portals)
                 {
-                    arena.AddCircle(dir > 0 ? p.s : p.n, 1, ArenaColor.Safe, 2);
+                    arena.AddCircle(dir > 0 ? p.s : p.n, 1, ComponentType.Safe, 2);
                 }
             }
         }

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C020Trash/C020Fuko.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C020Trash/C020Fuko.cs
@@ -89,9 +89,9 @@
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.NPenghou), ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.NYuki), ArenaColor.Object);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.NPenghou), ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.NYuki), ComponentType.ActorObject);
         }
     }
 
@@ -102,9 +102,9 @@
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.SPenghou), ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.SYuki), ArenaColor.Object);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.SPenghou), ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.SYuki), ComponentType.ActorObject);
         }
     }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C020Trash/C020Raiko.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C020Trash/C020Raiko.cs
@@ -96,9 +96,9 @@
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.NFurutsubaki), ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.NYuki), ArenaColor.Object);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.NFurutsubaki), ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.NYuki), ComponentType.ActorObject);
         }
     }
 
@@ -109,9 +109,9 @@
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.SFurutsubaki), ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.SYuki), ArenaColor.Object);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.SFurutsubaki), ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.SYuki), ComponentType.ActorObject);
         }
     }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C021Shishio/HauntingCry.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C021Shishio/HauntingCry.cs
@@ -45,10 +45,10 @@ namespace BossMod.Endwalker.Criterion.C02AMR.C021Shishio
         {
             foreach (var g in _ghosts)
             {
-                arena.Actor(g, ArenaColor.Object, true);
+                arena.Actor(g, ComponentType.ActorObject, true);
                 var target = module.WorldState.Actors.Find(g.Tether.Target);
                 if (target != null)
-                    arena.AddLine(g.Position, target.Position, ArenaColor.Danger);
+                    arena.AddLine(g.Position, target.Position, ComponentType.Danger);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C021Shishio/RokujoRevel.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C021Shishio/RokujoRevel.cs
@@ -37,10 +37,10 @@ namespace BossMod.Endwalker.Criterion.C02AMR.C021Shishio
                     firstFutureIndex = _pendingCircles.Count;
                 }
                 foreach (var p in _pendingCircles.Take(firstFutureIndex))
-                    yield return new(shapeCircle, p.origin, default, p.activation, ArenaColor.Danger);
+                    yield return new(shapeCircle, p.origin, default, p.activation, ComponentType.Danger);
             }
             if (_pendingLines.Count > 0)
-                yield return new(_shapeLine, module.Bounds.Center, _pendingLines[0].dir, _pendingLines[0].activation, ArenaColor.Danger);
+                yield return new(_shapeLine, module.Bounds.Center, _pendingLines[0].dir, _pendingLines[0].activation, ComponentType.Danger);
         }
 
         public override void Init(BossModule module)

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C022Gorai/MalformedReincarnation.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C022Gorai/MalformedReincarnation.cs
@@ -31,7 +31,7 @@ namespace BossMod.Endwalker.Criterion.C02AMR.C022Gorai
             base.DrawArenaForeground(module, pcSlot, pc, arena);
             if (!_baitsDone)
                 foreach (var p in module.Raid.WithoutSlot())
-                    arena.AddCircle(p.Position, TowerRadius, ArenaColor.Danger);
+                    arena.AddCircle(p.Position, TowerRadius, ComponentType.Danger);
         }
 
         public override void OnActorCreated(BossModule module, Actor actor)

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C022Gorai/RousingReincarnation.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C022Gorai/RousingReincarnation.cs
@@ -106,7 +106,7 @@ namespace BossMod.Endwalker.Criterion.C02AMR.C022Gorai
             ForbiddenPlayers = _oddSoakers;
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return _oddSoakers[playerSlot] != _oddSoakers[pcSlot] ? PlayerPriority.Danger : PlayerPriority.Normal;
         }

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C022Gorai/Thundercall.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C022Gorai/Thundercall.cs
@@ -17,11 +17,11 @@ namespace BossMod.Endwalker.Criterion.C02AMR.C022Gorai
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
-            arena.Actors(_orbs, ArenaColor.Object, true);
+            arena.Actors(_orbs, ComponentType.ActorObject, true);
             if (_miniTarget != null)
-                arena.AddCircle(_miniTarget.Position, 3, ArenaColor.Danger);
+                arena.AddCircle(_miniTarget.Position, 3, ComponentType.Danger);
             if (_safeOrb != null)
-                arena.AddCircle(_safeOrb.Position, 1, ArenaColor.Safe);
+                arena.AddCircle(_safeOrb.Position, 1, ComponentType.Safe);
         }
 
         public override void OnCastStarted(BossModule module, Actor caster, ActorCastInfo spell)

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C023Moko/ShadowTwin.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C023Moko/ShadowTwin.cs
@@ -74,7 +74,7 @@ namespace BossMod.Endwalker.Criterion.C02AMR.C023Moko
                 {
                     var potentialSafespot = module.Bounds.Center + baitDistance * dir;
                     if (!_clearout.AOEs.Any(aoe => aoe.Check(potentialSafespot)))
-                        arena.AddCircle(potentialSafespot, 1, ArenaColor.Safe);
+                        arena.AddCircle(potentialSafespot, 1, ComponentType.Safe);
                 }
             }
         }

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C023Moko/SoldiersOfDeath.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C023Moko/SoldiersOfDeath.cs
@@ -33,7 +33,7 @@ namespace BossMod.Endwalker.Criterion.C02AMR.C023Moko
                     var safespot = module.Bounds.Center + 19 * dir;
                     if (!AOEs.Any(aoe => aoe.Check(safespot)))
                     {
-                        arena.AddCircle(safespot + offset * dir.OrthoR(), 1, ArenaColor.Safe);
+                        arena.AddCircle(safespot + offset * dir.OrthoR(), 1, ComponentType.Safe);
                     }
                 }
             }

--- a/BossMod/Modules/Endwalker/Criterion/C03AAI/C030Trash/C030Ray.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C03AAI/C030Trash/C030Ray.cs
@@ -66,8 +66,8 @@
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.NPaddleBiter), ArenaColor.Enemy);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.NPaddleBiter), ComponentType.ActorEnemy);
         }
     }
 
@@ -78,8 +78,8 @@
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.SPaddleBiter), ArenaColor.Enemy);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.SPaddleBiter), ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C03AAI/C030Trash/C030Snipper.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C03AAI/C030Trash/C030Snipper.cs
@@ -84,8 +84,8 @@ namespace BossMod.Endwalker.Criterion.C03AAI.C030Trash1
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.NCrab), ArenaColor.Enemy);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.NCrab), ComponentType.ActorEnemy);
         }
     }
 
@@ -96,8 +96,8 @@ namespace BossMod.Endwalker.Criterion.C03AAI.C030Trash1
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.SCrab), ArenaColor.Enemy);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.SCrab), ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C03AAI/C030Trash/C030Trash1.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C03AAI/C030Trash/C030Trash1.cs
@@ -67,7 +67,7 @@
         public override void DrawArenaBackground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var twister in Actors)
-                arena.ZoneCircle(twister.Position, 6, ArenaColor.AOE);
+                arena.ZoneCircle(twister.Position, 6, ComponentType.AOE);
         }
     }
 

--- a/BossMod/Modules/Endwalker/Criterion/C03AAI/C031Ketuduke/FlukeGale.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C03AAI/C031Ketuduke/FlukeGale.cs
@@ -39,7 +39,7 @@ namespace BossMod.Endwalker.Criterion.C03AAI.C031Ketuduke
         public override void DrawArenaBackground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var c in SafeZones(pcSlot))
-                _safeZone.Draw(arena, c, default, ArenaColor.SafeFromAOE);
+                _safeZone.Draw(arena, c, default, ComponentType.SafeFromAOE);
         }
 
         public override void OnStatusGain(BossModule module, Actor actor, ActorStatus status)

--- a/BossMod/Modules/Endwalker/Criterion/C03AAI/C031Ketuduke/Roar.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C03AAI/C031Ketuduke/Roar.cs
@@ -30,9 +30,9 @@ namespace BossMod.Endwalker.Criterion.C03AAI.C031Ketuduke
             base.DrawArenaForeground(module, pcSlot, pc, arena);
             foreach (var s in _snakes)
             {
-                arena.Actor(s.actor, ArenaColor.Object, true);
+                arena.Actor(s.actor, ComponentType.ActorObject, true);
                 if (_highlightSnakes && s.bubble != _playerBubbles[pcSlot])
-                    arena.AddCircle(s.actor.Position, 1, ArenaColor.Safe);
+                    arena.AddCircle(s.actor.Position, 1, ComponentType.Safe);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Criterion/C03AAI/C032Lala/ArcanePoint.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C03AAI/C032Lala/ArcanePoint.cs
@@ -29,7 +29,7 @@ namespace BossMod.Endwalker.Criterion.C03AAI.C032Lala
                 hints.Add("Spread on different squares!");
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return PlayerPriority.Interesting;
         }
@@ -40,7 +40,7 @@ namespace BossMod.Endwalker.Criterion.C03AAI.C032Lala
                 return;
             var spot = CurrentSafeSpot(pc.Position);
             if (spot != null)
-                ArcaneArrayPlot.Shape.Draw(arena, spot.Value, default, ArenaColor.SafeFromAOE);
+                ArcaneArrayPlot.Shape.Draw(arena, spot.Value, default, ComponentType.SafeFromAOE);
         }
 
         public override void OnEventCast(BossModule module, Actor caster, ActorCastEvent spell)

--- a/BossMod/Modules/Endwalker/Criterion/C03AAI/C032Lala/PlanarTactics.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C03AAI/C032Lala/PlanarTactics.cs
@@ -25,7 +25,7 @@ namespace BossMod.Endwalker.Criterion.C03AAI.C032Lala
             ref var p = ref Players[pcSlot];
             if (p.StartingOffsets != null)
                 foreach (var off in p.StartingOffsets)
-                    arena.AddCircle(module.Bounds.Center + off, 1, ArenaColor.Safe);
+                    arena.AddCircle(module.Bounds.Center + off, 1, ComponentType.Safe);
         }
 
         public override void OnStatusGain(BossModule module, Actor actor, ActorStatus status)

--- a/BossMod/Modules/Endwalker/Criterion/C03AAI/C032Lala/SpatialTactics.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C03AAI/C032Lala/SpatialTactics.cs
@@ -19,7 +19,7 @@ namespace BossMod.Endwalker.Criterion.C03AAI.C032Lala
             bool wantMore = _remainingStacks[slot] > (NumCasts == 0 ? 1 : 0);
             foreach (var f in NextFonts().Take(2))
                 foreach (var p in _array.SafeZoneCenters.Where(p => _shape.Check(p, f.actor)))
-                    yield return new(ArcaneArrayPlot.Shape, p, default, f.activation, wantMore ? ArenaColor.SafeFromAOE : ArenaColor.AOE, !wantMore);
+                    yield return new(ArcaneArrayPlot.Shape, p, default, f.activation, wantMore ? ComponentType.SafeFromAOE : ComponentType.AOE, !wantMore);
         }
 
         public override void Init(BossModule module)

--- a/BossMod/Modules/Endwalker/Criterion/C03AAI/C033Statice/Dartboard.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C03AAI/C033Statice/Dartboard.cs
@@ -27,7 +27,7 @@ namespace BossMod.Endwalker.Criterion.C03AAI.C033Statice
             }
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return Bullseye[playerSlot] ? PlayerPriority.Danger : PlayerPriority.Interesting;
         }
@@ -35,12 +35,12 @@ namespace BossMod.Endwalker.Criterion.C03AAI.C033Statice
         public override void DrawArenaBackground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (ForbiddenColor != Color.None)
-                DrawSegmentsOfColor(module, ForbiddenColor, ArenaColor.AOE);
+                DrawSegmentsOfColor(module, ForbiddenColor, ComponentType.AOE);
             if (Bullseye[pcSlot])
             {
                 var color = PosToColor(module, pc.Position);
                 if (color != ForbiddenColor)
-                    DrawSegmentsOfColor(module, color, ArenaColor.SafeFromAOE);
+                    DrawSegmentsOfColor(module, color, ComponentType.SafeFromAOE);
             }
         }
 
@@ -81,14 +81,14 @@ namespace BossMod.Endwalker.Criterion.C03AAI.C033Statice
             return DirToColor(Angle.FromDirection(off), off.LengthSq() < 144);
         }
 
-        private void DrawSegmentsOfColor(BossModule module, Color color, uint zoneColor)
+        private void DrawSegmentsOfColor(BossModule module, Color color, ComponentType zoneType)
         {
             int index = (int)color - 1;
             var dirOut = (15 + index * 30).Degrees();
             for (int i = 0; i < 4; ++i)
             {
-                module.Arena.ZoneCone(module.Bounds.Center, 0, 12, dirOut + 30.Degrees(), 15.Degrees(), zoneColor);
-                module.Arena.ZoneCone(module.Bounds.Center, 12, module.Bounds.HalfSize, dirOut, 15.Degrees(), zoneColor);
+                module.Arena.ZoneCone(module.Bounds.Center, 0, 12, dirOut + 30.Degrees(), 15.Degrees(), zoneType);
+                module.Arena.ZoneCone(module.Bounds.Center, 12, module.Bounds.HalfSize, dirOut, 15.Degrees(), zoneType);
                 dirOut += 90.Degrees();
             }
         }

--- a/BossMod/Modules/Endwalker/Criterion/C03AAI/C033Statice/Fireworks.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C03AAI/C033Statice/Fireworks.cs
@@ -22,8 +22,8 @@ namespace BossMod.Endwalker.Criterion.C03AAI.C033Statice
         {
             if (TetheredAdds[pcSlot] is var add && add != null)
             {
-                arena.Actor(add, ArenaColor.Object, true);
-                arena.AddLine(add.Position, pc.Position, ArenaColor.Danger);
+                arena.Actor(add, ComponentType.ActorObject, true);
+                arena.AddLine(add.Position, pc.Position, ComponentType.Danger);
             }
             base.DrawArenaForeground(module, pcSlot, pc, arena);
         }
@@ -81,7 +81,7 @@ namespace BossMod.Endwalker.Criterion.C03AAI.C033Statice
             {
                 var partner = module.Raid[_chains.WithoutBit(pcSlot).LowestSetBit()];
                 if (partner != null)
-                    arena.AddLine(pc.Position, partner.Position, ArenaColor.Safe, 1);
+                    arena.AddLine(pc.Position, partner.Position, ComponentType.Safe, 1);
             }
         }
 
@@ -134,7 +134,7 @@ namespace BossMod.Endwalker.Criterion.C03AAI.C033Statice
             {
                 if (s.RemainingExplosions > 0)
                 {
-                    yield return new(_shape, module.Bounds.Center, s.NextRotation, s.NextActivation, ArenaColor.Danger);
+                    yield return new(_shape, module.Bounds.Center, s.NextRotation, s.NextActivation, ComponentType.Danger);
                 }
             }
         }
@@ -284,12 +284,12 @@ namespace BossMod.Endwalker.Criterion.C03AAI.C033Statice
             {
                 var safeSpots = (OID)add.OID is OID.NSurprisingClaw or OID.SSurprisingClaw ? _safeSpotsClaw : _safeSpotsMissile;
                 foreach (var p in safeSpots)
-                    arena.AddCircle(p, 1, ArenaColor.Safe);
+                    arena.AddCircle(p, 1, ComponentType.Safe);
             }
             else
             {
                 foreach (var p in _safeSpotsClaw)
-                    arena.AddCircle(p, 1, ArenaColor.Enemy);
+                    arena.AddCircle(p, 1, ComponentType.ActorEnemy);
             }
         }
 
@@ -325,12 +325,12 @@ namespace BossMod.Endwalker.Criterion.C03AAI.C033Statice
             if (_fireworks?.Spreads.Count > 0)
             {
                 foreach (var dir in SafeSpots(module, pcSlot, pc))
-                    arena.AddCircle(module.Bounds.Center + 19 * dir.ToDirection(), 1, ArenaColor.Safe);
+                    arena.AddCircle(module.Bounds.Center + 19 * dir.ToDirection(), 1, ComponentType.Safe);
             }
             else if (_relNorth != null)
             {
                 // show rel north before assignments are done
-                arena.AddCircle(module.Bounds.Center + 19 * _relNorth.Value.ToDirection(), 1, ArenaColor.Enemy);
+                arena.AddCircle(module.Bounds.Center + 19 * _relNorth.Value.ToDirection(), 1, ComponentType.ActorEnemy);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Extreme/Ex1Zodiark/Ania.cs
+++ b/BossMod/Modules/Endwalker/Extreme/Ex1Zodiark/Ania.cs
@@ -37,15 +37,15 @@ namespace BossMod.Endwalker.Extreme.Ex1Zodiark
             if (_target == null)
                 return;
 
-            arena.AddCircle(_target.Position, _aoeRadius, ArenaColor.Danger);
+            arena.AddCircle(_target.Position, _aoeRadius, ComponentType.Danger);
             if (pc == _target)
             {
                 foreach (var a in module.Raid.WithoutSlot().Exclude(pc))
-                    arena.Actor(a, a.Position.InCircle(_target.Position, _aoeRadius) ? ArenaColor.PlayerInteresting : ArenaColor.PlayerGeneric);
+                    arena.Actor(a, a.Position.InCircle(_target.Position, _aoeRadius) ? ComponentType.PlayerInteresting : ComponentType.PlayerGeneric);
             }
             else
             {
-                arena.Actor(_target, ArenaColor.Danger);
+                arena.Actor(_target, ComponentType.Danger);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Extreme/Ex1Zodiark/AstralEclipse.cs
+++ b/BossMod/Modules/Endwalker/Extreme/Ex1Zodiark/AstralEclipse.cs
@@ -27,7 +27,7 @@ namespace BossMod.Endwalker.Extreme.Ex1Zodiark
 
             if (movementHints != null)
                 foreach (var (from, to) in EnumMovementHints(module, actor.Position))
-                    movementHints.Add(from, to, ArenaColor.Safe);
+                    movementHints.Add(from, to, ComponentType.Safe);
         }
 
         public override void DrawArenaBackground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
@@ -40,7 +40,7 @@ namespace BossMod.Endwalker.Extreme.Ex1Zodiark
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var (from, to) in EnumMovementHints(module, pc.Position))
-                arena.AddLine(from, to, ArenaColor.Safe);
+                arena.AddLine(from, to, ComponentType.Safe);
         }
 
         public override void OnEventEnvControl(BossModule module, byte index, uint state)

--- a/BossMod/Modules/Endwalker/Extreme/Ex1Zodiark/Paradeigma.cs
+++ b/BossMod/Modules/Endwalker/Extreme/Ex1Zodiark/Paradeigma.cs
@@ -41,13 +41,13 @@ namespace BossMod.Endwalker.Extreme.Ex1Zodiark
             foreach (var s in RotatedSnakes(module))
                 _snakeAOE.Draw(arena, s.Item1, s.Item2);
             foreach (var c in _fireLine)
-                arena.ZoneTri(module.Bounds.Center + c, RotatedPosition(module, c), module.Bounds.Center, ArenaColor.AOE);
+                arena.ZoneTri(module.Bounds.Center + c, RotatedPosition(module, c), module.Bounds.Center, ComponentType.AOE);
         }
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (_fireLine.Count == 2)
-                arena.AddLine(module.Bounds.Center + _fireLine[0], module.Bounds.Center + _fireLine[1], ArenaColor.Danger);
+                arena.AddLine(module.Bounds.Center + _fireLine[0], module.Bounds.Center + _fireLine[1], ComponentType.Danger);
         }
 
         public override void OnEventEnvControl(BossModule module, byte index, uint state)

--- a/BossMod/Modules/Endwalker/Extreme/Ex2Hydaelyn/Crystallize.cs
+++ b/BossMod/Modules/Endwalker/Extreme/Ex2Hydaelyn/Crystallize.cs
@@ -69,24 +69,24 @@ namespace BossMod.Endwalker.Extreme.Ex2Hydaelyn
                     {
                         if (player.Role == Role.Healer)
                         {
-                            arena.Actor(player, ArenaColor.Danger);
-                            arena.AddCircle(player.Position, _waterRadius, ArenaColor.Safe);
+                            arena.Actor(player, ComponentType.Danger);
+                            arena.AddCircle(player.Position, _waterRadius, ComponentType.Safe);
                         }
                         else
                         {
-                            arena.Actor(player, ArenaColor.PlayerGeneric);
+                            arena.Actor(player, ComponentType.PlayerGeneric);
                         }
                     }
                     break;
                 case Element.Earth:
-                    arena.AddCircle(pc.Position, _earthRadius, ArenaColor.Safe);
+                    arena.AddCircle(pc.Position, _earthRadius, ComponentType.Safe);
                     foreach (var player in module.Raid.WithoutSlot().Exclude(pc))
-                        arena.Actor(player, player.Position.InCircle(pc.Position, _earthRadius) ? ArenaColor.PlayerInteresting : ArenaColor.PlayerGeneric);
+                        arena.Actor(player, player.Position.InCircle(pc.Position, _earthRadius) ? ComponentType.PlayerInteresting : ComponentType.PlayerGeneric);
                     break;
                 case Element.Ice:
-                    arena.AddCircle(pc.Position, _iceRadius, ArenaColor.Danger);
+                    arena.AddCircle(pc.Position, _iceRadius, ComponentType.Danger);
                     foreach (var player in module.Raid.WithoutSlot().Exclude(pc))
-                        arena.Actor(player, player.Position.InCircle(pc.Position, _iceRadius) ? ArenaColor.PlayerInteresting : ArenaColor.PlayerGeneric);
+                        arena.Actor(player, player.Position.InCircle(pc.Position, _iceRadius) ? ComponentType.PlayerInteresting : ComponentType.PlayerGeneric);
                     break;
             }
         }

--- a/BossMod/Modules/Endwalker/Extreme/Ex2Hydaelyn/HerosSundering.cs
+++ b/BossMod/Modules/Endwalker/Extreme/Ex2Hydaelyn/HerosSundering.cs
@@ -52,11 +52,11 @@
             if (pc == _target)
             {
                 foreach (var (slot, player) in module.Raid.WithSlot().Exclude(_target))
-                    arena.Actor(player, _otherHit[slot] ? ArenaColor.PlayerInteresting : ArenaColor.PlayerGeneric);
+                    arena.Actor(player, _otherHit[slot] ? ComponentType.PlayerInteresting : ComponentType.PlayerGeneric);
             }
             else
             {
-                arena.Actor(_target, ArenaColor.Danger);
+                arena.Actor(_target, ComponentType.Danger);
             }
         }
     }

--- a/BossMod/Modules/Endwalker/Extreme/Ex2Hydaelyn/InfralateralArc.cs
+++ b/BossMod/Modules/Endwalker/Extreme/Ex2Hydaelyn/InfralateralArc.cs
@@ -22,7 +22,7 @@ namespace BossMod.Endwalker.Extreme.Ex2Hydaelyn
             var pcRole = EffectiveRole(pc);
             var pcDir = Angle.FromDirection(pc.Position - module.PrimaryActor.Position);
             foreach (var actor in module.Raid.WithoutSlot().Where(a => EffectiveRole(a) != pcRole))
-                arena.Actor(actor, actor.Position.InCone(module.PrimaryActor.Position, pcDir, _coneHalfAngle) ? ArenaColor.Danger : ArenaColor.PlayerGeneric);
+                arena.Actor(actor, actor.Position.InCone(module.PrimaryActor.Position, pcDir, _coneHalfAngle) ? ComponentType.Danger : ComponentType.PlayerGeneric);
         }
 
         private Role EffectiveRole(Actor a) =>  a.Role == Role.Ranged ? Role.Melee : a.Role;

--- a/BossMod/Modules/Endwalker/Extreme/Ex2Hydaelyn/IntermissionAdds.cs
+++ b/BossMod/Modules/Endwalker/Extreme/Ex2Hydaelyn/IntermissionAdds.cs
@@ -11,7 +11,7 @@ namespace BossMod.Endwalker.Extreme.Ex2Hydaelyn
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var echo in module.Enemies(OID.Echo))
-                arena.Actor(echo, ArenaColor.Enemy);
+                arena.Actor(echo, ComponentType.ActorEnemy);
 
             // note that there are two crystals per position, one targetable and one not - untargetable one can be tethered to second echo
             foreach (var crystal in module.Enemies(OID.CrystalOfLight))
@@ -19,12 +19,12 @@ namespace BossMod.Endwalker.Extreme.Ex2Hydaelyn
                 if (crystal.IsTargetable && !crystal.IsDead)
                 {
                     bool isActive = _activeCrystals.Contains(crystal.InstanceID);
-                    arena.Actor(crystal, isActive ? ArenaColor.Danger : ArenaColor.PlayerGeneric);
+                    arena.Actor(crystal, isActive ? ComponentType.Danger : ComponentType.PlayerGeneric);
                 }
 
                 var tether = module.WorldState.Actors.Find(crystal.Tether.Target);
                 if (tether != null)
-                    arena.AddLine(crystal.Position, tether.Position, ArenaColor.Danger);
+                    arena.AddLine(crystal.Position, tether.Position, ComponentType.Danger);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Extreme/Ex2Hydaelyn/LightwaveCommon.cs
+++ b/BossMod/Modules/Endwalker/Extreme/Ex2Hydaelyn/LightwaveCommon.cs
@@ -41,7 +41,7 @@ namespace BossMod.Endwalker.Extreme.Ex2Hydaelyn
             var dist = toBlock.Length();
             var center = Angle.FromDirection(toBlock);
             var halfAngle = Angle.Asin(_losRadius / dist);
-            arena.ZoneCone(origin, dist, 40, center, halfAngle, ArenaColor.SafeFromAOE);
+            arena.ZoneCone(origin, dist, 40, center, halfAngle, ComponentType.SafeFromAOE);
         }
     }
 }

--- a/BossMod/Modules/Endwalker/Extreme/Ex2Hydaelyn/Spectrum.cs
+++ b/BossMod/Modules/Endwalker/Extreme/Ex2Hydaelyn/Spectrum.cs
@@ -26,9 +26,9 @@
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
-            arena.AddCircle(pc.Position, _radius, ArenaColor.Danger);
+            arena.AddCircle(pc.Position, _radius, ComponentType.Danger);
             foreach (var player in module.Raid.WithoutSlot().Exclude(pc))
-                arena.Actor(player, player.Position.InCircle(pc.Position, _radius) ? ArenaColor.PlayerInteresting : ArenaColor.PlayerGeneric);
+                arena.Actor(player, player.Position.InCircle(pc.Position, _radius) ? ComponentType.PlayerInteresting : ComponentType.PlayerGeneric);
         }
     }
 }

--- a/BossMod/Modules/Endwalker/Extreme/Ex3Endsinger/Planets.cs
+++ b/BossMod/Modules/Endwalker/Extreme/Ex3Endsinger/Planets.cs
@@ -48,8 +48,8 @@ namespace BossMod.Endwalker.Extreme.Ex3Endsigner
             if (_planetsAzure.Count > 0)
             {
                 var offsetLocation = Components.Knockback.AwayFromSource(pc.Position, _planetsAzure[0], _knockbackDistance);
-                arena.AddLine(pc.Position, offsetLocation, ArenaColor.Danger);
-                arena.Actor(offsetLocation, pc.Rotation, ArenaColor.Danger);
+                arena.AddLine(pc.Position, offsetLocation, ComponentType.Danger);
+                arena.Actor(offsetLocation, pc.Rotation, ComponentType.Danger);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Extreme/Ex4Barbariccia/Tangle.cs
+++ b/BossMod/Modules/Endwalker/Extreme/Ex4Barbariccia/Tangle.cs
@@ -19,7 +19,7 @@ namespace BossMod.Endwalker.Extreme.Ex4Barbariccia
             var tether = _tethers[pcSlot];
             if (tether != null)
             {
-                arena.AddCircle(tether.Position, 8, ArenaColor.Object);
+                arena.AddCircle(tether.Position, 8, ComponentType.ActorObject);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Extreme/Ex5Rubicante/FlamespireClaw.cs
+++ b/BossMod/Modules/Endwalker/Extreme/Ex5Rubicante/FlamespireClaw.cs
@@ -39,7 +39,7 @@ namespace BossMod.Endwalker.Extreme.Ex5Rubicante
         {
             base.DrawArenaForeground(module, pcSlot, pc, arena);
             foreach (var (_, player) in module.Raid.WithSlot(true).IncludedInMask(_tethers))
-                arena.AddLine(player.Position, module.PrimaryActor.Position, ArenaColor.Danger);
+                arena.AddLine(player.Position, module.PrimaryActor.Position, ComponentType.Danger);
         }
 
         public override void OnEventCast(BossModule module, Actor caster, ActorCastEvent spell)

--- a/BossMod/Modules/Endwalker/Extreme/Ex6Golbez/DoubleMeteor.cs
+++ b/BossMod/Modules/Endwalker/Extreme/Ex6Golbez/DoubleMeteor.cs
@@ -100,7 +100,7 @@ namespace BossMod.Endwalker.Extreme.Ex6Golbez
         private void DrawTower(MiniArena arena, Actor? tower, bool safe)
         {
             if (tower != null)
-                arena.AddCircle(tower.Position, 4, safe ? ArenaColor.Safe : ArenaColor.Danger, 2);
+                arena.AddCircle(tower.Position, 4, safe ? ComponentType.Safe : ComponentType.Danger, 2);
         }
     }
 

--- a/BossMod/Modules/Endwalker/Extreme/Ex6Golbez/VoidStardust.cs
+++ b/BossMod/Modules/Endwalker/Extreme/Ex6Golbez/VoidStardust.cs
@@ -15,7 +15,7 @@ namespace BossMod.Endwalker.Extreme.Ex6Golbez
             foreach (var aoe in _aoes.Skip(NumCasts + 2).Take(10))
                 yield return new(_shape, aoe.pos, default, aoe.activation);
             foreach (var aoe in _aoes.Skip(NumCasts).Take(2))
-                yield return new(_shape, aoe.pos, default, aoe.activation, ArenaColor.Danger);
+                yield return new(_shape, aoe.pos, default, aoe.activation, ComponentType.Danger);
         }
 
         public override void OnCastStarted(BossModule module, Actor caster, ActorCastInfo spell)

--- a/BossMod/Modules/Endwalker/Extreme/Ex7Zeromus/BlackHole.cs
+++ b/BossMod/Modules/Endwalker/Extreme/Ex7Zeromus/BlackHole.cs
@@ -30,7 +30,7 @@ namespace BossMod.Endwalker.Extreme.Ex7Zeromus
             }
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return player == Baiter ? PlayerPriority.Danger : PlayerPriority.Irrelevant;
         }
@@ -38,13 +38,13 @@ namespace BossMod.Endwalker.Extreme.Ex7Zeromus
         public override void DrawArenaBackground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (Voidzone != null)
-                arena.ZoneCircle(Voidzone.Position, _growthStart == default ? _startingRadius : Math.Min(_maxRadius, _startingRadius + _growthPerSecond * (float)(module.WorldState.CurrentTime - _growthStart).TotalSeconds), ArenaColor.AOE);
+                arena.ZoneCircle(Voidzone.Position, _growthStart == default ? _startingRadius : Math.Min(_maxRadius, _startingRadius + _growthPerSecond * (float)(module.WorldState.CurrentTime - _growthStart).TotalSeconds), ComponentType.AOE);
         }
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (Baiter != null)
-                arena.AddCircle(Baiter.Position, _startingRadius, ArenaColor.Danger);
+                arena.AddCircle(Baiter.Position, _startingRadius, ComponentType.Danger);
         }
 
         public override void OnActorCreated(BossModule module, Actor actor)
@@ -98,7 +98,7 @@ namespace BossMod.Endwalker.Extreme.Ex7Zeromus
             for (int i = NumCasts + 1; i < _maxCasts; ++i)
                 yield return new(_shape, _source.Position, _startingRotation + i * _increment, _startingActivation.AddSeconds(0.5f * i));
             if (NumCasts < _maxCasts)
-                yield return new(_shape, _source.Position, _startingRotation + NumCasts * _increment, _startingActivation.AddSeconds(0.5f * NumCasts), ArenaColor.Danger);
+                yield return new(_shape, _source.Position, _startingRotation + NumCasts * _increment, _startingActivation.AddSeconds(0.5f * NumCasts), ComponentType.Danger);
         }
 
         public override void OnCastStarted(BossModule module, Actor caster, ActorCastInfo spell)

--- a/BossMod/Modules/Endwalker/Extreme/Ex7Zeromus/Flare.cs
+++ b/BossMod/Modules/Endwalker/Extreme/Ex7Zeromus/Flare.cs
@@ -91,7 +91,7 @@ namespace BossMod.Endwalker.Extreme.Ex7Zeromus
             foreach (var c in _chasers)
             {
                 if (c.Pos != null)
-                    arena.AddLine(c.Pos.Value, c.Player.Position, ArenaColor.Danger);
+                    arena.AddLine(c.Pos.Value, c.Player.Position, ComponentType.Danger);
                 //else
                 //    _shape.Outline(arena, c.Player.Position);
             }

--- a/BossMod/Modules/Endwalker/Extreme/Ex7Zeromus/FlowOfTheAbyss.cs
+++ b/BossMod/Modules/Endwalker/Extreme/Ex7Zeromus/FlowOfTheAbyss.cs
@@ -71,7 +71,7 @@ namespace BossMod.Endwalker.Extreme.Ex7Zeromus
             foreach (var a in _angles.Skip(1).Take(2))
                 yield return new(_shape, module.PrimaryActor.Position, a.rot, a.activation);
             if (_angles.Count > 0)
-                yield return new(_shape, module.PrimaryActor.Position, _angles[0].rot, _angles[0].activation, ArenaColor.Danger);
+                yield return new(_shape, module.PrimaryActor.Position, _angles[0].rot, _angles[0].activation, ComponentType.Danger);
         }
 
         public override void OnCastStarted(BossModule module, Actor caster, ActorCastInfo spell)

--- a/BossMod/Modules/Endwalker/Extreme/Ex7Zeromus/VisceralWhirl.cs
+++ b/BossMod/Modules/Endwalker/Extreme/Ex7Zeromus/VisceralWhirl.cs
@@ -70,7 +70,7 @@ namespace BossMod.Endwalker.Extreme.Ex7Zeromus
                 hints.Add("Break tether!");
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return _partners[pcSlot] == playerSlot ? PlayerPriority.Interesting : PlayerPriority.Irrelevant;
         }
@@ -79,7 +79,7 @@ namespace BossMod.Endwalker.Extreme.Ex7Zeromus
         {
             var partner = module.Raid[_partners[pcSlot]];
             if (partner != null)
-                arena.AddLine(pc.Position, partner.Position, ArenaColor.Danger);
+                arena.AddLine(pc.Position, partner.Position, ComponentType.Danger);
         }
 
         public override void OnTethered(BossModule module, Actor source, ActorTetherInfo tether)

--- a/BossMod/Modules/Endwalker/Extreme/Ex7Zeromus/VoidMeteor.cs
+++ b/BossMod/Modules/Endwalker/Extreme/Ex7Zeromus/VoidMeteor.cs
@@ -44,7 +44,7 @@ namespace BossMod.Endwalker.Extreme.Ex7Zeromus
                 hints.Add("GTFO from charges!");
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return SourceIfActive(playerSlot) != null ? PlayerPriority.Interesting : PlayerPriority.Normal;
         }
@@ -55,14 +55,14 @@ namespace BossMod.Endwalker.Extreme.Ex7Zeromus
             {
                 ref var state = ref _playerStates.AsSpan()[pcSlot];
                 state.DangerZone ??= arena.Bounds.ClipAndTriangulate(new Clip2D().Union(_meteors.Select(m => BuildShadowPolygon(source.Position, m))));
-                arena.Zone(state.DangerZone, ArenaColor.AOE);
+                arena.Zone(state.DangerZone, ComponentType.AOE);
             }
         }
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var m in _meteors)
-                arena.AddCircle(m, _radius, ArenaColor.Object);
+                arena.AddCircle(m, _radius, ComponentType.ActorObject);
 
             foreach (var (slot, target) in module.Raid.WithSlot(true))
             {
@@ -76,15 +76,15 @@ namespace BossMod.Endwalker.Extreme.Ex7Zeromus
                         arena.PathArcTo(target.Position, 2, (rot + 90.Degrees()).Rad, (rot - 90.Degrees()).Rad);
                         arena.PathLineTo(source.Position - norm);
                         arena.PathLineTo(source.Position + norm);
-                        arena.PathStroke(true, _playerStates[slot].NonClipping ? ArenaColor.Safe : ArenaColor.Danger, thickness);
-                        arena.AddLine(source.Position, target.Position, _playerStates[slot].Stretched ? ArenaColor.Safe : ArenaColor.Danger, thickness);
+                        arena.PathStroke(true, _playerStates[slot].NonClipping ? ComponentType.Safe : ComponentType.Danger, thickness);
+                        arena.AddLine(source.Position, target.Position, _playerStates[slot].Stretched ? ComponentType.Safe : ComponentType.Danger, thickness);
                     }
                 }
             }
 
             // circle showing approximate min stretch distance; for second order, we might be forced to drop meteor there and die to avoid wipe
             if (SourceIfActive(pcSlot) is var pcSource && pcSource != null)
-                arena.AddCircle(pcSource.Position, 26, ArenaColor.Danger);
+                arena.AddCircle(pcSource.Position, 26, ComponentType.Danger);
         }
 
         public override void OnEventCast(BossModule module, Actor caster, ActorCastEvent spell)

--- a/BossMod/Modules/Endwalker/HuntA/Gurangatch.cs
+++ b/BossMod/Modules/Endwalker/HuntA/Gurangatch.cs
@@ -63,7 +63,7 @@ namespace BossMod.Endwalker.HuntA.Gurangatch
         {
             base.DrawArenaBackground(module, pcSlot, pc, arena);
             if (_remainingSlams > 0 && _slamDirIncrement.Rad != MathF.PI)
-                arena.ZoneCone(module.PrimaryActor.Position, 0, _shape.Radius, _slamDir - _slamDirIncrement * 3 / 2, 45.Degrees(), ArenaColor.SafeFromAOE);
+                arena.ZoneCone(module.PrimaryActor.Position, 0, _shape.Radius, _slamDir - _slamDirIncrement * 3 / 2, 45.Degrees(), ComponentType.SafeFromAOE);
         }
 
         public override void OnCastStarted(BossModule module, Actor caster, ActorCastInfo spell)

--- a/BossMod/Modules/Endwalker/HuntA/Sugriva.cs
+++ b/BossMod/Modules/Endwalker/HuntA/Sugriva.cs
@@ -34,7 +34,7 @@ namespace BossMod.Endwalker.HuntA.Sugriva
                 hints.Add("Stack and knockback");
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return Casters.FirstOrDefault()?.CastInfo?.TargetID == player.InstanceID ? PlayerPriority.Interesting : PlayerPriority.Irrelevant;
         }
@@ -84,7 +84,7 @@ namespace BossMod.Endwalker.HuntA.Sugriva
                 yield return new(_shape, module.PrimaryActor.CastInfo!.LocXZ, new(), module.PrimaryActor.CastInfo.FinishAt);
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return player == _target ? PlayerPriority.Interesting : PlayerPriority.Irrelevant;
         }
@@ -92,7 +92,7 @@ namespace BossMod.Endwalker.HuntA.Sugriva
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (_target != null)
-                arena.AddCircle(_target.Position, _shape.Radius, ArenaColor.Danger);
+                arena.AddCircle(_target.Position, _shape.Radius, ComponentType.Danger);
         }
 
         public override void OnCastStarted(BossModule module, Actor caster, ActorCastInfo spell)

--- a/BossMod/Modules/Endwalker/HuntS/Burfurlur.cs
+++ b/BossMod/Modules/Endwalker/HuntS/Burfurlur.cs
@@ -35,7 +35,7 @@ namespace BossMod.Endwalker.HuntS.Burfurlur
             {
                 // TODO: activation
                 if (_pendingOffsets.Count > 0)
-                    yield return new(_shape, module.PrimaryActor.Position, _referenceAngle + _pendingOffsets[0], color: ArenaColor.Danger);
+                    yield return new(_shape, module.PrimaryActor.Position, _referenceAngle + _pendingOffsets[0], type: ComponentType.Danger);
                 if (_pendingOffsets.Count > 1)
                     yield return new(_shape, module.PrimaryActor.Position, _referenceAngle + _pendingOffsets[1]);
             }

--- a/BossMod/Modules/Endwalker/Savage/P10SPandaemonium/Border.cs
+++ b/BossMod/Modules/Endwalker/Savage/P10SPandaemonium/Border.cs
@@ -40,7 +40,7 @@
         private void DrawPlatform(MiniArena arena, WPos center, WDir cornerOffset)
         {
             var otherCorner = new WDir(cornerOffset.X, -cornerOffset.Z);
-            arena.AddQuad(center - cornerOffset, center - otherCorner, center + cornerOffset, center + otherCorner, ArenaColor.Border);
+            arena.AddQuad(center - cornerOffset, center - otherCorner, center + cornerOffset, center + otherCorner, ComponentType.Border);
         }
 
         private void DrawBridge(MiniArena arena, float dir)
@@ -48,8 +48,8 @@
             var p1 = arena.Bounds.Center + new WDir(MainPlatformHalfSize.X * dir, 0);
             var p2 = arena.Bounds.Center + new WDir((SidePlatformOffsetX - SidePlatformHalfSize.X) * dir, 0);
             var o = new WDir(0, 1);
-            arena.AddLine(p1 + o, p2 + o, ArenaColor.Border);
-            arena.AddLine(p1 - o, p2 - o, ArenaColor.Border);
+            arena.AddLine(p1 + o, p2 + o, ComponentType.Border);
+            arena.AddLine(p1 - o, p2 - o, ComponentType.Border);
         }
     }
 }

--- a/BossMod/Modules/Endwalker/Savage/P10SPandaemonium/EntanglingWeb.cs
+++ b/BossMod/Modules/Endwalker/Savage/P10SPandaemonium/EntanglingWeb.cs
@@ -38,9 +38,9 @@ namespace BossMod.Endwalker.Savage.P10SPandaemonium
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
-            arena.Actors(_pillars, ArenaColor.Object, true);
+            arena.Actors(_pillars, ComponentType.ActorObject, true);
             foreach (var t in _targets)
-                arena.AddCircle(t.Position, _radius, ArenaColor.Danger);
+                arena.AddCircle(t.Position, _radius, ComponentType.Danger);
         }
 
         public override void OnCastStarted(BossModule module, Actor caster, ActorCastInfo spell)

--- a/BossMod/Modules/Endwalker/Savage/P10SPandaemonium/P10SPandaemonium.cs
+++ b/BossMod/Modules/Endwalker/Savage/P10SPandaemonium/P10SPandaemonium.cs
@@ -17,7 +17,7 @@ namespace BossMod.Endwalker.Savage.P10SPandaemonium
     class CirclesOfPandaemonium : Components.SelfTargetedAOEs
     {
         public CirclesOfPandaemonium() : base(ActionID.MakeSpell(AID.CirclesOfPandaemonium), new AOEShapeDonut(12, 40)) { }
-        public override IEnumerable<AOEInstance> ActiveAOEs(BossModule module, int slot, Actor actor) => ActiveCasters.Select(c => new AOEInstance(Shape, new(module.Bounds.Center.X, Border.MainPlatformCenterZ - Border.MainPlatformHalfSize.Z), c.CastInfo!.Rotation, c.CastInfo.FinishAt, Color, Risky));
+        public override IEnumerable<AOEInstance> ActiveAOEs(BossModule module, int slot, Actor actor) => ActiveCasters.Select(c => new AOEInstance(Shape, new(module.Bounds.Center.X, Border.MainPlatformCenterZ - Border.MainPlatformHalfSize.Z), c.CastInfo!.Rotation, c.CastInfo.FinishAt, Type, Risky));
     }
 
     class Imprisonment : Components.SelfTargetedAOEs

--- a/BossMod/Modules/Endwalker/Savage/P10SPandaemonium/PandaemoniacMeltdown.cs
+++ b/BossMod/Modules/Endwalker/Savage/P10SPandaemonium/PandaemoniacMeltdown.cs
@@ -35,7 +35,7 @@ namespace BossMod.Endwalker.Savage.P10SPandaemonium
             }
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return player == _stackTarget ? PlayerPriority.Interesting : _spreadTargets.Contains(player) ? PlayerPriority.Danger : PlayerPriority.Irrelevant;
         }
@@ -44,17 +44,17 @@ namespace BossMod.Endwalker.Savage.P10SPandaemonium
         {
             bool isSpread = _spreadTargets.Contains(pc);
             if (_stackTarget != null && _stackTarget != pc)
-                _shapeStack.Draw(arena, module.PrimaryActor.Position, Angle.FromDirection(_stackTarget.Position - module.PrimaryActor.Position), isSpread ? ArenaColor.AOE : ArenaColor.SafeFromAOE);
+                _shapeStack.Draw(arena, module.PrimaryActor.Position, Angle.FromDirection(_stackTarget.Position - module.PrimaryActor.Position), isSpread ? ComponentType.AOE : ComponentType.SafeFromAOE);
             foreach (var t in _spreadTargets.Exclude(pc))
-                _shapeStack.Draw(arena, module.PrimaryActor.Position, Angle.FromDirection(t.Position - module.PrimaryActor.Position), ArenaColor.AOE);
+                _shapeStack.Draw(arena, module.PrimaryActor.Position, Angle.FromDirection(t.Position - module.PrimaryActor.Position), ComponentType.AOE);
         }
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (pc == _stackTarget)
-                _shapeStack.Outline(arena, module.PrimaryActor.Position, Angle.FromDirection(pc.Position - module.PrimaryActor.Position), ArenaColor.Safe);
+                _shapeStack.Outline(arena, module.PrimaryActor.Position, Angle.FromDirection(pc.Position - module.PrimaryActor.Position), ComponentType.Safe);
             else if (_spreadTargets.Contains(pc))
-                _shapeSpread.Outline(arena, module.PrimaryActor.Position, Angle.FromDirection(pc.Position - module.PrimaryActor.Position), ArenaColor.Danger);
+                _shapeSpread.Outline(arena, module.PrimaryActor.Position, Angle.FromDirection(pc.Position - module.PrimaryActor.Position), ComponentType.Danger);
         }
 
         public override void OnEventCast(BossModule module, Actor caster, ActorCastEvent spell)

--- a/BossMod/Modules/Endwalker/Savage/P10SPandaemonium/PartedPlumes.cs
+++ b/BossMod/Modules/Endwalker/Savage/P10SPandaemonium/PartedPlumes.cs
@@ -9,7 +9,7 @@ namespace BossMod.Endwalker.Savage.P10SPandaemonium
 
         public override IEnumerable<AOEInstance> ActiveAOEs(BossModule module, int slot, Actor actor)
         {
-            return ActiveCasters.Select((c, i) => new AOEInstance(Shape, c.Position, c.CastInfo!.Rotation, c.CastInfo.FinishAt, i < 2 ? ArenaColor.Danger : ArenaColor.AOE));
+            return ActiveCasters.Select((c, i) => new AOEInstance(Shape, c.Position, c.CastInfo!.Rotation, c.CastInfo.FinishAt, i < 2 ? ComponentType.Danger : ComponentType.AOE));
         }
     }
 

--- a/BossMod/Modules/Endwalker/Savage/P10SPandaemonium/Silkspit.cs
+++ b/BossMod/Modules/Endwalker/Savage/P10SPandaemonium/Silkspit.cs
@@ -24,7 +24,7 @@ namespace BossMod.Endwalker.Savage.P10SPandaemonium
         public override void DrawArenaBackground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             base.DrawArenaBackground(module, pcSlot, pc, arena);
-            arena.Actors(_pillars, ArenaColor.Object, true);
+            arena.Actors(_pillars, ComponentType.ActorObject, true);
         }
 
         public override void OnEventCast(BossModule module, Actor caster, ActorCastEvent spell)

--- a/BossMod/Modules/Endwalker/Savage/P10SPandaemonium/SteelWeb.cs
+++ b/BossMod/Modules/Endwalker/Savage/P10SPandaemonium/SteelWeb.cs
@@ -36,18 +36,18 @@ namespace BossMod.Endwalker.Savage.P10SPandaemonium
 
     class SteelWebTethers : BossComponent
     {
-        private List<(Actor from, Actor to, uint color)> _webs = new();
+        private List<(Actor from, Actor to, ComponentType type)> _webs = new();
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var w in _webs)
-                arena.AddLine(w.from.Position, w.to.Position, w.color);
+                arena.AddLine(w.from.Position, w.to.Position, w.type);
         }
 
         public override void OnTethered(BossModule module, Actor source, ActorTetherInfo tether)
         {
             if ((TetherID)tether.ID is TetherID.Web or TetherID.WebFail && module.WorldState.Actors.Find(tether.Target) is var target && target != null)
-                _webs.Add((source, target, (TetherID)tether.ID == TetherID.Web ? ArenaColor.Danger : ArenaColor.Enemy));
+                _webs.Add((source, target, (TetherID)tether.ID == TetherID.Web ? ComponentType.Danger : ComponentType.ActorEnemy));
         }
 
         public override void OnUntethered(BossModule module, Actor source, ActorTetherInfo tether)

--- a/BossMod/Modules/Endwalker/Savage/P10SPandaemonium/Turrets.cs
+++ b/BossMod/Modules/Endwalker/Savage/P10SPandaemonium/Turrets.cs
@@ -45,7 +45,7 @@ namespace BossMod.Endwalker.Savage.P10SPandaemonium
                 hints.Add("About to be knocked off platform!");
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return ImminentTurretsWithTargets(module).Any(t => t.target == player) ? PlayerPriority.Interesting : PlayerPriority.Irrelevant;
         }
@@ -54,13 +54,13 @@ namespace BossMod.Endwalker.Savage.P10SPandaemonium
         {
             foreach (var t in ImminentTurretsWithTargets(module))
             {
-                arena.Actor(t.source, ArenaColor.Enemy, true);
+                arena.Actor(t.source, ComponentType.ActorEnemy, true);
                 if (t.source != null && t.target != null)
                     _shape.Outline(arena, t.source.Position, Angle.FromDirection(t.target.Position - t.source.Position));
             }
 
             foreach (var t in FutureTurrets())
-                arena.Actor(t, ArenaColor.Object, true);
+                arena.Actor(t, ComponentType.ActorObject, true);
 
             base.DrawArenaForeground(module, pcSlot, pc, arena);
         }

--- a/BossMod/Modules/Endwalker/Savage/P11SThemis/DarkAndLight.cs
+++ b/BossMod/Modules/Endwalker/Savage/P11SThemis/DarkAndLight.cs
@@ -26,10 +26,10 @@ namespace BossMod.Endwalker.Savage.P11SThemis
             if (state.Tether != TetherType.None)
                 hints.Add($"{state.Tether} tether", state.TetherBad);
             if (movementHints != null && Safespot(module, slot, actor) is var safespot && safespot != null)
-                movementHints.Add(actor.Position, safespot.Value, ArenaColor.Safe);
+                movementHints.Add(actor.Position, safespot.Value, ComponentType.Safe);
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             var pcState = _states[pcSlot];
             return pcState.Tether != TetherType.None && pcState.PartnerSlot == playerSlot ? PlayerPriority.Danger : PlayerPriority.Irrelevant;
@@ -39,9 +39,9 @@ namespace BossMod.Endwalker.Savage.P11SThemis
         {
             var pcState = _states[pcSlot];
             if (pcState.Tether != TetherType.None && module.Raid[pcState.PartnerSlot] is var partner && partner != null)
-                arena.AddLine(pc.Position, partner.Position, pcState.TetherBad ? ArenaColor.Danger : ArenaColor.Safe);
+                arena.AddLine(pc.Position, partner.Position, pcState.TetherBad ? ComponentType.Danger : ComponentType.Safe);
             if (Safespot(module, pcSlot, pc) is var safespot && safespot != null)
-                arena.AddCircle(safespot.Value, 1, ArenaColor.Safe);
+                arena.AddCircle(safespot.Value, 1, ComponentType.Safe);
         }
 
         public override void OnTethered(BossModule module, Actor source, ActorTetherInfo tether)

--- a/BossMod/Modules/Endwalker/Savage/P11SThemis/DarkCurrent.cs
+++ b/BossMod/Modules/Endwalker/Savage/P11SThemis/DarkCurrent.cs
@@ -25,7 +25,7 @@ namespace BossMod.Endwalker.Savage.P11SThemis
                 if (_aoes.Count > 0)
                     _aoes.RemoveAt(0);
                 if (_aoes.Count > 2)
-                    _aoes.AsSpan()[2].Color = ArenaColor.Danger;
+                    _aoes.AsSpan()[2].Type = ComponentType.Danger;
             }
         }
 
@@ -40,7 +40,7 @@ namespace BossMod.Endwalker.Savage.P11SThemis
                 for (int i = 0; i < 8; ++i)
                 {
                     var offset = 13 * (startingAngle + i * rotation).ToDirection();
-                    var color = i == 0 ? ArenaColor.Danger : ArenaColor.AOE;
+                    var color = i == 0 ? ComponentType.Danger : ComponentType.AOE;
                     _aoes.Add(new(_shape, module.Bounds.Center, default, module.WorldState.CurrentTime.AddSeconds(7.1f + i * 1.1f), color));
                     _aoes.Add(new(_shape, module.Bounds.Center + offset, default, module.WorldState.CurrentTime.AddSeconds(7.1f + i * 1.1f), color));
                     _aoes.Add(new(_shape, module.Bounds.Center - offset, default, module.WorldState.CurrentTime.AddSeconds(7.1f + i * 1.1f), color));

--- a/BossMod/Modules/Endwalker/Savage/P12S1Athena/EngravementOfSouls1.cs
+++ b/BossMod/Modules/Endwalker/Savage/P12S1Athena/EngravementOfSouls1.cs
@@ -32,7 +32,7 @@ namespace BossMod.Endwalker.Savage.P12S1Athena
 
             var safespot = CalculateSafeSpot(module, pcSlot);
             if (safespot != default)
-                arena.AddCircle(safespot, 1, ArenaColor.Safe);
+                arena.AddCircle(safespot, 1, ComponentType.Safe);
         }
 
         public override void OnStatusGain(BossModule module, Actor actor, ActorStatus status)

--- a/BossMod/Modules/Endwalker/Savage/P12S1Athena/EngravementOfSouls2.cs
+++ b/BossMod/Modules/Endwalker/Savage/P12S1Athena/EngravementOfSouls2.cs
@@ -19,7 +19,7 @@
                 hints.Add(_lightCamp[slot] ? "Go to light camp" : "GTFO from light camp");
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return player == _lightRay || player == _darkRay ? PlayerPriority.Interesting : PlayerPriority.Normal;
         }
@@ -64,7 +64,7 @@
         private void DrawOutline(BossModule module, Actor? target, bool safe)
         {
             if (target != null)
-                _shape.Outline(module.Arena, module.PrimaryActor.Position, Angle.FromDirection(target.Position - module.PrimaryActor.Position), safe ? ArenaColor.Safe : ArenaColor.Danger);
+                _shape.Outline(module.Arena, module.PrimaryActor.Position, Angle.FromDirection(target.Position - module.PrimaryActor.Position), safe ? ComponentType.Safe : ComponentType.Danger);
         }
     }
 

--- a/BossMod/Modules/Endwalker/Savage/P12S1Athena/EngravementOfSouls3.cs
+++ b/BossMod/Modules/Endwalker/Savage/P12S1Athena/EngravementOfSouls3.cs
@@ -56,12 +56,12 @@ namespace BossMod.Endwalker.Savage.P12S1Athena
             _tethers = module.FindComponent<EngravementOfSoulsTethers>();
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             if (IsSpreadTarget(pc))
                 return _tethers?.States[playerSlot].Tether == _soakers ? PlayerPriority.Danger : PlayerPriority.Irrelevant;
             else
-                return base.CalcPriority(module, pcSlot, pc, playerSlot, player, ref customColor);
+                return base.CalcPriority(module, pcSlot, pc, playerSlot, player, ref type);
         }
 
         public override void OnStatusGain(BossModule module, Actor actor, ActorStatus status)
@@ -115,13 +115,13 @@ namespace BossMod.Endwalker.Savage.P12S1Athena
                 foreach (var chain in PositionHints(slot))
                 {
                     var from = actor.Position;
-                    var color = ArenaColor.Safe;
+                    var color = ComponentType.Safe;
                     foreach (var offset in chain)
                     {
                         var to = module.Bounds.Center + offset;
                         movementHints.Add(from, to, color);
                         from = to;
-                        color = ArenaColor.Danger;
+                        color = ComponentType.Danger;
                     }
                 }
             }
@@ -131,7 +131,7 @@ namespace BossMod.Endwalker.Savage.P12S1Athena
         {
             foreach (var chain in PositionHints(pcSlot))
                 foreach (var offset in chain.Take(1))
-                    arena.AddCircle(module.Bounds.Center + offset, 1, ArenaColor.Safe);
+                    arena.AddCircle(module.Bounds.Center + offset, 1, ComponentType.Safe);
         }
 
         // note: these statuses are assigned before any tethers

--- a/BossMod/Modules/Endwalker/Savage/P12S1Athena/EngravementOfSoulsCommon.cs
+++ b/BossMod/Modules/Endwalker/Savage/P12S1Athena/EngravementOfSoulsCommon.cs
@@ -27,11 +27,11 @@
             base.DrawArenaForeground(module, pcSlot, pc, arena);
 
             foreach (var b in CurrentBaits)
-                arena.Actor(b.Source, ArenaColor.Object, true);
+                arena.Actor(b.Source, ComponentType.ActorObject, true);
 
             // TODO: consider drawing safespot based on configured strategy and mechanic order
             if (NumCasts == 0 && States[pcSlot] is var state && state.Source != null)
-                arena.AddLine(state.Source.Position, pc.Position, state.TooClose ? ArenaColor.Danger : ArenaColor.Safe);
+                arena.AddLine(state.Source.Position, pc.Position, state.TooClose ? ComponentType.Danger : ComponentType.Safe);
         }
 
         public override void OnTethered(BossModule module, Actor source, ActorTetherInfo tether)

--- a/BossMod/Modules/Endwalker/Savage/P12S1Athena/Palladion.cs
+++ b/BossMod/Modules/Endwalker/Savage/P12S1Athena/Palladion.cs
@@ -77,7 +77,7 @@ namespace BossMod.Endwalker.Savage.P12S1Athena
         {
             for (int i = 0; i < 8; ++i)
                 arena.PathLineTo(module.Bounds.Center + 14 * (i * 45).Degrees().ToDirection());
-            arena.PathStroke(true, ArenaColor.Border, 2);
+            arena.PathStroke(true, ComponentType.Border, 2);
         }
     }
 
@@ -111,7 +111,7 @@ namespace BossMod.Endwalker.Savage.P12S1Athena
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (_palladion != null && NumCasts < _palladion.JumpTargets.Length && _palladion.JumpTargets[NumCasts] is var target && target != null && (pc == target || pc == _palladion.Partners[NumCasts]))
-                BuildShape(target.Position).Outline(arena, _origin, default, ArenaColor.Safe);
+                BuildShape(target.Position).Outline(arena, _origin, default, ComponentType.Safe);
         }
 
         public override void OnEventCast(BossModule module, Actor caster, ActorCastEvent spell)
@@ -146,7 +146,7 @@ namespace BossMod.Endwalker.Savage.P12S1Athena
             UpdateStack(module, module.PrimaryActor.CastInfo?.FinishAt.AddSeconds(0.3f) ?? default);
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return IsStackTarget(player) ? PlayerPriority.Interesting : PlayerPriority.Normal;
         }
@@ -223,7 +223,7 @@ namespace BossMod.Endwalker.Savage.P12S1Athena
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (CurrentBaits.Count > 0)
-                arena.Actor(module.Bounds.Center, default, ArenaColor.Object);
+                arena.Actor(module.Bounds.Center, default, ComponentType.ActorObject);
             base.DrawArenaForeground(module, pcSlot, pc, arena);
         }
 

--- a/BossMod/Modules/Endwalker/Savage/P12S1Athena/SuperchainTheory.cs
+++ b/BossMod/Modules/Endwalker/Savage/P12S1Athena/SuperchainTheory.cs
@@ -101,7 +101,7 @@ namespace BossMod.Endwalker.Savage.P12S1Athena
             }
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return PlayerPriority.Normal;
         }
@@ -141,7 +141,7 @@ namespace BossMod.Endwalker.Savage.P12S1Athena
                         _shapeSpread.Outline(arena, c.Origin.Position, Angle.FromDirection(pc.Position - c.Origin.Position));
                         break;
                     case Shape.Pairs:
-                        _shapePair.Outline(arena, c.Origin.Position, Angle.FromDirection(pc.Position - c.Origin.Position), ArenaColor.Safe);
+                        _shapePair.Outline(arena, c.Origin.Position, Angle.FromDirection(pc.Position - c.Origin.Position), ComponentType.Safe);
                         break;
                 }
             }

--- a/BossMod/Modules/Endwalker/Savage/P12S1Athena/WhiteFlame.cs
+++ b/BossMod/Modules/Endwalker/Savage/P12S1Athena/WhiteFlame.cs
@@ -26,7 +26,7 @@ namespace BossMod.Endwalker.Savage.P12S1Athena
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             base.DrawArenaForeground(module, pcSlot, pc, arena);
-            arena.Actors(_sources, ArenaColor.Object, true);
+            arena.Actors(_sources, ComponentType.ActorObject, true);
         }
 
         public override void OnEventCast(BossModule module, Actor caster, ActorCastEvent spell)

--- a/BossMod/Modules/Endwalker/Savage/P12S2PallasAthena/ClassicalConcepts.cs
+++ b/BossMod/Modules/Endwalker/Savage/P12S2PallasAthena/ClassicalConcepts.cs
@@ -53,7 +53,7 @@ namespace BossMod.Endwalker.Savage.P12S2PallasAthena
             }
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return _states[pcSlot].PartnerSlot == playerSlot ? PlayerPriority.Danger : PlayerPriority.Irrelevant;
         }
@@ -62,16 +62,16 @@ namespace BossMod.Endwalker.Savage.P12S2PallasAthena
         {
             if (PlayerShapes(pcSlot) is var shapes && shapes.hexa != default && shapes.linked != default)
             {
-                arena.Actor(shapes.hexa, default, ArenaColor.Object);
-                arena.Actor(shapes.linked, default, ArenaColor.Object);
+                arena.Actor(shapes.hexa, default, ComponentType.ActorObject);
+                arena.Actor(shapes.linked, default, ComponentType.ActorObject);
                 var safespot = shapes.hexa + (shapes.linked - shapes.hexa) / 3;
-                arena.AddCircle(safespot, 1, ArenaColor.Safe);
+                arena.AddCircle(safespot, 1, ComponentType.Safe);
                 if (_invert)
-                    arena.AddCircle(InvertedPos(safespot), 1, ArenaColor.Danger);
+                    arena.AddCircle(InvertedPos(safespot), 1, ComponentType.Danger);
             }
             if (_showTethers && module.Raid[_states[pcSlot].PartnerSlot] is var partner && partner != null)
             {
-                arena.AddLine(pc.Position, partner.Position, ArenaColor.Safe);
+                arena.AddLine(pc.Position, partner.Position, ComponentType.Safe);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Savage/P12S2PallasAthena/Gaiaochos.cs
+++ b/BossMod/Modules/Endwalker/Savage/P12S2PallasAthena/Gaiaochos.cs
@@ -27,7 +27,7 @@ namespace BossMod.Endwalker.Savage.P12S2PallasAthena
                 hints.Add("Break the tether!");
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return _partner[pcSlot] == playerSlot ? PlayerPriority.Danger : PlayerPriority.Irrelevant;
         }
@@ -35,7 +35,7 @@ namespace BossMod.Endwalker.Savage.P12S2PallasAthena
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (module.Raid[_partner[pcSlot]] is var partner && partner != null)
-                arena.AddLine(pc.Position, partner.Position, ArenaColor.Danger);
+                arena.AddLine(pc.Position, partner.Position, ComponentType.Danger);
         }
 
         public override void OnTethered(BossModule module, Actor source, ActorTetherInfo tether)
@@ -175,7 +175,7 @@ namespace BossMod.Endwalker.Savage.P12S2PallasAthena
             }
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return _tethers.Any(t => t.target == player) ? PlayerPriority.Danger : PlayerPriority.Irrelevant;
         }
@@ -191,10 +191,10 @@ namespace BossMod.Endwalker.Savage.P12S2PallasAthena
         {
             foreach (var t in _tethers)
             {
-                arena.Actor(t.source, ArenaColor.Object, true);
-                arena.AddLine(t.source.Position, t.target.Position, ArenaColor.Danger);
+                arena.Actor(t.source, ComponentType.ActorObject, true);
+                arena.AddLine(t.source.Position, t.target.Position, ComponentType.Danger);
                 if (t.target == pc || !_vulnerable[pcSlot])
-                    _shape.Outline(arena, t.source.Position, Angle.FromDirection(t.target.Position - t.source.Position), t.target == pc ? ArenaColor.Safe : ArenaColor.Danger); // TODO: reconsider...
+                    _shape.Outline(arena, t.source.Position, Angle.FromDirection(t.target.Position - t.source.Position), t.target == pc ? ComponentType.Safe : ComponentType.Danger); // TODO: reconsider...
             }
         }
 

--- a/BossMod/Modules/Endwalker/Savage/P12S2PallasAthena/PalladianGrasp.cs
+++ b/BossMod/Modules/Endwalker/Savage/P12S2PallasAthena/PalladianGrasp.cs
@@ -33,7 +33,7 @@ namespace BossMod.Endwalker.Savage.P12S2PallasAthena
             }
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return Target(module)?.InstanceID == player.InstanceID ? PlayerPriority.Danger : PlayerPriority.Irrelevant;
         }
@@ -41,7 +41,7 @@ namespace BossMod.Endwalker.Savage.P12S2PallasAthena
         public override void DrawArenaBackground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (Target(module) is var target && target != default)
-                _shape.Draw(arena, Origin(module, target), default, pc.InstanceID == target.InstanceID ? ArenaColor.SafeFromAOE : ArenaColor.AOE);
+                _shape.Draw(arena, Origin(module, target), default, pc.InstanceID == target.InstanceID ? ComponentType.SafeFromAOE : ComponentType.AOE);
         }
 
         public override void OnCastStarted(BossModule module, Actor caster, ActorCastInfo spell)

--- a/BossMod/Modules/Endwalker/Savage/P12S2PallasAthena/Pangenesis.cs
+++ b/BossMod/Modules/Endwalker/Savage/P12S2PallasAthena/Pangenesis.cs
@@ -133,8 +133,8 @@ namespace BossMod.Endwalker.Savage.P12S2PallasAthena
             base.DrawArenaForeground(module, pcSlot, pc, arena);
             foreach (var s in _slimes)
             {
-                arena.Actor(s.source, ArenaColor.Object, true);
-                arena.AddLine(s.source.Position, s.target.Position, ArenaColor.Danger);
+                arena.Actor(s.source, ComponentType.ActorObject, true);
+                arena.AddLine(s.source.Position, s.target.Position, ComponentType.Danger);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Savage/P1SErichthonios/AetherExplosion.cs
+++ b/BossMod/Modules/Endwalker/Savage/P1SErichthonios/AetherExplosion.cs
@@ -10,7 +10,7 @@ namespace BossMod.Endwalker.Savage.P1SErichthonios
         private Actor? _memberWithSOT = null; // if not null, then every update exploding cells are recalculated based on this raid member's position
         private Cell _explodingCells = Cell.None;
 
-        private static uint _colorSOTActor = 0xff8080ff;
+        private static ComponentType _typeSOTActor = ComponentType.ActorA;
 
         public bool SOTActive => _memberWithSOT != null;
 
@@ -42,8 +42,8 @@ namespace BossMod.Endwalker.Savage.P1SErichthonios
             var start = _explodingCells == Cell.Blue ? 0.Degrees() : 45.Degrees();
             for (int i = 0; i < 4; ++i)
             {
-                arena.ZoneCone(module.Bounds.Center, 0, P1S.InnerCircleRadius, start + 22.5f.Degrees(), 22.5f.Degrees(), ArenaColor.AOE);
-                arena.ZoneCone(module.Bounds.Center, P1S.InnerCircleRadius, module.Bounds.HalfSize, start + 67.5f.Degrees(), 22.5f.Degrees(), ArenaColor.AOE);
+                arena.ZoneCone(module.Bounds.Center, 0, P1S.InnerCircleRadius, start + 22.5f.Degrees(), 22.5f.Degrees(), ComponentType.AOE);
+                arena.ZoneCone(module.Bounds.Center, P1S.InnerCircleRadius, module.Bounds.HalfSize, start + 67.5f.Degrees(), 22.5f.Degrees(), ComponentType.AOE);
                 start += 90.Degrees();
             }
         }
@@ -51,7 +51,7 @@ namespace BossMod.Endwalker.Savage.P1SErichthonios
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (_memberWithSOT != pc)
-                arena.Actor(_memberWithSOT, _colorSOTActor);
+                arena.Actor(_memberWithSOT, _typeSOTActor);
         }
 
         public override void OnStatusGain(BossModule module, Actor actor, ActorStatus status)

--- a/BossMod/Modules/Endwalker/Savage/P1SErichthonios/Intemperance.cs
+++ b/BossMod/Modules/Endwalker/Savage/P1SErichthonios/Intemperance.cs
@@ -236,17 +236,17 @@ namespace BossMod.Endwalker.Savage.P1SErichthonios
                 return pos1; // others return to initial spot
         }
 
-        private IEnumerable<(WPos, WPos, uint)> EnumMovementHints(BossModule module, WPos startingPosition, int assignment)
+        private IEnumerable<(WPos, WPos, ComponentType)> EnumMovementHints(BossModule module, WPos startingPosition, int assignment)
         {
             switch (NumExplosions)
             {
                 case 1:
                     var mid = PosCenter(module, Position2(module, assignment));
-                    yield return (mid, PosCenter(module, Position3(module, assignment)), ArenaColor.Danger);
-                    yield return (startingPosition, mid, ArenaColor.Safe);
+                    yield return (mid, PosCenter(module, Position3(module, assignment)), ComponentType.Danger);
+                    yield return (startingPosition, mid, ComponentType.Safe);
                     break;
                 case 2:
-                    yield return (startingPosition, PosCenter(module, Position3(module, assignment)), ArenaColor.Safe);
+                    yield return (startingPosition, PosCenter(module, Position3(module, assignment)), ComponentType.Safe);
                     break;
             }
         }

--- a/BossMod/Modules/Endwalker/Savage/P1SErichthonios/Knockback.cs
+++ b/BossMod/Modules/Endwalker/Savage/P1SErichthonios/Knockback.cs
@@ -14,7 +14,7 @@ namespace BossMod.Endwalker.Savage.P1SErichthonios
         private static float _kbDistance = 15;
         private static float _flareRange = 24; // max range is 50, but it has distance falloff - linear up to ~24, then constant ~3k
         private static float _holyRange = 6;
-        private static uint _colorAOETarget = 0xff8080ff;
+        private static ComponentType _typeAOETarget = ComponentType.ActorA;
 
         public override void Init(BossModule module)
         {
@@ -103,8 +103,8 @@ namespace BossMod.Endwalker.Savage.P1SErichthonios
         {
             if (module.PrimaryActor.CastInfo != null && pc == _knockbackTarget && pc.Position != _knockbackPos)
             {
-                arena.AddLine(pc.Position, _knockbackPos, ArenaColor.Danger);
-                arena.Actor(_knockbackPos, pc.Rotation, ArenaColor.Danger);
+                arena.AddLine(pc.Position, _knockbackPos, ComponentType.Danger);
+                arena.Actor(_knockbackPos, pc.Rotation, ComponentType.Danger);
             }
 
             var target = module.WorldState.Actors.Find(module.PrimaryActor.TargetID);
@@ -117,18 +117,18 @@ namespace BossMod.Endwalker.Savage.P1SErichthonios
             {
                 // there will be AOE around me, draw all players to help with positioning - note that we use position adjusted for knockback
                 foreach (var player in module.Raid.WithoutSlot())
-                    arena.Actor(player, player.Position.InCircle(targetPos, aoeRange) ? ArenaColor.PlayerInteresting : ArenaColor.PlayerGeneric);
+                    arena.Actor(player, player.Position.InCircle(targetPos, aoeRange) ? ComponentType.PlayerInteresting : ComponentType.PlayerGeneric);
             }
             else
             {
                 // draw AOE source
-                arena.Actor(targetPos, target.Rotation, _colorAOETarget);
+                arena.Actor(targetPos, target.Rotation, _typeAOETarget);
             }
-            arena.AddCircle(targetPos, aoeRange, ArenaColor.Danger);
+            arena.AddCircle(targetPos, aoeRange, ComponentType.Danger);
 
             // draw vulnerable target
             if (_knockbackTarget != pc && _knockbackTarget != target)
-                arena.Actor(_knockbackTarget, ArenaColor.Vulnerable);
+                arena.Actor(_knockbackTarget, ComponentType.ActorVulnerable);
         }
 
         public override void OnEventCast(BossModule module, Actor caster, ActorCastEvent spell)

--- a/BossMod/Modules/Endwalker/Savage/P1SErichthonios/P1S.cs
+++ b/BossMod/Modules/Endwalker/Savage/P1SErichthonios/P1S.cs
@@ -13,11 +13,11 @@
             {
                 // cells mode
                 float diag = Bounds.HalfSize / 1.414214f;
-                Arena.AddCircle(Bounds.Center, InnerCircleRadius, ArenaColor.Border);
-                Arena.AddLine(Bounds.Center + new WDir(Bounds.HalfSize, 0), Bounds.Center - new WDir(Bounds.HalfSize, 0), ArenaColor.Border);
-                Arena.AddLine(Bounds.Center + new WDir(0, Bounds.HalfSize), Bounds.Center - new WDir(0, Bounds.HalfSize), ArenaColor.Border);
-                Arena.AddLine(Bounds.Center + new WDir(diag,  diag), Bounds.Center - new WDir(diag,  diag), ArenaColor.Border);
-                Arena.AddLine(Bounds.Center + new WDir(diag, -diag), Bounds.Center - new WDir(diag, -diag), ArenaColor.Border);
+                Arena.AddCircle(Bounds.Center, InnerCircleRadius, ComponentType.Border);
+                Arena.AddLine(Bounds.Center + new WDir(Bounds.HalfSize, 0), Bounds.Center - new WDir(Bounds.HalfSize, 0), ComponentType.Border);
+                Arena.AddLine(Bounds.Center + new WDir(0, Bounds.HalfSize), Bounds.Center - new WDir(0, Bounds.HalfSize), ComponentType.Border);
+                Arena.AddLine(Bounds.Center + new WDir(diag,  diag), Bounds.Center - new WDir(diag,  diag), ComponentType.Border);
+                Arena.AddLine(Bounds.Center + new WDir(diag, -diag), Bounds.Center - new WDir(diag, -diag), ComponentType.Border);
             }
         }
     }

--- a/BossMod/Modules/Endwalker/Savage/P1SErichthonios/Shackles.cs
+++ b/BossMod/Modules/Endwalker/Savage/P1SErichthonios/Shackles.cs
@@ -19,7 +19,7 @@ namespace BossMod.Endwalker.Savage.P1SErichthonios
 
         private static float _blueExplosionRadius = 4;
         private static float _redExplosionRadius = 8;
-        private static uint TetherColor(bool blue, bool red) => blue ? (red ? 0xff00ffff : 0xffff0080) : (red ? 0xff8080ff : 0xff808080);
+        private static ComponentType TetherType(bool blue, bool red) => blue ? (red ? ComponentType.TetherMoveAway : ComponentType.TetherDontMove) : (red ? ComponentType.ActorA : ComponentType.PlayerGeneric);
 
         public override void Update(BossModule module)
         {
@@ -76,7 +76,7 @@ namespace BossMod.Endwalker.Savage.P1SErichthonios
 
             if (movementHints != null && _preferredPositions[slot] != new WPos())
             {
-                movementHints.Add(actor.Position, _preferredPositions[slot], ArenaColor.Safe);
+                movementHints.Add(actor.Position, _preferredPositions[slot], ComponentType.Safe);
             }
         }
 
@@ -91,17 +91,17 @@ namespace BossMod.Endwalker.Savage.P1SErichthonios
             {
                 var blueTetheredTo = _blueTetherMatrix[i];
                 var redTetheredTo = _redTetherMatrix[i];
-                arena.Actor(actor, TetherColor(blueTetheredTo.Any(), redTetheredTo.Any()));
+                arena.Actor(actor, TetherType(blueTetheredTo.Any(), redTetheredTo.Any()));
 
                 // draw tethers
                 foreach ((int j, var target) in module.Raid.WithSlot(true).Exclude(i).IncludedInMask(blueTetheredTo | redTetheredTo))
-                    arena.AddLine(actor.Position, target.Position, TetherColor(blueTetheredTo[j], redTetheredTo[j]));
+                    arena.AddLine(actor.Position, target.Position, TetherType(blueTetheredTo[j], redTetheredTo[j]));
 
                 // draw explosion circles that hit me
                 if (_blueExplosionMatrix[pcSlot, i])
-                    arena.AddCircle(actor.Position, _blueExplosionRadius, ArenaColor.Danger);
+                    arena.AddCircle(actor.Position, _blueExplosionRadius, ComponentType.Danger);
                 if (_redExplosionMatrix[pcSlot, i])
-                    arena.AddCircle(actor.Position, _redExplosionRadius, ArenaColor.Danger);
+                    arena.AddCircle(actor.Position, _redExplosionRadius, ComponentType.Danger);
 
                 drawBlueAroundMe |= _blueExplosionMatrix[i, pcSlot];
                 drawRedAroundMe |= _redExplosionMatrix[i, pcSlot];
@@ -109,13 +109,13 @@ namespace BossMod.Endwalker.Savage.P1SErichthonios
 
             // draw explosion circles if I hit anyone
             if (drawBlueAroundMe)
-                arena.AddCircle(pc.Position, _blueExplosionRadius, ArenaColor.Danger);
+                arena.AddCircle(pc.Position, _blueExplosionRadius, ComponentType.Danger);
             if (drawRedAroundMe)
-                arena.AddCircle(pc.Position, _redExplosionRadius, ArenaColor.Danger);
+                arena.AddCircle(pc.Position, _redExplosionRadius, ComponentType.Danger);
 
             // draw assigned spot, if any
             if (_preferredPositions[pcSlot] != new WPos())
-                arena.AddCircle(_preferredPositions[pcSlot], 2, ArenaColor.Safe);
+                arena.AddCircle(_preferredPositions[pcSlot], 2, ComponentType.Safe);
 
         }
 

--- a/BossMod/Modules/Endwalker/Savage/P2SHippokampos/ChannelingFlow.cs
+++ b/BossMod/Modules/Endwalker/Savage/P2SHippokampos/ChannelingFlow.cs
@@ -56,7 +56,7 @@ namespace BossMod.Endwalker.Savage.P2SHippokampos
         {
             foreach (var (player, dir) in ActiveArrows(module))
             {
-                arena.ZoneRect(player.Position, dir, 50, 0, _typhoonHalfWidth, ArenaColor.AOE);
+                arena.ZoneRect(player.Position, dir, 50, 0, _typhoonHalfWidth, ComponentType.AOE);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Savage/P2SHippokampos/Coherence.cs
+++ b/BossMod/Modules/Endwalker/Savage/P2SHippokampos/Coherence.cs
@@ -77,17 +77,17 @@ namespace BossMod.Endwalker.Savage.P2SHippokampos
             {
                 if (head?.Tether.Target == player.InstanceID)
                 {
-                    arena.AddLine(player.Position, module.PrimaryActor.Position, ArenaColor.Danger);
-                    arena.Actor(player, ArenaColor.Danger);
-                    arena.AddCircle(player.Position, _aoeRadius, ArenaColor.Danger);
+                    arena.AddLine(player.Position, module.PrimaryActor.Position, ComponentType.Danger);
+                    arena.Actor(player, ComponentType.Danger);
+                    arena.AddCircle(player.Position, _aoeRadius, ComponentType.Danger);
                 }
                 else if (player == _rayTarget)
                 {
-                    arena.Actor(player, ArenaColor.Danger);
+                    arena.Actor(player, ComponentType.Danger);
                 }
                 else if (player != _tetherTarget)
                 {
-                    arena.Actor(player, _inRay[i] ? ArenaColor.PlayerInteresting : ArenaColor.PlayerGeneric);
+                    arena.Actor(player, _inRay[i] ? ComponentType.PlayerInteresting : ComponentType.PlayerGeneric);
                 }
             }
         }

--- a/BossMod/Modules/Endwalker/Savage/P2SHippokampos/KampeosHarma.cs
+++ b/BossMod/Modules/Endwalker/Savage/P2SHippokampos/KampeosHarma.cs
@@ -17,7 +17,7 @@
                 hints.Add("Go to safe zone!");
                 if (movementHints != null)
                 {
-                    movementHints.Add(actor.Position, safePos.Value, ArenaColor.Danger);
+                    movementHints.Add(actor.Position, safePos.Value, ComponentType.Danger);
                 }
             }
         }
@@ -26,7 +26,7 @@
         {
             var pos = GetSafeZone(module, pcSlot);
             if (pos != null)
-                arena.AddCircle(pos.Value, 1, ArenaColor.Safe);
+                arena.AddCircle(pos.Value, 1, ComponentType.Safe);
         }
 
         public override void OnEventIcon(BossModule module, Actor actor, uint iconID)

--- a/BossMod/Modules/Endwalker/Savage/P2SHippokampos/OminousBubbling.cs
+++ b/BossMod/Modules/Endwalker/Savage/P2SHippokampos/OminousBubbling.cs
@@ -23,12 +23,12 @@ namespace BossMod.Endwalker.Savage.P2SHippokampos
             {
                 if (player.Role == Role.Healer)
                 {
-                    arena.Actor(player, ArenaColor.Danger);
-                    arena.AddCircle(player.Position, _radius, ArenaColor.Danger);
+                    arena.Actor(player, ComponentType.Danger);
+                    arena.AddCircle(player.Position, _radius, ComponentType.Danger);
                 }
                 else
                 {
-                    arena.Actor(player, ArenaColor.PlayerGeneric);
+                    arena.Actor(player, ComponentType.PlayerGeneric);
                 }
             }
         }

--- a/BossMod/Modules/Endwalker/Savage/P2SHippokampos/PredatoryAvarice.cs
+++ b/BossMod/Modules/Endwalker/Savage/P2SHippokampos/PredatoryAvarice.cs
@@ -75,20 +75,20 @@ namespace BossMod.Endwalker.Savage.P2SHippokampos
                 if (_playersWithTides[i])
                 {
                     // tides are always drawn
-                    arena.AddCircle(actor.Position, _tidesRadius, ArenaColor.Danger);
-                    arena.Actor(actor, ArenaColor.Danger);
+                    arena.AddCircle(actor.Position, _tidesRadius, ComponentType.Danger);
+                    arena.Actor(actor, ComponentType.Danger);
                 }
                 else if (_playersWithDepths[i] && !pcHasTides)
                 {
                     // depths are drawn only if pc has no tides - otherwise it is to be considered a generic player
-                    arena.AddCircle(actor.Position, _tidesRadius, ArenaColor.Safe);
-                    arena.Actor(actor, ArenaColor.Danger);
+                    arena.AddCircle(actor.Position, _tidesRadius, ComponentType.Safe);
+                    arena.Actor(actor, ComponentType.Danger);
                 }
                 else if (pcHasTides || pcHasDepths)
                 {
                     // other players are only drawn if pc has some debuff
                     bool playerInteresting = pcHasTides ? _playersInTides[i] : _playersInDepths[i];
-                    arena.Actor(actor.Position, actor.Rotation, playerInteresting ? ArenaColor.PlayerInteresting : ArenaColor.PlayerGeneric);
+                    arena.Actor(actor.Position, actor.Rotation, playerInteresting ? ComponentType.PlayerInteresting : ComponentType.PlayerGeneric);
                 }
             }
         }

--- a/BossMod/Modules/Endwalker/Savage/P2SHippokampos/SewageDeluge.cs
+++ b/BossMod/Modules/Endwalker/Savage/P2SHippokampos/SewageDeluge.cs
@@ -23,23 +23,23 @@
                 return;
 
             // central area + H additionals
-            arena.ZoneRect(module.Bounds.Center, new WDir( 1, 0), _connectInner, _connectInner, _cornerInner, ArenaColor.AOE);
+            arena.ZoneRect(module.Bounds.Center, new WDir( 1, 0), _connectInner, _connectInner, _cornerInner, ComponentType.AOE);
             // central V additionals
-            arena.ZoneRect(module.Bounds.Center, new WDir(0,  1), _connectInner, -_cornerInner, _cornerInner, ArenaColor.AOE);
-            arena.ZoneRect(module.Bounds.Center, new WDir(0, -1), _connectInner, -_cornerInner, _cornerInner, ArenaColor.AOE);
+            arena.ZoneRect(module.Bounds.Center, new WDir(0,  1), _connectInner, -_cornerInner, _cornerInner, ComponentType.AOE);
+            arena.ZoneRect(module.Bounds.Center, new WDir(0, -1), _connectInner, -_cornerInner, _cornerInner, ComponentType.AOE);
             // outer additionals
-            arena.ZoneRect(module.Bounds.Center, new WDir( 1, 0), _cornerOuter, -_connectOuter, _cornerInner, ArenaColor.AOE);
-            arena.ZoneRect(module.Bounds.Center, new WDir(-1, 0), _cornerOuter, -_connectOuter, _cornerInner, ArenaColor.AOE);
-            arena.ZoneRect(module.Bounds.Center, new WDir(0,  1), _cornerOuter, -_connectOuter, _cornerInner, ArenaColor.AOE);
-            arena.ZoneRect(module.Bounds.Center, new WDir(0, -1), _cornerOuter, -_connectOuter, _cornerInner, ArenaColor.AOE);
+            arena.ZoneRect(module.Bounds.Center, new WDir( 1, 0), _cornerOuter, -_connectOuter, _cornerInner, ComponentType.AOE);
+            arena.ZoneRect(module.Bounds.Center, new WDir(-1, 0), _cornerOuter, -_connectOuter, _cornerInner, ComponentType.AOE);
+            arena.ZoneRect(module.Bounds.Center, new WDir(0,  1), _cornerOuter, -_connectOuter, _cornerInner, ComponentType.AOE);
+            arena.ZoneRect(module.Bounds.Center, new WDir(0, -1), _cornerOuter, -_connectOuter, _cornerInner, ComponentType.AOE);
             // outer area
-            arena.ZoneRect(module.Bounds.Center, new WDir( 1, 0), module.Bounds.HalfSize, -_cornerOuter, module.Bounds.HalfSize, ArenaColor.AOE);
-            arena.ZoneRect(module.Bounds.Center, new WDir(-1, 0), module.Bounds.HalfSize, -_cornerOuter, module.Bounds.HalfSize, ArenaColor.AOE);
-            arena.ZoneRect(module.Bounds.Center, new WDir(0,  1), module.Bounds.HalfSize, -_cornerOuter, _cornerOuter, ArenaColor.AOE);
-            arena.ZoneRect(module.Bounds.Center, new WDir(0, -1), module.Bounds.HalfSize, -_cornerOuter, _cornerOuter, ArenaColor.AOE);
+            arena.ZoneRect(module.Bounds.Center, new WDir( 1, 0), module.Bounds.HalfSize, -_cornerOuter, module.Bounds.HalfSize, ComponentType.AOE);
+            arena.ZoneRect(module.Bounds.Center, new WDir(-1, 0), module.Bounds.HalfSize, -_cornerOuter, module.Bounds.HalfSize, ComponentType.AOE);
+            arena.ZoneRect(module.Bounds.Center, new WDir(0,  1), module.Bounds.HalfSize, -_cornerOuter, _cornerOuter, ComponentType.AOE);
+            arena.ZoneRect(module.Bounds.Center, new WDir(0, -1), module.Bounds.HalfSize, -_cornerOuter, _cornerOuter, ComponentType.AOE);
 
             var corner = module.Bounds.Center + _corners[(int)_blockedCorner] * _offsetCorner;
-            arena.ZoneRect(corner, new WDir(1, 0), _cornerHalfSize, _cornerHalfSize, _cornerHalfSize, ArenaColor.AOE);
+            arena.ZoneRect(corner, new WDir(1, 0), _cornerHalfSize, _cornerHalfSize, _cornerHalfSize, ComponentType.AOE);
         }
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
@@ -57,7 +57,7 @@
             arena.PathLineTo(module.Bounds.Center + new WDir(-_cornerInner, +_cornerInner));
             arena.PathLineTo(module.Bounds.Center + new WDir(-_connectInner, +_cornerInner));
             arena.PathLineTo(module.Bounds.Center + new WDir(-_connectInner, -_cornerInner));
-            arena.PathStroke(true, ArenaColor.Border);
+            arena.PathStroke(true, ComponentType.Border);
 
             // outer border
             arena.PathLineTo(module.Bounds.Center + new WDir(-_cornerOuter, -_cornerOuter));
@@ -80,7 +80,7 @@
             arena.PathLineTo(module.Bounds.Center + new WDir(-_connectOuter, +_cornerInner));
             arena.PathLineTo(module.Bounds.Center + new WDir(-_connectOuter, -_cornerInner));
             arena.PathLineTo(module.Bounds.Center + new WDir(-_cornerOuter, -_cornerInner));
-            arena.PathStroke(true, ArenaColor.Border);
+            arena.PathStroke(true, ComponentType.Border);
         }
 
         public override void OnEventEnvControl(BossModule module, byte index, uint state)

--- a/BossMod/Modules/Endwalker/Savage/P2SHippokampos/TaintedFlood.cs
+++ b/BossMod/Modules/Endwalker/Savage/P2SHippokampos/TaintedFlood.cs
@@ -48,15 +48,15 @@ namespace BossMod.Endwalker.Savage.P2SHippokampos
             {
                 foreach ((_, var actor) in module.Raid.WithSlot().ExcludedFromMask(_ignoredTargets))
                 {
-                    arena.Actor(actor, ArenaColor.Danger);
-                    arena.AddCircle(actor.Position, _radius, ArenaColor.Danger);
+                    arena.Actor(actor, ComponentType.Danger);
+                    arena.AddCircle(actor.Position, _radius, ComponentType.Danger);
                 }
             }
             else
             {
-                arena.AddCircle(pc.Position, _radius, ArenaColor.Danger);
+                arena.AddCircle(pc.Position, _radius, ComponentType.Danger);
                 foreach (var player in module.Raid.WithoutSlot().Exclude(pc))
-                    arena.Actor(player, player.Position.InCircle(pc.Position, _radius) ? ArenaColor.PlayerInteresting : ArenaColor.PlayerGeneric);
+                    arena.Actor(player, player.Position.InCircle(pc.Position, _radius) ? ComponentType.PlayerInteresting : ComponentType.PlayerGeneric);
             }
         }
     }

--- a/BossMod/Modules/Endwalker/Savage/P3SPhoinix/Ashplume.cs
+++ b/BossMod/Modules/Endwalker/Savage/P3SPhoinix/Ashplume.cs
@@ -76,11 +76,11 @@ namespace BossMod.Endwalker.Savage.P3SPhoinix
             float aoeRadius = CurState == State.Stack ? _stackRadius : _spreadRadius;
             foreach (var player in module.Raid.WithoutSlot().Exclude(pc))
             {
-                arena.Actor(player, player.Position.InCircle(pc.Position, aoeRadius) ? ArenaColor.PlayerInteresting : ArenaColor.PlayerGeneric);
+                arena.Actor(player, player.Position.InCircle(pc.Position, aoeRadius) ? ComponentType.PlayerInteresting : ComponentType.PlayerGeneric);
             }
 
             // draw circle around pc
-            arena.AddCircle(pc.Position, aoeRadius, ArenaColor.Danger);
+            arena.AddCircle(pc.Position, aoeRadius, ComponentType.Danger);
         }
 
         public override void OnEventCast(BossModule module, Actor caster, ActorCastEvent spell)

--- a/BossMod/Modules/Endwalker/Savage/P3SPhoinix/BirdDistance.cs
+++ b/BossMod/Modules/Endwalker/Savage/P3SPhoinix/BirdDistance.cs
@@ -55,11 +55,11 @@ namespace BossMod.Endwalker.Savage.P3SPhoinix
                 var bird = watchedBirds[i];
                 if (bird.IsDead)
                 {
-                    arena.AddCircle(bird.Position, _radius, ArenaColor.Danger);
+                    arena.AddCircle(bird.Position, _radius, ComponentType.Danger);
                 }
                 else if (bird.TargetID == pc.InstanceID)
                 {
-                    arena.Actor(bird, _birdsAtRisk[i] ? ArenaColor.Enemy : ArenaColor.PlayerGeneric);
+                    arena.Actor(bird, _birdsAtRisk[i] ? ComponentType.ActorEnemy : ComponentType.PlayerGeneric);
                 }
             }
         }

--- a/BossMod/Modules/Endwalker/Savage/P3SPhoinix/BirdTether.cs
+++ b/BossMod/Modules/Endwalker/Savage/P3SPhoinix/BirdTether.cs
@@ -101,7 +101,7 @@ namespace BossMod.Endwalker.Savage.P3SPhoinix
                 {
                     var fromTo = nextTarget.Position - bird.Position;
                     float len = fromTo.Length();
-                    arena.ZoneRect(bird.Position, fromTo / len, len, 0, _chargeHalfWidth, ArenaColor.AOE);
+                    arena.ZoneRect(bird.Position, fromTo / len, len, 0, _chargeHalfWidth, ComponentType.AOE);
                 }
             }
         }
@@ -111,9 +111,9 @@ namespace BossMod.Endwalker.Savage.P3SPhoinix
             // draw all birds and all players
             var birdsLarge = module.Enemies(OID.SunbirdLarge);
             foreach (var bird in birdsLarge)
-                arena.Actor(bird, ArenaColor.Enemy);
+                arena.Actor(bird, ComponentType.ActorEnemy);
             foreach ((int i, var player) in module.Raid.WithSlot())
-                arena.Actor(player, _playersInAOE[i] ? ArenaColor.PlayerInteresting : ArenaColor.PlayerGeneric);
+                arena.Actor(player, _playersInAOE[i] ? ComponentType.PlayerInteresting : ComponentType.PlayerGeneric);
 
             // draw chains containing player
             foreach ((var bird, (var p1, var p2, int numCharges)) in birdsLarge.Zip(_chains))
@@ -126,16 +126,16 @@ namespace BossMod.Endwalker.Savage.P3SPhoinix
                     // bird -> pc -> other
                     if (numCharges == 0)
                     {
-                        arena.AddLine(bird.Position, pc.Position, (bird.Tether.ID == (uint)TetherID.LargeBirdFar) ? ArenaColor.Safe : ArenaColor.Danger);
+                        arena.AddLine(bird.Position, pc.Position, (bird.Tether.ID == (uint)TetherID.LargeBirdFar) ? ComponentType.Safe : ComponentType.Danger);
                         if (p2 != null)
                         {
-                            arena.AddLine(pc.Position, p2.Position, (pc.Tether.ID == (uint)TetherID.LargeBirdFar) ? ArenaColor.Safe : ArenaColor.Danger);
+                            arena.AddLine(pc.Position, p2.Position, (pc.Tether.ID == (uint)TetherID.LargeBirdFar) ? ComponentType.Safe : ComponentType.Danger);
                         }
 
                         if (bird.Position != module.Bounds.Center)
                         {
                             var safespot = bird.Position + (module.Bounds.Center - bird.Position).Normalized() * _chargeMinSafeDistance;
-                            arena.AddCircle(safespot, 1, ArenaColor.Safe);
+                            arena.AddCircle(safespot, 1, ComponentType.Safe);
                         }
                     }
                     // else: don't care, charge to pc already happened
@@ -145,19 +145,19 @@ namespace BossMod.Endwalker.Savage.P3SPhoinix
                     // bird -> other -> pc
                     if (numCharges == 0)
                     {
-                        arena.AddLine(bird.Position, p1.Position, (bird.Tether.ID == (uint)TetherID.LargeBirdFar) ? ArenaColor.Safe : ArenaColor.Danger);
-                        arena.AddLine(p1.Position, pc.Position, (p1.Tether.ID == (uint)TetherID.LargeBirdFar) ? ArenaColor.Safe : ArenaColor.Danger);
+                        arena.AddLine(bird.Position, p1.Position, (bird.Tether.ID == (uint)TetherID.LargeBirdFar) ? ComponentType.Safe : ComponentType.Danger);
+                        arena.AddLine(p1.Position, pc.Position, (p1.Tether.ID == (uint)TetherID.LargeBirdFar) ? ComponentType.Safe : ComponentType.Danger);
 
-                        arena.AddCircle(bird.Position, 1, ArenaColor.Safe); // draw safespot near bird
+                        arena.AddCircle(bird.Position, 1, ComponentType.Safe); // draw safespot near bird
                     }
                     else
                     {
-                        arena.AddLine(bird.Position, pc.Position, (p1.Tether.ID == (uint)TetherID.LargeBirdFar) ? ArenaColor.Safe : ArenaColor.Danger);
+                        arena.AddLine(bird.Position, pc.Position, (p1.Tether.ID == (uint)TetherID.LargeBirdFar) ? ComponentType.Safe : ComponentType.Danger);
 
                         if (bird.Position != module.Bounds.Center)
                         {
                             var safespot = bird.Position + (module.Bounds.Center - bird.Position).Normalized() * _chargeMinSafeDistance;
-                            arena.AddCircle(safespot, 1, ArenaColor.Safe);
+                            arena.AddCircle(safespot, 1, ComponentType.Safe);
                         }
                     }
                 }

--- a/BossMod/Modules/Endwalker/Savage/P3SPhoinix/BrightenedFire.cs
+++ b/BossMod/Modules/Endwalker/Savage/P3SPhoinix/BrightenedFire.cs
@@ -36,17 +36,17 @@ namespace BossMod.Endwalker.Savage.P3SPhoinix
                 return;
 
             var pos = PositionForOrder(module, _playerOrder[pcSlot]);
-            arena.AddCircle(pos, 1, ArenaColor.Safe);
+            arena.AddCircle(pos, 1, ComponentType.Safe);
 
             // draw all adds
             int addIndex = 0;
             foreach (var fire in module.Enemies(OID.DarkenedFire).SortedByRange(pos))
             {
-                arena.Actor(fire, addIndex++ < 2 ? ArenaColor.Danger : ArenaColor.PlayerGeneric);
+                arena.Actor(fire, addIndex++ < 2 ? ComponentType.Danger : ComponentType.PlayerGeneric);
             }
 
             // draw range circle
-            arena.AddCircle(pc.Position, _aoeRange, ArenaColor.Danger);
+            arena.AddCircle(pc.Position, _aoeRange, ComponentType.Danger);
         }
 
         public override void OnEventIcon(BossModule module, Actor actor, uint iconID)

--- a/BossMod/Modules/Endwalker/Savage/P3SPhoinix/DarkblazeTwister.cs
+++ b/BossMod/Modules/Endwalker/Savage/P3SPhoinix/DarkblazeTwister.cs
@@ -36,8 +36,8 @@ namespace BossMod.Endwalker.Savage.P3SPhoinix
         {
             foreach (var twister in BurningTwisters(module))
             {
-                arena.ZoneCircle(twister.Position, _aoeInnerRadius, ArenaColor.AOE);
-                arena.ZoneDonut(twister.Position, _aoeMiddleRadius, _aoeOuterRadius, ArenaColor.AOE);
+                arena.ZoneCircle(twister.Position, _aoeInnerRadius, ComponentType.AOE);
+                arena.ZoneDonut(twister.Position, _aoeMiddleRadius, _aoeOuterRadius, ComponentType.AOE);
             }
         }
 
@@ -50,8 +50,8 @@ namespace BossMod.Endwalker.Savage.P3SPhoinix
             var adjPos = Components.Knockback.AwayFromSource(pc.Position, darkTwister, _knockbackRange);
             if (adjPos != pc.Position)
             {
-                arena.AddLine(pc.Position, adjPos, ArenaColor.Danger);
-                arena.Actor(adjPos, pc.Rotation, ArenaColor.Danger);
+                arena.AddLine(pc.Position, adjPos, ComponentType.Danger);
+                arena.Actor(adjPos, pc.Rotation, ComponentType.Danger);
             }
 
             var safeOffset = _knockbackRange + (_aoeInnerRadius + _aoeMiddleRadius) / 2;
@@ -61,7 +61,7 @@ namespace BossMod.Endwalker.Savage.P3SPhoinix
                 var dir = burningTwister.Position - darkTwister.Position;
                 var len = dir.Length();
                 dir /= len;
-                arena.AddCircle(darkTwister.Position + dir * (len - safeOffset), safeRadius, ArenaColor.Safe);
+                arena.AddCircle(darkTwister.Position + dir * (len - safeOffset), safeRadius, ComponentType.Safe);
             }
         }
     }

--- a/BossMod/Modules/Endwalker/Savage/P3SPhoinix/DarkenedFire.cs
+++ b/BossMod/Modules/Endwalker/Savage/P3SPhoinix/DarkenedFire.cs
@@ -38,12 +38,12 @@ namespace BossMod.Endwalker.Savage.P3SPhoinix
             {
                 bool tooClose = player.Position.InCircle(pc.Position, _minRange);
                 bool inRange = player.Position.InCircle(pc.Position, _maxRange);
-                arena.Actor(player, tooClose ? ArenaColor.Danger : (inRange ? ArenaColor.PlayerInteresting : ArenaColor.PlayerGeneric));
+                arena.Actor(player, tooClose ? ComponentType.Danger : (inRange ? ComponentType.PlayerInteresting : ComponentType.PlayerGeneric));
             }
 
             // draw circles around pc
-            arena.AddCircle(pc.Position, _minRange, ArenaColor.Danger);
-            arena.AddCircle(pc.Position, _maxRange, ArenaColor.Safe);
+            arena.AddCircle(pc.Position, _minRange, ComponentType.Danger);
+            arena.AddCircle(pc.Position, _maxRange, ComponentType.Safe);
         }
 
         private bool CanBothBeTargets(Actor one, Actor two)

--- a/BossMod/Modules/Endwalker/Savage/P3SPhoinix/DevouringBrand.cs
+++ b/BossMod/Modules/Endwalker/Savage/P3SPhoinix/DevouringBrand.cs
@@ -18,9 +18,9 @@ namespace BossMod.Endwalker.Savage.P3SPhoinix
 
         public override void DrawArenaBackground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
-            arena.ZoneRect(module.Bounds.Center, new WDir(1,  0), module.Bounds.HalfSize, module.Bounds.HalfSize, _halfWidth, ArenaColor.AOE);
-            arena.ZoneRect(module.Bounds.Center, new WDir(0,  1), module.Bounds.HalfSize, -_halfWidth, _halfWidth, ArenaColor.AOE);
-            arena.ZoneRect(module.Bounds.Center, new WDir(0, -1), module.Bounds.HalfSize, -_halfWidth, _halfWidth, ArenaColor.AOE);
+            arena.ZoneRect(module.Bounds.Center, new WDir(1,  0), module.Bounds.HalfSize, module.Bounds.HalfSize, _halfWidth, ComponentType.AOE);
+            arena.ZoneRect(module.Bounds.Center, new WDir(0,  1), module.Bounds.HalfSize, -_halfWidth, _halfWidth, ComponentType.AOE);
+            arena.ZoneRect(module.Bounds.Center, new WDir(0, -1), module.Bounds.HalfSize, -_halfWidth, _halfWidth, ComponentType.AOE);
         }
     }
 }

--- a/BossMod/Modules/Endwalker/Savage/P3SPhoinix/Fireplume.cs
+++ b/BossMod/Modules/Endwalker/Savage/P3SPhoinix/Fireplume.cs
@@ -36,13 +36,13 @@
         {
             if (_singlePos != null)
             {
-                arena.ZoneCircle(_singlePos.Value, _singleRadius, ArenaColor.AOE);
+                arena.ZoneCircle(_singlePos.Value, _singleRadius, ComponentType.AOE);
             }
 
             if (_multiStartedCasts > _multiFinishedCasts)
             {
                 if (_multiFinishedCasts > 0) // don't draw center aoe before first explosion, it's confusing - but start drawing it immediately after first explosion, to simplify positioning
-                    arena.ZoneCircle(module.Bounds.Center, _multiRadius, _multiFinishedCasts >= 6 ? ArenaColor.Danger : ArenaColor.AOE);
+                    arena.ZoneCircle(module.Bounds.Center, _multiRadius, _multiFinishedCasts >= 6 ? ComponentType.Danger : ComponentType.AOE);
 
                 // don't draw more than two next pairs
                 if (_multiFinishedCasts < 8)
@@ -97,8 +97,8 @@
         private void DrawPair(MiniArena arena, Angle direction, bool imminent)
         {
             var offset = _multiPairOffset * direction.ToDirection();
-            arena.ZoneCircle(arena.Bounds.Center + offset, _multiRadius, imminent ? ArenaColor.Danger : ArenaColor.AOE);
-            arena.ZoneCircle(arena.Bounds.Center - offset, _multiRadius, imminent ? ArenaColor.Danger : ArenaColor.AOE);
+            arena.ZoneCircle(arena.Bounds.Center + offset, _multiRadius, imminent ? ComponentType.Danger : ComponentType.AOE);
+            arena.ZoneCircle(arena.Bounds.Center - offset, _multiRadius, imminent ? ComponentType.Danger : ComponentType.AOE);
         }
     }
 }

--- a/BossMod/Modules/Endwalker/Savage/P3SPhoinix/FlamesOfAsphodelos.cs
+++ b/BossMod/Modules/Endwalker/Savage/P3SPhoinix/FlamesOfAsphodelos.cs
@@ -19,17 +19,17 @@ namespace BossMod.Endwalker.Savage.P3SPhoinix
         {
             if (_directions[0] != null)
             {
-                DrawZone(arena, _directions[0], ArenaColor.Danger);
-                DrawZone(arena, _directions[1], ArenaColor.AOE);
+                DrawZone(arena, _directions[0], ComponentType.Danger);
+                DrawZone(arena, _directions[1], ComponentType.AOE);
             }
             else if (_directions[1] != null)
             {
-                DrawZone(arena, _directions[1], ArenaColor.Danger);
-                DrawZone(arena, _directions[2], ArenaColor.AOE);
+                DrawZone(arena, _directions[1], ComponentType.Danger);
+                DrawZone(arena, _directions[2], ComponentType.AOE);
             }
             else
             {
-                DrawZone(arena, _directions[2], ArenaColor.Danger);
+                DrawZone(arena, _directions[2], ComponentType.Danger);
             }
         }
 
@@ -65,12 +65,12 @@ namespace BossMod.Endwalker.Savage.P3SPhoinix
             }
         }
 
-        private void DrawZone(MiniArena arena, Angle? dir, uint color)
+        private void DrawZone(MiniArena arena, Angle? dir, ComponentType type)
         {
             if (dir != null)
             {
-                arena.ZoneIsoscelesTri(arena.Bounds.Center, dir.Value, 30.Degrees(), 50, color);
-                arena.ZoneIsoscelesTri(arena.Bounds.Center, dir.Value + 180.Degrees(), 30.Degrees(), 50, color);
+                arena.ZoneIsoscelesTri(arena.Bounds.Center, dir.Value, 30.Degrees(), 50, type);
+                arena.ZoneIsoscelesTri(arena.Bounds.Center, dir.Value + 180.Degrees(), 30.Degrees(), 50, type);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Savage/P3SPhoinix/FledglingFlight.cs
+++ b/BossMod/Modules/Endwalker/Savage/P3SPhoinix/FledglingFlight.cs
@@ -55,18 +55,18 @@ namespace BossMod.Endwalker.Savage.P3SPhoinix
 
             // draw all players
             foreach ((int i, var player) in module.Raid.WithSlot())
-                arena.Actor(player, _playerAOECount[i] != _playerDeathTollStacks[i] ? ArenaColor.PlayerInteresting : ArenaColor.PlayerGeneric);
+                arena.Actor(player, _playerAOECount[i] != _playerDeathTollStacks[i] ? ComponentType.PlayerInteresting : ComponentType.PlayerGeneric);
 
             var eyePos = GetEyePlacementPosition(module, pcSlot, pc);
             if (eyePos != null)
-                arena.AddCircle(eyePos.Value, 1, ArenaColor.Safe);
+                arena.AddCircle(eyePos.Value, 1, ComponentType.Safe);
         }
 
         public override void DrawArenaBackground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach ((var source, var dir) in _sources)
             {
-                arena.ZoneIsoscelesTri(source.Position, dir, _coneHalfAngle, 50, ArenaColor.AOE);
+                arena.ZoneIsoscelesTri(source.Position, dir, _coneHalfAngle, 50, ComponentType.AOE);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Savage/P3SPhoinix/StormsOfAsphodelos.cs
+++ b/BossMod/Modules/Endwalker/Savage/P3SPhoinix/StormsOfAsphodelos.cs
@@ -117,17 +117,17 @@ namespace BossMod.Endwalker.Savage.P3SPhoinix
         {
             foreach (var twister in module.Enemies(OID.DarkblazeTwister))
             {
-                arena.Actor(twister, ArenaColor.Enemy, true);
+                arena.Actor(twister, ComponentType.ActorEnemy, true);
             }
 
             foreach ((int i, var player) in module.Raid.WithSlot())
             {
                 bool tethered = _tetherTargets[i];
                 if (tethered)
-                    arena.AddLine(module.PrimaryActor.Position, player.Position, player.Role == Role.Tank ? ArenaColor.Safe : ArenaColor.Danger);
+                    arena.AddLine(module.PrimaryActor.Position, player.Position, player.Role == Role.Tank ? ComponentType.Safe : ComponentType.Danger);
                 bool active = tethered || _bossTargets[i] || _twisterTargets.Contains(player);
                 bool failing = (_hitByMultipleAOEs | _closeToTetherTarget)[i];
-                arena.Actor(player, active ? ArenaColor.Danger : (failing ? ArenaColor.PlayerInteresting : ArenaColor.PlayerGeneric));
+                arena.Actor(player, active ? ComponentType.Danger : (failing ? ComponentType.PlayerInteresting : ComponentType.PlayerGeneric));
             }
         }
 

--- a/BossMod/Modules/Endwalker/Savage/P3SPhoinix/SunshadowTether.cs
+++ b/BossMod/Modules/Endwalker/Savage/P3SPhoinix/SunshadowTether.cs
@@ -60,7 +60,7 @@ namespace BossMod.Endwalker.Savage.P3SPhoinix
                 if (target != null && target.Position != bird.Position)
                 {
                     var dir = (target.Position - bird.Position).Normalized();
-                    arena.ZoneRect(bird.Position, dir, 50, 0, _chargeHalfWidth, ArenaColor.AOE);
+                    arena.ZoneRect(bird.Position, dir, 50, 0, _chargeHalfWidth, ComponentType.AOE);
                 }
             }
         }
@@ -72,14 +72,14 @@ namespace BossMod.Endwalker.Savage.P3SPhoinix
 
             // draw all players
             foreach ((int i, var player) in module.Raid.WithSlot())
-                arena.Actor(player, _playersInAOE[i] ? ArenaColor.PlayerInteresting : ArenaColor.PlayerGeneric);
+                arena.Actor(player, _playersInAOE[i] ? ComponentType.PlayerInteresting : ComponentType.PlayerGeneric);
 
             // draw my tether
             var myBird = module.Enemies(OID.Sunshadow).Find(bird => BirdTarget(bird) == pc.InstanceID);
             if (myBird != null && !_chargedSunshadows.Contains(myBird.InstanceID))
             {
-                arena.AddLine(myBird.Position, pc.Position, myBird.Tether.ID != (uint)TetherID.LargeBirdFar ? ArenaColor.Danger : ArenaColor.Safe);
-                arena.Actor(myBird, ArenaColor.Enemy);
+                arena.AddLine(myBird.Position, pc.Position, myBird.Tether.ID != (uint)TetherID.LargeBirdFar ? ComponentType.Danger : ComponentType.Safe);
+                arena.Actor(myBird, ComponentType.ActorEnemy);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Savage/P3SPhoinix/TrailOfCondemnation.cs
+++ b/BossMod/Modules/Endwalker/Savage/P3SPhoinix/TrailOfCondemnation.cs
@@ -69,13 +69,13 @@ namespace BossMod.Endwalker.Savage.P3SPhoinix
             var dir = (module.Bounds.Center - module.PrimaryActor.Position).Normalized();
             if (_isCenter)
             {
-                arena.ZoneRect(module.PrimaryActor.Position, dir, 2 * module.Bounds.HalfSize, 0, _halfWidth, ArenaColor.AOE);
+                arena.ZoneRect(module.PrimaryActor.Position, dir, 2 * module.Bounds.HalfSize, 0, _halfWidth, ComponentType.AOE);
             }
             else
             {
                 var offset = _sidesOffset * dir.OrthoR();
-                arena.ZoneRect(module.PrimaryActor.Position + offset, dir, 2 * module.Bounds.HalfSize, 0, _halfWidth, ArenaColor.AOE);
-                arena.ZoneRect(module.PrimaryActor.Position - offset, dir, 2 * module.Bounds.HalfSize, 0, _halfWidth, ArenaColor.AOE);
+                arena.ZoneRect(module.PrimaryActor.Position + offset, dir, 2 * module.Bounds.HalfSize, 0, _halfWidth, ComponentType.AOE);
+                arena.ZoneRect(module.PrimaryActor.Position - offset, dir, 2 * module.Bounds.HalfSize, 0, _halfWidth, ComponentType.AOE);
             }
         }
 
@@ -85,11 +85,11 @@ namespace BossMod.Endwalker.Savage.P3SPhoinix
             foreach (var player in module.Raid.WithoutSlot().Exclude(pc))
             {
                 bool inRange = player.Position.InCircle(pc.Position, _aoeRadius);
-                arena.Actor(player, inRange ? ArenaColor.PlayerInteresting : ArenaColor.PlayerGeneric);
+                arena.Actor(player, inRange ? ComponentType.PlayerInteresting : ComponentType.PlayerGeneric);
             }
 
             // draw circle around pc
-            arena.AddCircle(pc.Position, _aoeRadius, ArenaColor.Danger);
+            arena.AddCircle(pc.Position, _aoeRadius, ComponentType.Danger);
         }
 
         public override void OnEventCast(BossModule module, Actor caster, ActorCastEvent spell)

--- a/BossMod/Modules/Endwalker/Savage/P4S1Hesperos/BeloneCoils.cs
+++ b/BossMod/Modules/Endwalker/Savage/P4S1Hesperos/BeloneCoils.cs
@@ -47,7 +47,7 @@ namespace BossMod.Endwalker.Savage.P4S1Hesperos
             bool validSoaker = IsValidSoaker(pc);
             foreach (var tower in _activeTowers)
             {
-                arena.AddCircle(tower.Position, _towerRadius, validSoaker ? ArenaColor.Safe : ArenaColor.Danger);
+                arena.AddCircle(tower.Position, _towerRadius, validSoaker ? ComponentType.Safe : ComponentType.Danger);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Savage/P4S1Hesperos/DirectorsBelone.cs
+++ b/BossMod/Modules/Endwalker/Savage/P4S1Hesperos/DirectorsBelone.cs
@@ -96,7 +96,7 @@ namespace BossMod.Endwalker.Savage.P4S1Hesperos
             var failingPlayers = _debuffForbidden & _debuffTargets;
             foreach ((int i, var player) in module.Raid.WithSlot())
             {
-                arena.Actor(player, failingPlayers[i] ? ArenaColor.Danger : ArenaColor.PlayerGeneric);
+                arena.Actor(player, failingPlayers[i] ? ComponentType.Danger : ComponentType.PlayerGeneric);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Savage/P4S1Hesperos/ElementalBelone.cs
+++ b/BossMod/Modules/Endwalker/Savage/P4S1Hesperos/ElementalBelone.cs
@@ -43,12 +43,12 @@ namespace BossMod.Endwalker.Savage.P4S1Hesperos
                 if (safeCorner != SettingTheScene.Corner.Unknown)
                 {
                     var p = module.Bounds.Center + 10 * assignments.Direction(safeCorner);
-                    arena.ZoneRect(p, new WDir(1, 0), 10, 10, 10, ArenaColor.SafeFromAOE);
+                    arena.ZoneRect(p, new WDir(1, 0), 10, 10, 10, ComponentType.SafeFromAOE);
                 }
             }
             foreach (var p in _imminentExplodingCorners)
             {
-                arena.ZoneRect(p, new WDir(1, 0), 10, 10, 10, ArenaColor.AOE);
+                arena.ZoneRect(p, new WDir(1, 0), 10, 10, 10, ComponentType.AOE);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Savage/P4S1Hesperos/InversiveChlamys.cs
+++ b/BossMod/Modules/Endwalker/Savage/P4S1Hesperos/InversiveChlamys.cs
@@ -111,12 +111,12 @@ namespace BossMod.Endwalker.Savage.P4S1Hesperos
             {
                 bool failing = failingPlayers[i];
                 bool inAOE = _tetherInAOE[i];
-                arena.Actor(player, failing ? ArenaColor.Danger : (inAOE ? ArenaColor.PlayerInteresting : ArenaColor.PlayerGeneric));
+                arena.Actor(player, failing ? ComponentType.Danger : (inAOE ? ComponentType.PlayerInteresting : ComponentType.PlayerGeneric));
 
                 if (player.Tether.ID == (uint)TetherID.Chlamys)
                 {
-                    arena.AddLine(player.Position, module.PrimaryActor.Position, failing ? ArenaColor.Danger : ArenaColor.Safe);
-                    arena.AddCircle(player.Position, _aoeRange, ArenaColor.Danger);
+                    arena.AddLine(player.Position, module.PrimaryActor.Position, failing ? ComponentType.Danger : ComponentType.Safe);
+                    arena.AddCircle(player.Position, _aoeRange, ComponentType.Danger);
                 }
             }
         }

--- a/BossMod/Modules/Endwalker/Savage/P4S1Hesperos/Pinax.cs
+++ b/BossMod/Modules/Endwalker/Savage/P4S1Hesperos/Pinax.cs
@@ -77,20 +77,20 @@ namespace BossMod.Endwalker.Savage.P4S1Hesperos
         {
             if (_acid != null)
             {
-                arena.ZoneRect(_acid.Position, new WDir(1, 0), 10, 10, 10, ArenaColor.AOE);
+                arena.ZoneRect(_acid.Position, new WDir(1, 0), 10, 10, 10, ComponentType.AOE);
             }
             if (_fire != null)
             {
-                arena.ZoneRect(_fire.Position, new WDir(1, 0), 10, 10, 10, ArenaColor.AOE);
+                arena.ZoneRect(_fire.Position, new WDir(1, 0), 10, 10, 10, ComponentType.AOE);
             }
             if (_water != null)
             {
-                arena.ZoneRect(_water.Position, new WDir(1, 0), 10, 10, 10, ArenaColor.AOE);
+                arena.ZoneRect(_water.Position, new WDir(1, 0), 10, 10, 10, ComponentType.AOE);
             }
             if (_lighting != null)
             {
-                arena.ZoneRect(_lighting.Position, new WDir(1, 0), 10, 10, 10, ArenaColor.AOE);
-                arena.ZoneRect(module.Bounds.Center, new WDir(1, 0), _lightingSafeDistance, _lightingSafeDistance, _lightingSafeDistance, ArenaColor.AOE);
+                arena.ZoneRect(_lighting.Position, new WDir(1, 0), 10, 10, 10, ComponentType.AOE);
+                arena.ZoneRect(module.Bounds.Center, new WDir(1, 0), _lightingSafeDistance, _lightingSafeDistance, _lightingSafeDistance, ComponentType.AOE);
             }
         }
 
@@ -98,9 +98,9 @@ namespace BossMod.Endwalker.Savage.P4S1Hesperos
         {
             if (_acid != null)
             {
-                arena.AddCircle(pc.Position, _acidAOERadius, ArenaColor.Danger);
+                arena.AddCircle(pc.Position, _acidAOERadius, ComponentType.Danger);
                 foreach (var player in module.Raid.WithoutSlot().Exclude(pc))
-                    arena.Actor(player, player.Position.InCircle(pc.Position, _acidAOERadius) ? ArenaColor.PlayerInteresting : ArenaColor.PlayerGeneric);
+                    arena.Actor(player, player.Position.InCircle(pc.Position, _acidAOERadius) ? ComponentType.PlayerInteresting : ComponentType.PlayerGeneric);
             }
             if (_fire != null)
             {
@@ -108,12 +108,12 @@ namespace BossMod.Endwalker.Savage.P4S1Hesperos
                 {
                     if (player.Role == Role.Healer)
                     {
-                        arena.Actor(player, ArenaColor.Danger);
-                        arena.AddCircle(player.Position, _fireAOERadius, ArenaColor.Danger);
+                        arena.Actor(player, ComponentType.Danger);
+                        arena.AddCircle(player.Position, _fireAOERadius, ComponentType.Danger);
                     }
                     else
                     {
-                        arena.Actor(player, ArenaColor.PlayerGeneric);
+                        arena.Actor(player, ComponentType.PlayerGeneric);
                     }
                 }
             }
@@ -122,8 +122,8 @@ namespace BossMod.Endwalker.Savage.P4S1Hesperos
                 var adjPos = Components.Knockback.AwayFromSource(pc.Position, module.Bounds.Center, _knockbackRadius);
                 if (adjPos != pc.Position)
                 {
-                    arena.AddLine(pc.Position, adjPos, ArenaColor.Danger);
-                    arena.Actor(adjPos, pc.Rotation, ArenaColor.Danger);
+                    arena.AddLine(pc.Position, adjPos, ComponentType.Danger);
+                    arena.Actor(adjPos, pc.Rotation, ComponentType.Danger);
                 }
             }
         }

--- a/BossMod/Modules/Endwalker/Savage/P4S1Hesperos/PinaxUptime.cs
+++ b/BossMod/Modules/Endwalker/Savage/P4S1Hesperos/PinaxUptime.cs
@@ -14,7 +14,7 @@
             if (doubleOffset == new WDir())
                 return;
 
-            arena.AddCircle(module.Bounds.Center + 9 * doubleOffset, 2, ArenaColor.Safe);
+            arena.AddCircle(module.Bounds.Center + 9 * doubleOffset, 2, ComponentType.Safe);
         }
     }
 }

--- a/BossMod/Modules/Endwalker/Savage/P4S1Hesperos/Shift.cs
+++ b/BossMod/Modules/Endwalker/Savage/P4S1Hesperos/Shift.cs
@@ -30,13 +30,13 @@
         {
             if (_cloakCaster != null)
             {
-                arena.AddCircle(_cloakCaster.Position, 5, ArenaColor.Safe);
+                arena.AddCircle(_cloakCaster.Position, 5, ComponentType.Safe);
 
                 var adjPos = Components.Knockback.AwayFromSource(pc.Position, _cloakCaster, _knockbackRange);
                 if (adjPos != pc.Position)
                 {
-                    arena.AddLine(pc.Position, adjPos, ArenaColor.Danger);
-                    arena.Actor(adjPos, pc.Rotation, ArenaColor.Danger);
+                    arena.AddLine(pc.Position, adjPos, ComponentType.Danger);
+                    arena.Actor(adjPos, pc.Rotation, ComponentType.Danger);
                 }
             }
         }

--- a/BossMod/Modules/Endwalker/Savage/P4S1Hesperos/VengefulBelone.cs
+++ b/BossMod/Modules/Endwalker/Savage/P4S1Hesperos/VengefulBelone.cs
@@ -55,12 +55,12 @@ namespace BossMod.Endwalker.Savage.P4S1Hesperos
                     continue; // this orb has already exploded
 
                 bool lethal = IsOrbLethal(pcSlot, pc, orbRole);
-                arena.Actor(orb, lethal ? ArenaColor.Enemy : ArenaColor.Danger, true);
+                arena.Actor(orb, lethal ? ComponentType.ActorEnemy : ComponentType.Danger, true);
 
                 var target = module.WorldState.Actors.Find(orb.Tether.Target);
                 if (target != null)
                 {
-                    arena.AddLine(orb.Position, target.Position, ArenaColor.Danger);
+                    arena.AddLine(orb.Position, target.Position, ComponentType.Danger);
                 }
 
                 int goodInRange = 0, badInRange = 0;
@@ -73,13 +73,13 @@ namespace BossMod.Endwalker.Savage.P4S1Hesperos
                 }
 
                 bool goodToExplode = goodInRange == 2 && badInRange == 0;
-                arena.AddCircle(orb.Position, _burstRadius, goodToExplode ? ArenaColor.Safe : ArenaColor.Danger);
+                arena.AddCircle(orb.Position, _burstRadius, goodToExplode ? ComponentType.Safe : ComponentType.Danger);
             }
 
             foreach ((int i, var player) in module.Raid.WithSlot())
             {
                 bool nearLethalOrb = orbs.Where(orb => IsOrbLethal(i, player, OrbTarget(orb.InstanceID))).InRadius(player.Position, _burstRadius).Any();
-                arena.Actor(player, nearLethalOrb ? ArenaColor.PlayerInteresting : ArenaColor.PlayerGeneric);
+                arena.Actor(player, nearLethalOrb ? ComponentType.PlayerInteresting : ComponentType.PlayerGeneric);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Savage/P4S2Hesperos/CurtainCall.cs
+++ b/BossMod/Modules/Endwalker/Savage/P4S2Hesperos/CurtainCall.cs
@@ -38,12 +38,12 @@ namespace BossMod.Endwalker.Savage.P4S2Hesperos
         {
             // draw other players
             foreach ((int slot, var player) in module.Raid.WithSlot().Exclude(pc))
-                arena.Actor(player, _playerOrder[slot] == _numCasts + 1 ? ArenaColor.Danger : ArenaColor.PlayerGeneric);
+                arena.Actor(player, _playerOrder[slot] == _numCasts + 1 ? ComponentType.Danger : ComponentType.PlayerGeneric);
 
             // tether
             var tetherTarget = module.WorldState.Actors.Find(pc.Tether.Target);
             if (tetherTarget != null)
-                arena.AddLine(pc.Position, tetherTarget.Position, pc.Tether.ID == (uint)TetherID.WreathOfThorns ? ArenaColor.Danger : ArenaColor.Safe);
+                arena.AddLine(pc.Position, tetherTarget.Position, pc.Tether.ID == (uint)TetherID.WreathOfThorns ? ComponentType.Danger : ComponentType.Safe);
         }
 
         public override void OnStatusGain(BossModule module, Actor actor, ActorStatus status)

--- a/BossMod/Modules/Endwalker/Savage/P4S2Hesperos/NearFarSight.cs
+++ b/BossMod/Modules/Endwalker/Savage/P4S2Hesperos/NearFarSight.cs
@@ -64,12 +64,12 @@ namespace BossMod.Endwalker.Savage.P4S2Hesperos
             {
                 if (_targets[i])
                 {
-                    arena.Actor(player, ArenaColor.Danger);
-                    arena.AddCircle(player.Position, _aoeRadius, ArenaColor.Danger);
+                    arena.Actor(player, ComponentType.Danger);
+                    arena.AddCircle(player.Position, _aoeRadius, ComponentType.Danger);
                 }
                 else
                 {
-                    arena.Actor(player, _inAOE[i] ? ArenaColor.PlayerInteresting : ArenaColor.PlayerGeneric);
+                    arena.Actor(player, _inAOE[i] ? ComponentType.PlayerInteresting : ComponentType.PlayerGeneric);
                 }
             }
         }

--- a/BossMod/Modules/Endwalker/Savage/P4S2Hesperos/WreathOfThorns1.cs
+++ b/BossMod/Modules/Endwalker/Savage/P4S2Hesperos/WreathOfThorns1.cs
@@ -52,7 +52,7 @@ namespace BossMod.Endwalker.Savage.P4S2Hesperos
         {
             if (CurState == State.FirstAOEs || CurState == State.LastAOEs)
                 foreach (var aoe in CurState == State.FirstAOEs ? _firstAOEs : _lastAOEs)
-                    arena.ZoneCircle(aoe.Position, P4S2.WreathAOERadius, ArenaColor.AOE);
+                    arena.ZoneCircle(aoe.Position, P4S2.WreathAOERadius, ComponentType.AOE);
         }
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
@@ -60,9 +60,9 @@ namespace BossMod.Endwalker.Savage.P4S2Hesperos
             if (CurState == State.Towers)
             {
                 foreach (var tower in _towers)
-                    arena.AddCircle(tower.Position, P4S2.WreathTowerRadius, ArenaColor.Safe);
+                    arena.AddCircle(tower.Position, P4S2.WreathTowerRadius, ComponentType.Safe);
                 foreach (var player in module.Raid.WithoutSlot())
-                    arena.Actor(player, ArenaColor.PlayerGeneric);
+                    arena.Actor(player, ComponentType.PlayerGeneric);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Savage/P4S2Hesperos/WreathOfThorns2.cs
+++ b/BossMod/Modules/Endwalker/Savage/P4S2Hesperos/WreathOfThorns2.cs
@@ -79,14 +79,14 @@ namespace BossMod.Endwalker.Savage.P4S2Hesperos
                 return;
 
             foreach (var aoe in (CurState == State.SecondSet ? _secondSet : _firstSet).Where(IsAOE))
-                arena.ZoneCircle(aoe.Position, P4S2.WreathAOERadius, ArenaColor.AOE);
+                arena.ZoneCircle(aoe.Position, P4S2.WreathAOERadius, ComponentType.AOE);
         }
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             // draw players
             foreach (var player in module.Raid.WithoutSlot().Exclude(pc))
-                arena.Actor(player, ArenaColor.PlayerGeneric);
+                arena.Actor(player, ComponentType.PlayerGeneric);
 
             // draw pc's tether
             var pcPartner = pc.Tether.Target != 0
@@ -95,9 +95,9 @@ namespace BossMod.Endwalker.Savage.P4S2Hesperos
             if (pcPartner != null)
             {
                 var tetherColor = _playerIcons[pcSlot] switch {
-                    IconID.AkanthaiFire => 0xff00ffff,
-                    IconID.AkanthaiWind => 0xff00ff00,
-                    _ => 0xffff00ff
+                    IconID.AkanthaiFire => ComponentType.TetherMoveAway,
+                    IconID.AkanthaiWind => ComponentType.Safe,
+                    _ => ComponentType.TetherDontMove
                 };
                 arena.AddLine(pc.Position, pcPartner.Position, tetherColor);
             }
@@ -106,7 +106,7 @@ namespace BossMod.Endwalker.Savage.P4S2Hesperos
             bool isTowerSoaker = pc == _darkTH.Item1 || pc == _darkTH.Item2;
             if (isTowerSoaker && CurState != State.Done)
                 foreach (var tower in (CurState == State.SecondSet ? _secondSet : _firstSet).Where(IsTower))
-                    arena.AddCircle(tower.Position, P4S2.WreathTowerRadius, CurState == State.DarkDesign ?  ArenaColor.Danger : ArenaColor.Safe);
+                    arena.AddCircle(tower.Position, P4S2.WreathTowerRadius, CurState == State.DarkDesign ?  ComponentType.Danger : ComponentType.Safe);
 
             // draw circles around next imminent fire explosion
             if (CurState != State.DarkDesign)
@@ -114,8 +114,8 @@ namespace BossMod.Endwalker.Savage.P4S2Hesperos
                 var curFirePair = (_fireTH.Item1 != null && _fireTH.Item1.Tether.ID != 0) ? _fireTH : ((_fireDD.Item1 != null && _fireDD.Item1.Tether.ID != 0) ? _fireDD : (null, null));
                 if (curFirePair.Item1 != null)
                 {
-                    arena.AddCircle(curFirePair.Item1!.Position, _fireExplosionRadius, isTowerSoaker ? ArenaColor.Danger : ArenaColor.Safe);
-                    arena.AddCircle(curFirePair.Item2!.Position, _fireExplosionRadius, isTowerSoaker ? ArenaColor.Danger : ArenaColor.Safe);
+                    arena.AddCircle(curFirePair.Item1!.Position, _fireExplosionRadius, isTowerSoaker ? ComponentType.Danger : ComponentType.Safe);
+                    arena.AddCircle(curFirePair.Item2!.Position, _fireExplosionRadius, isTowerSoaker ? ComponentType.Danger : ComponentType.Safe);
                 }
             }
         }

--- a/BossMod/Modules/Endwalker/Savage/P4S2Hesperos/WreathOfThorns3.cs
+++ b/BossMod/Modules/Endwalker/Savage/P4S2Hesperos/WreathOfThorns3.cs
@@ -93,24 +93,24 @@ namespace BossMod.Endwalker.Savage.P4S2Hesperos
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach ((int i, var player) in module.Raid.WithSlot())
-                arena.Actor(player, _playersInAOE[i] ? ArenaColor.PlayerInteresting : ArenaColor.PlayerGeneric);
+                arena.Actor(player, _playersInAOE[i] ? ComponentType.PlayerInteresting : ComponentType.PlayerGeneric);
 
             if (CurState != State.Done)
             {
                 foreach (var tower in (CurState == State.RangedTowers ? _rangedTowers : _meleeTowers))
-                    arena.AddCircle(tower.Position, P4S2.WreathTowerRadius, ArenaColor.Safe);
+                    arena.AddCircle(tower.Position, P4S2.WreathTowerRadius, ComponentType.Safe);
             }
 
             if (NumCones != NumJumps)
             {
                 foreach ((_, var player) in module.Raid.WithSlot().IncludedInMask(_coneTargets))
-                    arena.Actor(player, ArenaColor.Danger);
-                arena.Actor(_jumpTarget, ArenaColor.Vulnerable);
+                    arena.Actor(player, ComponentType.Danger);
+                arena.Actor(_jumpTarget, ComponentType.ActorVulnerable);
             }
             else if (_jumpTarget != null)
             {
-                arena.Actor(_jumpTarget, ArenaColor.Danger);
-                arena.AddCircle(_jumpTarget.Position, _jumpAOERadius, ArenaColor.Danger);
+                arena.Actor(_jumpTarget, ComponentType.Danger);
+                arena.AddCircle(_jumpTarget.Position, _jumpAOERadius, ComponentType.Danger);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Savage/P4S2Hesperos/WreathOfThorns4.cs
+++ b/BossMod/Modules/Endwalker/Savage/P4S2Hesperos/WreathOfThorns4.cs
@@ -100,7 +100,7 @@ namespace BossMod.Endwalker.Savage.P4S2Hesperos
                 return;
             var nextAOE = NextAOE();
             if (nextAOE != null)
-                arena.ZoneCircle(nextAOE.Position, P4S2.WreathAOERadius, ArenaColor.AOE);
+                arena.ZoneCircle(nextAOE.Position, P4S2.WreathAOERadius, ComponentType.AOE);
         }
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
@@ -110,7 +110,7 @@ namespace BossMod.Endwalker.Savage.P4S2Hesperos
             {
                 var icon = _playerIcons[slot];
                 bool nextBreaking = _doneTowers < 4 ? icon == IconID.AkanthaiWater : (icon == IconID.AkanthaiDark && NextAOE()?.Tether.Target == player.InstanceID);
-                arena.Actor(player, nextBreaking ? ArenaColor.Danger : ArenaColor.PlayerGeneric);
+                arena.Actor(player, nextBreaking ? ComponentType.Danger : ComponentType.PlayerGeneric);
             }
 
             // tether
@@ -119,15 +119,15 @@ namespace BossMod.Endwalker.Savage.P4S2Hesperos
                 return; // pc is not tethered anymore, nothing to draw...
 
             var pcIcon = _playerIcons[pcSlot];
-            arena.AddLine(pc.Position, pcTetherSource.Position, pcIcon == IconID.AkanthaiWater ? 0xffff8000 : 0xffff00ff);
+            arena.AddLine(pc.Position, pcTetherSource.Position, pcIcon == IconID.AkanthaiWater ? ComponentType.TetherMoveToward : ComponentType.TetherMoveAway);
 
             if (_doneTowers < 4)
             {
                 if (pcIcon == IconID.AkanthaiWater)
                 {
                     // if player has blue => show AOE radius around him and single safe spot
-                    arena.AddCircle(pc.Position, _waterExplosionRange, ArenaColor.Danger);
-                    arena.AddCircle(DetermineWaterSafeSpot(module, pcTetherSource), 1, ArenaColor.Safe);
+                    arena.AddCircle(pc.Position, _waterExplosionRange, ComponentType.Danger);
+                    arena.AddCircle(DetermineWaterSafeSpot(module, pcTetherSource), 1, ComponentType.Safe);
                 }
                 else
                 {
@@ -136,13 +136,13 @@ namespace BossMod.Endwalker.Savage.P4S2Hesperos
                     {
                         if (icon == IconID.AkanthaiWater && player != null)
                         {
-                            arena.AddCircle(player.Position, _waterExplosionRange, ArenaColor.Danger);
+                            arena.AddCircle(player.Position, _waterExplosionRange, ComponentType.Danger);
                         }
                     }
                     var tower = DetermineTowerToSoak(module, pcTetherSource);
                     if (tower != null)
                     {
-                        arena.AddCircle(tower.Position, P4S2.WreathTowerRadius, ArenaColor.Safe);
+                        arena.AddCircle(tower.Position, P4S2.WreathTowerRadius, ComponentType.Safe);
                     }
                 }
             }

--- a/BossMod/Modules/Endwalker/Savage/P4S2Hesperos/WreathOfThorns5.cs
+++ b/BossMod/Modules/Endwalker/Savage/P4S2Hesperos/WreathOfThorns5.cs
@@ -40,19 +40,19 @@ namespace BossMod.Endwalker.Savage.P4S2Hesperos
         {
             int order = _playersOrder.IndexOf(pc.InstanceID);
             if (order >= _castsDone && order < _towersOrder.Count)
-                arena.AddCircle(_towersOrder[order].Position, P4S2.WreathTowerRadius, ArenaColor.Safe);
+                arena.AddCircle(_towersOrder[order].Position, P4S2.WreathTowerRadius, ComponentType.Safe);
 
             var pcTetherTarget = module.WorldState.Actors.Find(pc.Tether.Target);
             if (pcTetherTarget != null)
             {
-                arena.AddLine(pc.Position, pcTetherTarget.Position, pc.Tether.ID == (uint)TetherID.WreathOfThorns ? ArenaColor.Danger : ArenaColor.Safe);
+                arena.AddLine(pc.Position, pcTetherTarget.Position, pc.Tether.ID == (uint)TetherID.WreathOfThorns ? ComponentType.Danger : ComponentType.Safe);
             }
 
             if (_playersOrder.Count < 8)
             {
-                arena.AddCircle(pc.Position, _impulseAOERadius, ArenaColor.Danger);
+                arena.AddCircle(pc.Position, _impulseAOERadius, ComponentType.Danger);
                 foreach (var player in module.Raid.WithoutSlot().Exclude(pc))
-                    arena.Actor(player, player.Position.InCircle(pc.Position, _impulseAOERadius) ? ArenaColor.PlayerInteresting : ArenaColor.PlayerGeneric);
+                    arena.Actor(player, player.Position.InCircle(pc.Position, _impulseAOERadius) ? ComponentType.PlayerInteresting : ComponentType.PlayerGeneric);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Savage/P5SProtoCarbuncle/RubyGlowCommon.cs
+++ b/BossMod/Modules/Endwalker/Savage/P5SProtoCarbuncle/RubyGlowCommon.cs
@@ -69,14 +69,14 @@ namespace BossMod.Endwalker.Savage.P5SProtoCarbuncle
             switch (State)
             {
                 case ArenaState.Cells:
-                    arena.AddLine(module.Bounds.Center - new WDir(module.Bounds.HalfSize, 0), module.Bounds.Center + new WDir(module.Bounds.HalfSize, 0), ArenaColor.Border);
-                    arena.AddLine(module.Bounds.Center - new WDir(0, module.Bounds.HalfSize), module.Bounds.Center + new WDir(0, module.Bounds.HalfSize), ArenaColor.Border);
+                    arena.AddLine(module.Bounds.Center - new WDir(module.Bounds.HalfSize, 0), module.Bounds.Center + new WDir(module.Bounds.HalfSize, 0), ComponentType.Border);
+                    arena.AddLine(module.Bounds.Center - new WDir(0, module.Bounds.HalfSize), module.Bounds.Center + new WDir(0, module.Bounds.HalfSize), ComponentType.Border);
                     break;
                 case ArenaState.DiagNW:
-                    arena.AddLine(module.Bounds.Center - new WDir(module.Bounds.HalfSize, module.Bounds.HalfSize), module.Bounds.Center + new WDir(module.Bounds.HalfSize, module.Bounds.HalfSize), ArenaColor.Border);
+                    arena.AddLine(module.Bounds.Center - new WDir(module.Bounds.HalfSize, module.Bounds.HalfSize), module.Bounds.Center + new WDir(module.Bounds.HalfSize, module.Bounds.HalfSize), ComponentType.Border);
                     break;
                 case ArenaState.DiagNE:
-                    arena.AddLine(module.Bounds.Center - new WDir(module.Bounds.HalfSize, -module.Bounds.HalfSize), module.Bounds.Center + new WDir(module.Bounds.HalfSize, -module.Bounds.HalfSize), ArenaColor.Border);
+                    arena.AddLine(module.Bounds.Center - new WDir(module.Bounds.HalfSize, -module.Bounds.HalfSize), module.Bounds.Center + new WDir(module.Bounds.HalfSize, -module.Bounds.HalfSize), ComponentType.Border);
                     break;
             }
         }
@@ -161,7 +161,7 @@ namespace BossMod.Endwalker.Savage.P5SProtoCarbuncle
                 hints.Add("Stack with healer!");
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return VenomPoolActive && player.Role == Role.Healer ? PlayerPriority.Interesting : PlayerPriority.Irrelevant;
         }
@@ -173,11 +173,11 @@ namespace BossMod.Endwalker.Savage.P5SProtoCarbuncle
             if (CurRecolorState == RecolorState.BeforeRecolor)
                 foreach (var o in MagicStones)
                     if (QuadrantForPosition(module, o.Position) != AOEQuadrant)
-                        arena.Actor(o, ArenaColor.Vulnerable, true);
+                        arena.Actor(o, ComponentType.ActorVulnerable, true);
 
             if (VenomPoolActive)
                 foreach (var a in module.Raid.WithoutSlot().Where(a => a.Role == Role.Healer))
-                    arena.AddCircle(a.Position, _recolorRadius, ArenaColor.Safe);
+                    arena.AddCircle(a.Position, _recolorRadius, ComponentType.Safe);
         }
 
         public override void OnActorEAnim(BossModule module, Actor actor, uint state)

--- a/BossMod/Modules/Endwalker/Savage/P5SProtoCarbuncle/VenomSquallSurge.cs
+++ b/BossMod/Modules/Endwalker/Savage/P5SProtoCarbuncle/VenomSquallSurge.cs
@@ -36,7 +36,7 @@ namespace BossMod.Endwalker.Savage.P5SProtoCarbuncle
             hints.Add(_reverse ? "Order: stack -> mid -> spread" : "Order: spread -> mid -> stack");
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return NextMechanic == Mechanic.Pool && player.Role == Role.Healer ? PlayerPriority.Interesting : PlayerPriority.Irrelevant;
         }
@@ -46,15 +46,15 @@ namespace BossMod.Endwalker.Savage.P5SProtoCarbuncle
             switch (NextMechanic)
             {
                 case Mechanic.Rain: // spreads
-                    arena.AddCircle(pc.Position, _radius, ArenaColor.Danger);
+                    arena.AddCircle(pc.Position, _radius, ComponentType.Danger);
                     break;
                 case Mechanic.Drops: // bait
                     foreach (var p in module.Raid.WithoutSlot())
-                        arena.AddCircle(p.Position, _radius, ArenaColor.Danger);
+                        arena.AddCircle(p.Position, _radius, ComponentType.Danger);
                     break;
                 case Mechanic.Pool: // party stacks
                     foreach (var p in module.Raid.WithoutSlot().Where(p => p.Role == Role.Healer))
-                        arena.AddCircle(p.Position, _radius, ArenaColor.Danger);
+                        arena.AddCircle(p.Position, _radius, ComponentType.Danger);
                     break;
             }
         }

--- a/BossMod/Modules/Endwalker/Savage/P5SProtoCarbuncle/VenomTowers.cs
+++ b/BossMod/Modules/Endwalker/Savage/P5SProtoCarbuncle/VenomTowers.cs
@@ -18,7 +18,7 @@ namespace BossMod.Endwalker.Savage.P5SProtoCarbuncle
             foreach (var t in _activeTowerOffsets)
             {
                 var origin = module.Bounds.Center + t;
-                arena.AddCircle(origin, _radius, module.Raid.WithoutSlot().InRadius(origin, _radius).Any() ? ArenaColor.Safe : ArenaColor.Danger);
+                arena.AddCircle(origin, _radius, module.Raid.WithoutSlot().InRadius(origin, _radius).Any() ? ComponentType.Safe : ComponentType.Danger);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Savage/P5SProtoCarbuncle/VenomousMass.cs
+++ b/BossMod/Modules/Endwalker/Savage/P5SProtoCarbuncle/VenomousMass.cs
@@ -17,7 +17,7 @@
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (_target != null)
-                arena.AddCircle(_target.Position, _radius, ArenaColor.Danger);
+                arena.AddCircle(_target.Position, _radius, ComponentType.Danger);
         }
 
         public override void OnCastStarted(BossModule module, Actor caster, ActorCastInfo spell)

--- a/BossMod/Modules/Endwalker/Savage/P6SHegemone/Synergy.cs
+++ b/BossMod/Modules/Endwalker/Savage/P6SHegemone/Synergy.cs
@@ -37,7 +37,7 @@ namespace BossMod.Endwalker.Savage.P6SHegemone
             }
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return _targets.Contains(player) ? PlayerPriority.Danger : PlayerPriority.Irrelevant;
         }

--- a/BossMod/Modules/Endwalker/Savage/P6SHegemone/Transmission.cs
+++ b/BossMod/Modules/Endwalker/Savage/P6SHegemone/Transmission.cs
@@ -38,7 +38,7 @@ namespace BossMod.Endwalker.Savage.P6SHegemone
                 hints.Add("Avoid transmission aoe!");
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return _clips[playerSlot, pcSlot] ? PlayerPriority.Danger : _clippedByOthers[playerSlot] ? PlayerPriority.Interesting : PlayerPriority.Normal;
         }

--- a/BossMod/Modules/Endwalker/Savage/P7SAgdistis/Border.cs
+++ b/BossMod/Modules/Endwalker/Savage/P7SAgdistis/Border.cs
@@ -26,16 +26,16 @@ namespace BossMod.Endwalker.Savage.P7SAgdistis
         {
             if (!_threePlatforms)
             {
-                arena.AddCircle(module.Bounds.Center, LargePlatformRadius, ArenaColor.Border);
+                arena.AddCircle(module.Bounds.Center, LargePlatformRadius, ComponentType.Border);
             }
             else
             {
                 var cs = module.Bounds.Center + PlatformSOffset;
                 var ce = module.Bounds.Center + PlatformEOffset;
                 var cw = module.Bounds.Center + PlatformWOffset;
-                arena.AddCircle(cs, SmallPlatformRadius, ArenaColor.Border);
-                arena.AddCircle(ce, SmallPlatformRadius, ArenaColor.Border);
-                arena.AddCircle(cw, SmallPlatformRadius, ArenaColor.Border);
+                arena.AddCircle(cs, SmallPlatformRadius, ComponentType.Border);
+                arena.AddCircle(ce, SmallPlatformRadius, ComponentType.Border);
+                arena.AddCircle(cw, SmallPlatformRadius, ComponentType.Border);
                 if (_bridgeN)
                 {
                     DrawBridge(arena, ce, cw, false);
@@ -96,8 +96,8 @@ namespace BossMod.Endwalker.Savage.P7SAgdistis
             var p1adj = p1 + dir * BridgeStartOffset;
             var p2adj = p2 - dir * (p2center ? BridgeCenterOffset : BridgeStartOffset);
             var ortho = dir.OrthoL() * BridgeHalfWidth;
-            arena.AddLine(p1adj + ortho, p2adj + ortho, ArenaColor.Border);
-            arena.AddLine(p1adj - ortho, p2adj - ortho, ArenaColor.Border);
+            arena.AddLine(p1adj + ortho, p2adj + ortho, ComponentType.Border);
+            arena.AddLine(p1adj - ortho, p2adj - ortho, ComponentType.Border);
         }
 
         private void BridgeEnvControl(ref bool bridge, uint state)

--- a/BossMod/Modules/Endwalker/Savage/P7SAgdistis/DispersedCondensedAero.cs
+++ b/BossMod/Modules/Endwalker/Savage/P7SAgdistis/DispersedCondensedAero.cs
@@ -41,7 +41,7 @@ namespace BossMod.Endwalker.Savage.P7SAgdistis
             }
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return (_condensed ? module.PrimaryActor.TargetID == player.InstanceID : player.Role == Role.Tank) ? PlayerPriority.Danger : PlayerPriority.Irrelevant;
         }
@@ -52,12 +52,12 @@ namespace BossMod.Endwalker.Savage.P7SAgdistis
             {
                 var tank = module.WorldState.Actors.Find(module.PrimaryActor.TargetID);
                 if (tank != null)
-                    arena.AddCircle(tank.Position, _radiusCondensed, ArenaColor.Danger);
+                    arena.AddCircle(tank.Position, _radiusCondensed, ComponentType.Danger);
             }
             else
             {
                 foreach (var tank in module.Raid.WithoutSlot().Where(a => a.Role == Role.Tank))
-                    arena.AddCircle(tank.Position, _radiusDispersed, ArenaColor.Danger);
+                    arena.AddCircle(tank.Position, _radiusDispersed, ComponentType.Danger);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Savage/P7SAgdistis/ForbiddenFruit4.cs
+++ b/BossMod/Modules/Endwalker/Savage/P7SAgdistis/ForbiddenFruit4.cs
@@ -13,7 +13,7 @@ namespace BossMod.Endwalker.Savage.P7SAgdistis
             base.DrawArenaForeground(module, pcSlot, pc, arena);
             if (NumAssignedTethers > 0 && !MinotaursBaited && TetherSources[pcSlot] == null)
             {
-                arena.AddCircle(module.Bounds.Center - 2 * PlatformDirection(_bullPlatform).ToDirection(), 2, ArenaColor.Safe);
+                arena.AddCircle(module.Bounds.Center - 2 * PlatformDirection(_bullPlatform).ToDirection(), 2, ComponentType.Safe);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Savage/P7SAgdistis/ForbiddenFruit5.cs
+++ b/BossMod/Modules/Endwalker/Savage/P7SAgdistis/ForbiddenFruit5.cs
@@ -20,10 +20,10 @@ namespace BossMod.Endwalker.Savage.P7SAgdistis
         {
             var tetherSource = TetherSources[pcSlot];
             if (tetherSource != null)
-                arena.AddLine(tetherSource.Position, pc.Position, TetherColor(tetherSource));
+                arena.AddLine(tetherSource.Position, pc.Position, TetherType(tetherSource));
 
             foreach (var tower in _towers)
-                arena.AddCircle(tower.Position, _towerRadius, tetherSource == null ? ArenaColor.Safe : ArenaColor.Danger);
+                arena.AddCircle(tower.Position, _towerRadius, tetherSource == null ? ComponentType.Safe : ComponentType.Danger);
         }
     }
 }

--- a/BossMod/Modules/Endwalker/Savage/P7SAgdistis/ForbiddenFruitCommon.cs
+++ b/BossMod/Modules/Endwalker/Savage/P7SAgdistis/ForbiddenFruitCommon.cs
@@ -58,7 +58,7 @@ namespace BossMod.Endwalker.Savage.P7SAgdistis
                 hints.Add("Clipped by other tethers!");
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return _tetherClips[playerSlot, pcSlot] || _tetherClips[pcSlot, playerSlot] ? PlayerPriority.Danger : PlayerPriority.Normal;
         }
@@ -67,10 +67,10 @@ namespace BossMod.Endwalker.Savage.P7SAgdistis
         {
             var tetherSource = TetherSources[pcSlot];
             if (tetherSource != null)
-                arena.AddLine(tetherSource.Position, pc.Position, TetherColor(tetherSource));
+                arena.AddLine(tetherSource.Position, pc.Position, TetherType(tetherSource));
 
             foreach (var platform in SafePlatforms[pcSlot].SetBits())
-                arena.AddCircle(module.Bounds.Center + PlatformDirection(platform).ToDirection() * Border.SmallPlatformOffset, Border.SmallPlatformRadius, ArenaColor.Safe);
+                arena.AddCircle(module.Bounds.Center + PlatformDirection(platform).ToDirection() * Border.SmallPlatformOffset, Border.SmallPlatformRadius, ComponentType.Safe);
         }
 
         public override void OnTethered(BossModule module, Actor source, ActorTetherInfo tether)
@@ -143,12 +143,12 @@ namespace BossMod.Endwalker.Savage.P7SAgdistis
             return -1;
         }
 
-        protected uint TetherColor(Actor source) => (OID)source.OID switch
+        protected ComponentType TetherType(Actor source) => (OID)source.OID switch
         {
-            OID.ImmatureMinotaur => 0xffff00ff,
-            OID.BullTetherSource => 0xffffff00,
-            OID.ImmatureStymphalide => 0xff00ffff,
-            _ => 0
+            OID.ImmatureMinotaur => ComponentType.TetherDontMove,
+            OID.BullTetherSource => ComponentType.TetherMoveToward,
+            OID.ImmatureStymphalide => ComponentType.TetherMoveAway,
+            _ => ComponentType.Unspecified,
         };
 
         protected int PlatformIDFromOffset(WDir offset) => offset.Z > 0 ? 1 : offset.X > 0 ? 2 : 0;

--- a/BossMod/Modules/Endwalker/Savage/P8S1Hephaistos/Centaur2.cs
+++ b/BossMod/Modules/Endwalker/Savage/P8S1Hephaistos/Centaur2.cs
@@ -95,23 +95,23 @@ namespace BossMod.Endwalker.Savage.P8S1Hephaistos
             if (NumMechanicsDone == 0)
             {
                 // draw first trailblaze
-                arena.ZoneRect(module.Bounds.Center, new WDir(0, 1), module.Bounds.HalfSize, module.Bounds.HalfSize, _trailblazeHalfWidth, ArenaColor.AOE);
+                arena.ZoneRect(module.Bounds.Center, new WDir(0, 1), module.Bounds.HalfSize, module.Bounds.HalfSize, _trailblazeHalfWidth, ComponentType.AOE);
             }
             if (NumMechanicsDone == 2)
             {
                 // draw second trailblaze
-                arena.ZoneRect(module.Bounds.Center, new WDir(1, 0), module.Bounds.HalfSize, module.Bounds.HalfSize, _trailblazeHalfWidth, ArenaColor.AOE);
+                arena.ZoneRect(module.Bounds.Center, new WDir(1, 0), module.Bounds.HalfSize, module.Bounds.HalfSize, _trailblazeHalfWidth, ComponentType.AOE);
             }
 
             if (_firstCrush && NumMechanicsDone < 2)
             {
                 // draw first crush
-                arena.ZoneCircle(module.Bounds.Center + module.Bounds.HalfSize * new WDir(_firstSafeLeft ? 1 : -1, 0), _crushRadius, ArenaColor.AOE);
+                arena.ZoneCircle(module.Bounds.Center + module.Bounds.HalfSize * new WDir(_firstSafeLeft ? 1 : -1, 0), _crushRadius, ComponentType.AOE);
             }
             if (!_firstCrush && NumMechanicsDone is >= 2 and < 4)
             {
                 // draw second crush
-                arena.ZoneCircle(module.Bounds.Center + module.Bounds.HalfSize * new WDir(0, _secondSafeTop ? 1 : -1), _crushRadius, ArenaColor.AOE);
+                arena.ZoneCircle(module.Bounds.Center + module.Bounds.HalfSize * new WDir(0, _secondSafeTop ? 1 : -1), _crushRadius, ComponentType.AOE);
             }
         }
 
@@ -120,12 +120,12 @@ namespace BossMod.Endwalker.Savage.P8S1Hephaistos
             if (NumMechanicsDone < 2 && _seenVisuals > 0)
             {
                 // draw first safespot
-                arena.AddCircle(module.Bounds.Center + _safespotOffset * new WDir(_firstSafeLeft ? -1 : 1, 0), _safespotRadius, ArenaColor.Safe, 2);
+                arena.AddCircle(module.Bounds.Center + _safespotOffset * new WDir(_firstSafeLeft ? -1 : 1, 0), _safespotRadius, ComponentType.Safe, 2);
             }
             if (NumMechanicsDone < 4 && _seenVisuals > 1)
             {
                 // draw second safespot
-                arena.AddCircle(module.Bounds.Center + _safespotOffset * new WDir(0, _secondSafeTop ? -1 : 1), _safespotRadius, ArenaColor.Safe, 2);
+                arena.AddCircle(module.Bounds.Center + _safespotOffset * new WDir(0, _secondSafeTop ? -1 : 1), _safespotRadius, ComponentType.Safe, 2);
             }
 
             if (NumMechanicsDone == 0)

--- a/BossMod/Modules/Endwalker/Savage/P8S1Hephaistos/Snake1.cs
+++ b/BossMod/Modules/Endwalker/Savage/P8S1Hephaistos/Snake1.cs
@@ -33,7 +33,7 @@ namespace BossMod.Endwalker.Savage.P8S1Hephaistos
             {
                 // show circle around assigned snake
                 if (state.AssignedSnake >= 0)
-                    arena.AddCircle(ActiveGorgons[state.AssignedSnake].caster.Position, 2, ArenaColor.Safe);
+                    arena.AddCircle(ActiveGorgons[state.AssignedSnake].caster.Position, 2, ComponentType.Safe);
 
                 if (state.IsExplode)
                     DrawExplode(pc, state.Order == 1 && NumCasts < 2, arena);

--- a/BossMod/Modules/Endwalker/Savage/P8S1Hephaistos/Snake2.cs
+++ b/BossMod/Modules/Endwalker/Savage/P8S1Hephaistos/Snake2.cs
@@ -61,7 +61,7 @@ namespace BossMod.Endwalker.Savage.P8S1Hephaistos
             hints.Add($"Petrify order: {(state.LongPetrify ? 2 : 1)}, {(state.HasCrown ? "hide behind snake" : "stack between snakes")}", false);
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return NumCrownCasts == 0 && _players[playerSlot].HasCrown ? PlayerPriority.Danger : PlayerPriority.Irrelevant;
         }
@@ -81,11 +81,11 @@ namespace BossMod.Endwalker.Savage.P8S1Hephaistos
             {
                 // show circle around assigned snake
                 if (_players[pcSlot].AssignedSnake >= 0)
-                    arena.AddCircle(ActiveGorgons[_players[pcSlot].AssignedSnake].caster.Position, 2, ArenaColor.Safe);
+                    arena.AddCircle(ActiveGorgons[_players[pcSlot].AssignedSnake].caster.Position, 2, ComponentType.Safe);
 
                 foreach (var (slot, player) in module.Raid.WithSlot())
                     if (_players[slot].HasBreath)
-                        arena.AddCircle(player.Position, _breathRadius, ArenaColor.Safe);
+                        arena.AddCircle(player.Position, _breathRadius, ComponentType.Safe);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Savage/P8S1Hephaistos/SnakeCommon.cs
+++ b/BossMod/Modules/Endwalker/Savage/P8S1Hephaistos/SnakeCommon.cs
@@ -40,7 +40,7 @@ namespace BossMod.Endwalker.Savage.P8S1Hephaistos
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var g in module.Enemies(OID.Gorgon).Where(g => !g.IsDead))
-                arena.Actor(g, ArenaColor.Enemy, true);
+                arena.Actor(g, ComponentType.ActorEnemy, true);
             base.DrawArenaForeground(module, pcSlot, pc, arena);
         }
 
@@ -74,7 +74,7 @@ namespace BossMod.Endwalker.Savage.P8S1Hephaistos
             }
         }
 
-        public void DrawPetrify(Actor source, bool delayed, MiniArena arena) => arena.AddCone(source.Position, 25, source.Rotation, 45.Degrees(), delayed ? ArenaColor.Safe : ArenaColor.Danger);
-        public void DrawExplode(Actor source, bool delayed, MiniArena arena) => arena.AddCircle(source.Position, 5, delayed ? ArenaColor.Safe : ArenaColor.Danger);
+        public void DrawPetrify(Actor source, bool delayed, MiniArena arena) => arena.AddCone(source.Position, 25, source.Rotation, 45.Degrees(), delayed ? ComponentType.Safe : ComponentType.Danger);
+        public void DrawExplode(Actor source, bool delayed, MiniArena arena) => arena.AddCircle(source.Position, 5, delayed ? ComponentType.Safe : ComponentType.Danger);
     }
 }

--- a/BossMod/Modules/Endwalker/Savage/P8S1Hephaistos/Sunforge.cs
+++ b/BossMod/Modules/Endwalker/Savage/P8S1Hephaistos/Sunforge.cs
@@ -8,8 +8,8 @@
         {
             if (Active)
             {
-                arena.ZoneRect(module.Bounds.Center, new WDir(1, 0), 21, -7, 21, ArenaColor.SafeFromAOE);
-                arena.ZoneRect(module.Bounds.Center, new WDir(-1, 0), 21, -7, 21, ArenaColor.SafeFromAOE);
+                arena.ZoneRect(module.Bounds.Center, new WDir(1, 0), 21, -7, 21, ComponentType.SafeFromAOE);
+                arena.ZoneRect(module.Bounds.Center, new WDir(-1, 0), 21, -7, 21, ComponentType.SafeFromAOE);
             }
         }
     }
@@ -22,7 +22,7 @@
         {
             if (Active)
             {
-                arena.ZoneRect(module.Bounds.Center, new WDir(0, 1), 21, 21, 7, ArenaColor.SafeFromAOE);
+                arena.ZoneRect(module.Bounds.Center, new WDir(0, 1), 21, 21, 7, ComponentType.SafeFromAOE);
             }
         }
     }

--- a/BossMod/Modules/Endwalker/Savage/P8S2Hephaistos/Dominion.cs
+++ b/BossMod/Modules/Endwalker/Savage/P8S2Hephaistos/Dominion.cs
@@ -35,7 +35,7 @@ namespace BossMod.Endwalker.Savage.P8S2
 
             if (NumDeformations >= 4 && ShouldSoak(pcSlot))
                 foreach (var tower in ActiveTowers())
-                    arena.AddCircle(tower.Position, _towerRadius, ArenaColor.Danger, 2);
+                    arena.AddCircle(tower.Position, _towerRadius, ComponentType.Danger, 2);
         }
 
         public override void OnCastStarted(BossModule module, Actor caster, ActorCastInfo spell)

--- a/BossMod/Modules/Endwalker/Savage/P8S2Hephaistos/EndOfDaysTethered.cs
+++ b/BossMod/Modules/Endwalker/Savage/P8S2Hephaistos/EndOfDaysTethered.cs
@@ -32,7 +32,7 @@ namespace BossMod.Endwalker.Savage.P8S2
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var t in _tethers)
-                arena.AddLine(t.source.Position, t.target.Position, ArenaColor.Danger);
+                arena.AddLine(t.source.Position, t.target.Position, ComponentType.Danger);
         }
 
         public override void OnTethered(BossModule module, Actor source, ActorTetherInfo tether)

--- a/BossMod/Modules/Endwalker/Savage/P8S2Hephaistos/HighConcept.cs
+++ b/BossMod/Modules/Endwalker/Savage/P8S2Hephaistos/HighConcept.cs
@@ -25,7 +25,7 @@ namespace BossMod.Endwalker.Savage.P8S2
         protected static float SpliceRadius = 6;
         protected static float TowerRadius = 3;
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return NumAssignedRoles < 8 ? PlayerPriority.Irrelevant : PlayerPriority.Normal;
         }
@@ -122,10 +122,10 @@ namespace BossMod.Endwalker.Savage.P8S2
         {
             var source = module.Raid[slot];
             if (source != null)
-                module.Arena.AddCircle(source.Position, radius, safe ? ArenaColor.Safe : ArenaColor.Danger);
+                module.Arena.AddCircle(source.Position, radius, safe ? ComponentType.Safe : ComponentType.Danger);
         }
 
-        protected void DrawTower(BossModule module, WPos pos, bool assigned) => module.Arena.AddCircle(pos, TowerRadius, assigned ? ArenaColor.Safe : ArenaColor.Danger, 2);
+        protected void DrawTower(BossModule module, WPos pos, bool assigned) => module.Arena.AddCircle(pos, TowerRadius, assigned ? ComponentType.Safe : ComponentType.Danger, 2);
         protected void DrawTower(BossModule module, float offsetZ, bool assigned) => DrawTower(module, module.Bounds.Center + new WDir(0, offsetZ), assigned);
 
         protected void DrawTether(BossModule module, int slot1, int slot2, int pcSlot)
@@ -133,7 +133,7 @@ namespace BossMod.Endwalker.Savage.P8S2
             var a1 = module.Raid[slot1];
             var a2 = module.Raid[slot2];
             if (a1 != null && a2 != null)
-                module.Arena.AddLine(a1.Position, a2.Position, pcSlot == slot1 || pcSlot == slot2 ? ArenaColor.Safe : ArenaColor.Danger);
+                module.Arena.AddLine(a1.Position, a2.Position, pcSlot == slot1 || pcSlot == slot2 ? ComponentType.Safe : ComponentType.Danger);
         }
     }
 

--- a/BossMod/Modules/Endwalker/Savage/P8S2Hephaistos/LimitlessDesolation.cs
+++ b/BossMod/Modules/Endwalker/Savage/P8S2Hephaistos/LimitlessDesolation.cs
@@ -38,7 +38,7 @@ namespace BossMod.Endwalker.Savage.P8S2
 
             var towerIndex = _towerAssignments[pcSlot];
             if (towerIndex >= 0)
-                arena.AddCircle(module.Bounds.Center + _towerOffsets[towerIndex], _towerRadius, ArenaColor.Safe, 2);
+                arena.AddCircle(module.Bounds.Center + _towerOffsets[towerIndex], _towerRadius, ComponentType.Safe, 2);
         }
 
         public override void OnEventCast(BossModule module, Actor caster, ActorCastEvent spell)

--- a/BossMod/Modules/Endwalker/Savage/P8S2Hephaistos/TyrantsUnholyDarkness.cs
+++ b/BossMod/Modules/Endwalker/Savage/P8S2Hephaistos/TyrantsUnholyDarkness.cs
@@ -23,7 +23,7 @@ namespace BossMod.Endwalker.Savage.P8S2
             }
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return IsTarget(player) ? PlayerPriority.Danger : PlayerPriority.Irrelevant;
         }
@@ -31,7 +31,7 @@ namespace BossMod.Endwalker.Savage.P8S2
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var target in module.Raid.WithoutSlot().Where(IsTarget))
-                arena.AddCircle(target.Position, _radius, ArenaColor.Danger);
+                arena.AddCircle(target.Position, _radius, ComponentType.Danger);
         }
     }
 }

--- a/BossMod/Modules/Endwalker/Savage/P9SKokytos/ArchaicRockbreaker.cs
+++ b/BossMod/Modules/Endwalker/Savage/P9SKokytos/ArchaicRockbreaker.cs
@@ -79,7 +79,7 @@ namespace BossMod.Endwalker.Savage.P9SKokytos
             base.AddHints(module, slot, actor, hints, movementHints);
             if (movementHints != null)
                 foreach (var p in SafeSpots(module))
-                    movementHints.Add(actor.Position, p, ArenaColor.Safe);
+                    movementHints.Add(actor.Position, p, ComponentType.Safe);
         }
 
         public override void OnCastStarted(BossModule module, Actor caster, ActorCastInfo spell)

--- a/BossMod/Modules/Endwalker/Savage/P9SKokytos/Charibdys.cs
+++ b/BossMod/Modules/Endwalker/Savage/P9SKokytos/Charibdys.cs
@@ -19,7 +19,7 @@ namespace BossMod.Endwalker.Savage.P9SKokytos
         {
             foreach (var c in Actors.Where(a => !IsFinished(a)))
             {
-                arena.Actor(c, IsActive(c) ? ArenaColor.Enemy : ArenaColor.Object, true);
+                arena.Actor(c, IsActive(c) ? ComponentType.ActorEnemy : ComponentType.ActorObject, true);
             }
         }
     }

--- a/BossMod/Modules/Endwalker/Savage/P9SKokytos/LevinstrikeSummoning.cs
+++ b/BossMod/Modules/Endwalker/Savage/P9SKokytos/LevinstrikeSummoning.cs
@@ -127,7 +127,7 @@ namespace BossMod.Endwalker.Savage.P9SKokytos
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (NumTowers < NumCasts)
-                arena.AddCircle(_explodeOrder[NumTowers], 3, _soakerOrder[NumTowers] == pc ? ArenaColor.Safe : ArenaColor.Danger, 2);
+                arena.AddCircle(_explodeOrder[NumTowers], 3, _soakerOrder[NumTowers] == pc ? ComponentType.Safe : ComponentType.Danger, 2);
         }
 
         public override void OnEventIcon(BossModule module, Actor actor, uint iconID)

--- a/BossMod/Modules/Endwalker/Savage/P9SKokytos/Uplift.cs
+++ b/BossMod/Modules/Endwalker/Savage/P9SKokytos/Uplift.cs
@@ -14,7 +14,7 @@
                 {
                     var center = WallDirection.Value + i * 90.Degrees();
                     arena.PathArcTo(module.Bounds.Center, module.Bounds.HalfSize - 0.5f, (center - 22.5f.Degrees()).Rad, (center + 22.5f.Degrees()).Rad);
-                    arena.PathStroke(false, ArenaColor.Border, 2);
+                    arena.PathStroke(false, ComponentType.Border, 2);
                 }
             }
         }

--- a/BossMod/Modules/Endwalker/TreasureHunt/TheExcitatron6000/LuckyFace.cs
+++ b/BossMod/Modules/Endwalker/TreasureHunt/TheExcitatron6000/LuckyFace.cs
@@ -197,17 +197,17 @@ namespace BossMod.Endwalker.TreasureHunt.LuckyFace
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy, true);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy, true);
             foreach (var s in Enemies(OID.ExcitingEgg))
-                Arena.Actor(s, ArenaColor.Vulnerable, false);
+                Arena.Actor(s, ComponentType.ActorVulnerable, false);
             foreach (var s in Enemies(OID.ExcitingTomato))
-                Arena.Actor(s, ArenaColor.Vulnerable, false);
+                Arena.Actor(s, ComponentType.ActorVulnerable, false);
             foreach (var s in Enemies(OID.ExcitingQueen))
-                Arena.Actor(s, ArenaColor.Vulnerable, false);
+                Arena.Actor(s, ComponentType.ActorVulnerable, false);
             foreach (var s in Enemies(OID.ExcitingGarlic))
-                Arena.Actor(s, ArenaColor.Vulnerable, false);
+                Arena.Actor(s, ComponentType.ActorVulnerable, false);
             foreach (var s in Enemies(OID.ExcitingOnion))
-                Arena.Actor(s, ArenaColor.Vulnerable, false);
+                Arena.Actor(s, ComponentType.ActorVulnerable, false);
         }
 
         public override void CalculateAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)

--- a/BossMod/Modules/Endwalker/TreasureHunt/TheShiftingGymnasionAgonon/GymnasiouAcheloios.cs
+++ b/BossMod/Modules/Endwalker/TreasureHunt/TheShiftingGymnasionAgonon/GymnasiouAcheloios.cs
@@ -71,12 +71,12 @@ namespace BossMod.Endwalker.TreasureHunt.GymnasiouAcheloios
             {
                 _increment = 180.Degrees();
                 Sequences.Add(new(_shape, caster.Position, spell.Rotation, _increment, spell.FinishAt, 3.9f, 2, 1));
-                ImminentColor = ArenaColor.AOE;
+                ImminentType = ComponentType.AOE;
             }
             if ((AID)spell.Action.ID == AID.QuadrupleHammer2)
             {
                 Sequences.Add(new(_shape, caster.Position, spell.Rotation, _increment, spell.FinishAt, 3.3f, 4));
-                ImminentColor = ArenaColor.Danger;
+                ImminentType = ComponentType.Danger;
             }
         }
         public override void OnCastFinished(BossModule module, Actor caster, ActorCastInfo spell)
@@ -169,23 +169,23 @@ namespace BossMod.Endwalker.TreasureHunt.GymnasiouAcheloios
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy, true);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy, true);
             foreach (var s in Enemies(OID.BossAdd))
-                Arena.Actor(s, ArenaColor.Object, false);
+                Arena.Actor(s, ComponentType.ActorObject, false);
             foreach (var s in Enemies(OID.GymnasticEggplant))
-                Arena.Actor(s, ArenaColor.Vulnerable, false);
+                Arena.Actor(s, ComponentType.ActorVulnerable, false);
             foreach (var s in Enemies(OID.GymnasticTomato))
-                Arena.Actor(s, ArenaColor.Vulnerable, false);
+                Arena.Actor(s, ComponentType.ActorVulnerable, false);
             foreach (var s in Enemies(OID.GymnasticQueen))
-                Arena.Actor(s, ArenaColor.Vulnerable, false);
+                Arena.Actor(s, ComponentType.ActorVulnerable, false);
             foreach (var s in Enemies(OID.GymnasticGarlic))
-                Arena.Actor(s, ArenaColor.Vulnerable, false);
+                Arena.Actor(s, ComponentType.ActorVulnerable, false);
             foreach (var s in Enemies(OID.GymnasticOnion))
-                Arena.Actor(s, ArenaColor.Vulnerable, false);
+                Arena.Actor(s, ComponentType.ActorVulnerable, false);
             foreach (var s in Enemies(OID.BonusAdds_Lampas))
-                Arena.Actor(s, ArenaColor.Vulnerable, false);
+                Arena.Actor(s, ComponentType.ActorVulnerable, false);
             foreach (var s in Enemies(OID.BonusAdds_Lyssa))
-                Arena.Actor(s, ArenaColor.Vulnerable, false);
+                Arena.Actor(s, ComponentType.ActorVulnerable, false);
         }
 
         public override void CalculateAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)

--- a/BossMod/Modules/Endwalker/TreasureHunt/TheShiftingGymnasionAgonon/GymnasiouPithekos.cs
+++ b/BossMod/Modules/Endwalker/TreasureHunt/TheShiftingGymnasionAgonon/GymnasiouPithekos.cs
@@ -118,11 +118,11 @@ namespace BossMod.Endwalker.TreasureHunt.GymnasiouPithekos
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy, true);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy, true);
             foreach (var s in Enemies(OID.BossAdd))
-                Arena.Actor(s, ArenaColor.Object, false);
+                Arena.Actor(s, ComponentType.ActorObject, false);
             foreach (var s in Enemies(OID.BonusAdd_Lyssa))
-                Arena.Actor(s, ArenaColor.Vulnerable, false);
+                Arena.Actor(s, ComponentType.ActorVulnerable, false);
         }
 
         public override void CalculateAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)

--- a/BossMod/Modules/Endwalker/TreasureHunt/TheShiftingGymnasionAgonon/LyssaChrysine.cs
+++ b/BossMod/Modules/Endwalker/TreasureHunt/TheShiftingGymnasionAgonon/LyssaChrysine.cs
@@ -157,11 +157,11 @@ namespace BossMod.Endwalker.TreasureHunt.LyssaChrysine
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy, true);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy, true);
             foreach (var s in Enemies(OID.BonusAdds_Lyssa))
-                Arena.Actor(s, ArenaColor.Vulnerable, false);
+                Arena.Actor(s, ComponentType.ActorVulnerable, false);
             foreach (var s in Enemies(OID.BonusAdds_Lampas))
-                Arena.Actor(s, ArenaColor.Vulnerable, false);
+                Arena.Actor(s, ComponentType.ActorVulnerable, false);
         }
 
         public override void CalculateAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)

--- a/BossMod/Modules/Endwalker/Ultimate/DSW1/DSW1.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/DSW1/DSW1.cs
@@ -38,9 +38,9 @@ namespace BossMod.Endwalker.Ultimate.DSW1
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(SerAdelphel(), ArenaColor.Enemy);
-            Arena.Actor(SerGrinnaux(), ArenaColor.Enemy);
-            Arena.Actor(SerCharibert(), ArenaColor.Enemy);
+            Arena.Actor(SerAdelphel(), ComponentType.ActorEnemy);
+            Arena.Actor(SerGrinnaux(), ComponentType.ActorEnemy);
+            Arena.Actor(SerCharibert(), ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/Endwalker/Ultimate/DSW1/Heavensflame.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/DSW1/Heavensflame.cs
@@ -45,7 +45,7 @@ namespace BossMod.Endwalker.Ultimate.DSW1
                 hints.Add("Aim to break tether!");
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return _playerIcons[pcSlot] == 0 ? PlayerPriority.Irrelevant :
                 !_brokenTethers[pcSlot] && _playerIcons[pcSlot] == _playerIcons[playerSlot] ? PlayerPriority.Interesting
@@ -59,7 +59,7 @@ namespace BossMod.Endwalker.Ultimate.DSW1
 
             foreach (var hint in PositionHints(module, pcSlot))
             {
-                module.Arena.AddCircle(hint, 1, ArenaColor.Safe);
+                module.Arena.AddCircle(hint, 1, ComponentType.Safe);
                 //var dir = Vector3.Normalize(pos.Value - _knockbackSource.Position);
                 //var adjPos = module.Arena.ClampToBounds(_knockbackSource.Position + 50 * dir);
                 //module.Arena.AddLine(module.Bounds.Center, adjPos, ArenaColor.Safe);
@@ -67,12 +67,12 @@ namespace BossMod.Endwalker.Ultimate.DSW1
 
             int partner = FindTetheredPartner(pcSlot);
             if (partner >= 0)
-                arena.AddLine(pc.Position, module.Raid[partner]!.Position, ArenaColor.Safe);
+                arena.AddLine(pc.Position, module.Raid[partner]!.Position, ComponentType.Safe);
 
             DrawKnockback(pc, _playerAdjustedPositions[pcSlot], arena);
 
             foreach (var (slot, _) in module.Raid.WithSlot().Exclude(pc))
-                arena.AddCircle(_playerAdjustedPositions[slot], _aoeRadius, ArenaColor.Danger);
+                arena.AddCircle(_playerAdjustedPositions[slot], _aoeRadius, ComponentType.Danger);
         }
 
         public override void OnUntethered(BossModule module, Actor source, ActorTetherInfo tether)

--- a/BossMod/Modules/Endwalker/Ultimate/DSW1/HyperdimensionalSlash.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/DSW1/HyperdimensionalSlash.cs
@@ -84,10 +84,10 @@ namespace BossMod.Endwalker.Ultimate.DSW1
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             for (int i = 0; i < _tears.Count; ++i)
-                arena.AddCircle(_tears[i].Pos, _linkRadius, _riskyTears[i] ? ArenaColor.Danger : ArenaColor.Safe);
+                arena.AddCircle(_tears[i].Pos, _linkRadius, _riskyTears[i] ? ComponentType.Danger : ComponentType.Safe);
 
             if (_laserTargets[pcSlot])
-                arena.AddLine(module.Bounds.Center, TearPosition(module, pc), ArenaColor.Danger);
+                arena.AddLine(module.Bounds.Center, TearPosition(module, pc), ComponentType.Danger);
         }
 
         public override void OnEventCast(BossModule module, Actor caster, ActorCastEvent spell)

--- a/BossMod/Modules/Endwalker/Ultimate/DSW1/PureOfHeart.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/DSW1/PureOfHeart.cs
@@ -38,7 +38,7 @@ namespace BossMod.Endwalker.Ultimate.DSW1
                 hints.Add("GTFO from raid!");
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return _baiters[playerSlot] ? PlayerPriority.Danger : PlayerPriority.Normal;
         }
@@ -46,7 +46,7 @@ namespace BossMod.Endwalker.Ultimate.DSW1
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var (_, player) in module.Raid.WithSlot().IncludedInMask(_baiters))
-                arena.AddCircle(player.Position, _radius, ArenaColor.Danger);
+                arena.AddCircle(player.Position, _radius, ComponentType.Danger);
         }
 
         public override void OnStatusGain(BossModule module, Actor actor, ActorStatus status)

--- a/BossMod/Modules/Endwalker/Ultimate/DSW1/ShiningBlade.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/DSW1/ShiningBlade.cs
@@ -38,7 +38,7 @@ namespace BossMod.Endwalker.Ultimate.DSW1
         public override void DrawArenaBackground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var p in _tears)
-                arena.ZoneCircle(p.Position, _tearRadius, ArenaColor.AOE);
+                arena.ZoneCircle(p.Position, _tearRadius, ComponentType.AOE);
         }
     }
 
@@ -122,7 +122,7 @@ namespace BossMod.Endwalker.Ultimate.DSW1
             }
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return player == _target ? PlayerPriority.Danger : PlayerPriority.Irrelevant;
         }
@@ -130,7 +130,7 @@ namespace BossMod.Endwalker.Ultimate.DSW1
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (_target != null)
-                arena.AddCircle(_target.Position, _executionRadius, ArenaColor.Danger);
+                arena.AddCircle(_target.Position, _executionRadius, ComponentType.Danger);
         }
 
         public override void OnEventCast(BossModule module, Actor caster, ActorCastEvent spell)

--- a/BossMod/Modules/Endwalker/Ultimate/DSW2/DSW2.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/DSW2/DSW2.cs
@@ -128,17 +128,17 @@ namespace BossMod.Endwalker.Ultimate.DSW2
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy, true);
-            Arena.Actor(_bossP3, ArenaColor.Enemy);
-            Arena.Actor(_leftEyeP4, ArenaColor.Enemy);
-            Arena.Actor(_rightEyeP4, ArenaColor.Enemy);
-            Arena.Actor(_nidhoggP4, ArenaColor.Enemy);
-            Arena.Actor(_serCharibert, ArenaColor.Enemy);
-            Arena.Actor(_spear, ArenaColor.Enemy);
-            Arena.Actor(_bossP5, ArenaColor.Enemy);
-            Arena.Actor(_nidhoggP6, ArenaColor.Enemy);
-            Arena.Actor(_hraesvelgrP6, ArenaColor.Enemy);
-            Arena.Actor(_bossP7, ArenaColor.Enemy);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy, true);
+            Arena.Actor(_bossP3, ComponentType.ActorEnemy);
+            Arena.Actor(_leftEyeP4, ComponentType.ActorEnemy);
+            Arena.Actor(_rightEyeP4, ComponentType.ActorEnemy);
+            Arena.Actor(_nidhoggP4, ComponentType.ActorEnemy);
+            Arena.Actor(_serCharibert, ComponentType.ActorEnemy);
+            Arena.Actor(_spear, ComponentType.ActorEnemy);
+            Arena.Actor(_bossP5, ComponentType.ActorEnemy);
+            Arena.Actor(_nidhoggP6, ComponentType.ActorEnemy);
+            Arena.Actor(_hraesvelgrP6, ComponentType.ActorEnemy);
+            Arena.Actor(_bossP7, ComponentType.ActorEnemy);
             //Arena.Actor(Enemies(OID.SerJanlenoux).FirstOrDefault(), 0xffffffff);
             //Arena.Actor(Enemies(OID.SerVellguine).FirstOrDefault(), 0xff0000ff);
             //Arena.Actor(Enemies(OID.SerPaulecrain).FirstOrDefault(), 0xff00ff00);

--- a/BossMod/Modules/Endwalker/Ultimate/DSW2/P2BroadSwing.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/DSW2/P2BroadSwing.cs
@@ -23,7 +23,7 @@ namespace BossMod.Endwalker.Ultimate.DSW2
             };
             if (rot != default)
             {
-                _aoes.Add(new(_aoe, caster.Position, spell.Rotation + rot, spell.FinishAt.AddSeconds(0.8f), ArenaColor.Danger));
+                _aoes.Add(new(_aoe, caster.Position, spell.Rotation + rot, spell.FinishAt.AddSeconds(0.8f), ComponentType.Danger));
                 _aoes.Add(new(_aoe, caster.Position, spell.Rotation - rot, spell.FinishAt.AddSeconds(1.8f)));
                 _aoes.Add(new(_aoe, caster.Position, spell.Rotation + 180.Degrees(), spell.FinishAt.AddSeconds(2.8f)));
             }
@@ -37,7 +37,7 @@ namespace BossMod.Endwalker.Ultimate.DSW2
                 if (_aoes.Count > 0)
                     _aoes.RemoveAt(0);
                 if (_aoes.Count > 0)
-                    _aoes.AsSpan()[0].Color = ArenaColor.Danger;
+                    _aoes.AsSpan()[0].Type = ComponentType.Danger;
             }
         }
     }

--- a/BossMod/Modules/Endwalker/Ultimate/DSW2/P2SanctityOfTheWard1.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/DSW2/P2SanctityOfTheWard1.cs
@@ -31,8 +31,8 @@ namespace BossMod.Endwalker.Ultimate.DSW2
 
             if (Stacks.Count == 2 && Source != null)
             {
-                arena.Actor(Source, ArenaColor.Enemy, true);
-                arena.AddLine(Source.Position, Stacks[NumCasts % 2].Target.Position, ArenaColor.Danger);
+                arena.Actor(Source, ComponentType.ActorEnemy, true);
+                arena.AddLine(Source.Position, Stacks[NumCasts % 2].Target.Position, ComponentType.Danger);
             }
         }
 
@@ -92,7 +92,7 @@ namespace BossMod.Endwalker.Ultimate.DSW2
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
-            arena.Actors(Charges.Where(c => c.ChargeAOEs.Count > 0).Select(c => c.Source), ArenaColor.Enemy, true);
+            arena.Actors(Charges.Where(c => c.ChargeAOEs.Count > 0).Select(c => c.Source), ComponentType.ActorEnemy, true);
         }
 
         public override void OnEventCast(BossModule module, Actor caster, ActorCastEvent spell)
@@ -255,13 +255,13 @@ namespace BossMod.Endwalker.Ultimate.DSW2
             if (movementHints != null && _groupEast.Any())
             {
                 var from = actor.Position;
-                var color = ArenaColor.Safe;
+                var color = ComponentType.Safe;
                 foreach (var safespot in MovementHintOffsets(slot))
                 {
                     var to = module.Bounds.Center + safespot;
                     movementHints.Add(from, to, color);
                     from = to;
-                    color = ArenaColor.Danger;
+                    color = ComponentType.Danger;
                 }
             }
         }
@@ -270,9 +270,9 @@ namespace BossMod.Endwalker.Ultimate.DSW2
         {
             foreach (var safespot in MovementHintOffsets(pcSlot).Take(1))
             {
-                arena.AddCircle(module.Bounds.Center + safespot, 1, ArenaColor.Safe);
+                arena.AddCircle(module.Bounds.Center + safespot, 1, ComponentType.Safe);
                 if (_groupEast.None())
-                    arena.AddCircle(module.Bounds.Center - safespot, 1, ArenaColor.Safe); // if there are no valid assignments, draw spots for both groups
+                    arena.AddCircle(module.Bounds.Center - safespot, 1, ComponentType.Safe); // if there are no valid assignments, draw spots for both groups
             }
         }
 

--- a/BossMod/Modules/Endwalker/Ultimate/DSW2/P2SanctityOfTheWard2.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/DSW2/P2SanctityOfTheWard2.cs
@@ -45,7 +45,7 @@ namespace BossMod.Endwalker.Ultimate.DSW2
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
-            arena.AddCircle(pc.Position, 7, ArenaColor.Danger);
+            arena.AddCircle(pc.Position, 7, ComponentType.Danger);
         }
     }
 
@@ -120,13 +120,13 @@ namespace BossMod.Endwalker.Ultimate.DSW2
             if (Active && movementHints != null && _players[slot].AssignedQuadrant >= 0)
             {
                 var from = actor.Position;
-                var color = ArenaColor.Safe;
+                var color = ComponentType.Safe;
                 if (!_stormsDone)
                 {
                     var stormPos = StormPlacementPosition(module, _players[slot].AssignedQuadrant);
                     movementHints.Add(from, stormPos, color);
                     from = stormPos;
-                    color = ArenaColor.Danger;
+                    color = ComponentType.Danger;
                 }
 
                 foreach (var tower in Towers.Where(t => !t.ForbiddenSoakers[slot]))
@@ -144,7 +144,7 @@ namespace BossMod.Endwalker.Ultimate.DSW2
             }
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return _preyTargets[playerSlot] ? PlayerPriority.Danger : PlayerPriority.Normal;
         }
@@ -156,8 +156,8 @@ namespace BossMod.Endwalker.Ultimate.DSW2
             if (Active)
             {
                 float diag = module.Bounds.HalfSize / 1.414214f;
-                arena.AddLine(module.Bounds.Center + new WDir(diag, diag), module.Bounds.Center - new WDir(diag, diag), ArenaColor.Border);
-                arena.AddLine(module.Bounds.Center + new WDir(diag, -diag), module.Bounds.Center - new WDir(diag, -diag), ArenaColor.Border);
+                arena.AddLine(module.Bounds.Center + new WDir(diag, diag), module.Bounds.Center - new WDir(diag, diag), ComponentType.Border);
+                arena.AddLine(module.Bounds.Center + new WDir(diag, -diag), module.Bounds.Center - new WDir(diag, -diag), ComponentType.Border);
             }
 
             // TODO: move to separate comet component...
@@ -165,8 +165,8 @@ namespace BossMod.Endwalker.Ultimate.DSW2
             {
                 foreach (var comet in module.Enemies(OID.HolyComet))
                 {
-                    arena.Actor(comet, ArenaColor.Object, true);
-                    arena.AddCircle(comet.Position, _cometLinkRange, ArenaColor.Object);
+                    arena.Actor(comet, ComponentType.ActorObject, true);
+                    arena.AddCircle(comet.Position, _cometLinkRange, ComponentType.ActorObject);
                 }
             }
         }

--- a/BossMod/Modules/Endwalker/Ultimate/DSW2/P2StrengthOfTheWard2.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/DSW2/P2StrengthOfTheWard2.cs
@@ -38,16 +38,16 @@ namespace BossMod.Endwalker.Ultimate.DSW2
             base.AddHints(module, slot, actor, hints, movementHints);
             if (movementHints != null)
                 foreach (var safespot in EnumSafeSpots(module, actor))
-                    movementHints.Add(actor.Position, safespot, ArenaColor.Safe);
+                    movementHints.Add(actor.Position, safespot, ComponentType.Safe);
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor) => PlayerPriority.Normal;
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type) => PlayerPriority.Normal;
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             base.DrawArenaForeground(module, pcSlot, pc, arena);
             foreach (var safespot in EnumSafeSpots(module, pc))
-                arena.AddCircle(safespot, 1, ArenaColor.Safe);
+                arena.AddCircle(safespot, 1, ComponentType.Safe);
         }
 
         public override void OnEventCast(BossModule module, Actor caster, ActorCastEvent spell)
@@ -150,7 +150,7 @@ namespace BossMod.Endwalker.Ultimate.DSW2
                 var target = module.WorldState.Actors.Find(source.Tether.Target);
                 if (target != null)
                 {
-                    arena.ZoneRect(source.Position, target.Position, _chargeHalfWidth, ArenaColor.AOE);
+                    arena.ZoneRect(source.Position, target.Position, _chargeHalfWidth, ComponentType.AOE);
                 }
             }
         }
@@ -160,10 +160,10 @@ namespace BossMod.Endwalker.Ultimate.DSW2
             // draw tethers
             foreach (var source in _chargeSources)
             {
-                module.Arena.Actor(source, ArenaColor.Enemy, true);
+                module.Arena.Actor(source, ComponentType.ActorEnemy, true);
                 var target = module.WorldState.Actors.Find(source.Tether.Target);
                 if (target != null)
-                    module.Arena.AddLine(source.Position, target.Position, ArenaColor.Danger);
+                    module.Arena.AddLine(source.Position, target.Position, ComponentType.Danger);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Ultimate/DSW2/P3DiveFromGrace.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/DSW2/P3DiveFromGrace.cs
@@ -14,7 +14,7 @@ namespace BossMod.Endwalker.Ultimate.DSW2
         {
             foreach (var p in _predicted)
             {
-                arena.Actor(p, ArenaColor.Object, true);
+                arena.Actor(p, ComponentType.ActorObject, true);
                 var target = module.Raid.WithoutSlot().Closest(p.Position);
                 if (target != null)
                     Shape.Outline(arena, p.Position, Angle.FromDirection(target.Position - p.Position));
@@ -123,7 +123,7 @@ namespace BossMod.Endwalker.Ultimate.DSW2
 
             if (movementHints != null)
                 foreach (var s in SafeSpots(module, slot))
-                    movementHints.Add(actor.Position, s, ArenaColor.Safe);
+                    movementHints.Add(actor.Position, s, ComponentType.Safe);
         }
 
         public override void AddGlobalHints(BossModule module, GlobalHints hints)
@@ -132,7 +132,7 @@ namespace BossMod.Endwalker.Ultimate.DSW2
                 hints.Add($"Arrows for: {(_ordersWithArrows.Any() ? string.Join(", ", _ordersWithArrows.SetBits()) : "none")}");
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return _playerStates[playerSlot].JumpOrder == CurrentBaitOrder() ? PlayerPriority.Interesting : PlayerPriority.Normal;
         }
@@ -148,14 +148,14 @@ namespace BossMod.Endwalker.Ultimate.DSW2
             foreach (var (slot, player) in module.Raid.WithSlot(true).WhereSlot(i => _playerStates[i].JumpOrder == baitOrder))
             {
                 var pos = player.Position + _playerStates[slot].JumpDirection * player.Rotation.ToDirection() * _towerOffset;
-                arena.AddCircle(pos, Radius, ArenaColor.Object);
+                arena.AddCircle(pos, Radius, ComponentType.ActorObject);
                 if (slot == pcSlot)
-                    arena.AddLine(pc.Position, pos, ArenaColor.Object);
+                    arena.AddLine(pc.Position, pos, ComponentType.ActorObject);
             }
 
             // safe spots
             foreach (var s in SafeSpots(module, pcSlot))
-                arena.AddCircle(s, 1, ArenaColor.Safe);
+                arena.AddCircle(s, 1, ComponentType.Safe);
         }
 
         public override void OnStatusGain(BossModule module, Actor actor, ActorStatus status)

--- a/BossMod/Modules/Endwalker/Ultimate/DSW2/P4Hatebound.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/DSW2/P4Hatebound.cs
@@ -28,9 +28,9 @@ namespace BossMod.Endwalker.Ultimate.DSW2
         {
             foreach (var o in _orbs.Where(o => !o.exploded))
             {
-                arena.Actor(o.orb, ArenaColor.Object, true);
+                arena.Actor(o.orb, ComponentType.ActorObject, true);
                 if (OrbReady(o.orb))
-                    arena.AddCircle(o.orb.Position, 6, _playerColors[pcSlot] == Color.Red ? ArenaColor.Safe : ArenaColor.Danger);
+                    arena.AddCircle(o.orb.Position, 6, _playerColors[pcSlot] == Color.Red ? ComponentType.Safe : ComponentType.Danger);
             }
         }
 
@@ -96,7 +96,7 @@ namespace BossMod.Endwalker.Ultimate.DSW2
             }
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return _baiters[playerSlot] ? PlayerPriority.Danger : PlayerPriority.Normal;
         }
@@ -107,7 +107,7 @@ namespace BossMod.Endwalker.Ultimate.DSW2
             foreach (var (slot, player) in module.Raid.WithSlot(true).IncludedInMask(_baiters))
             {
                 bool canSwap = pcCanSwap && _forbidden[slot];
-                arena.AddCircle(player.Position, _radius, canSwap ? ArenaColor.Safe : ArenaColor.Danger);
+                arena.AddCircle(player.Position, _radius, canSwap ? ComponentType.Safe : ComponentType.Danger);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Ultimate/DSW2/P5DeathOfTheHeavens.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/DSW2/P5DeathOfTheHeavens.cs
@@ -96,7 +96,7 @@ namespace BossMod.Endwalker.Ultimate.DSW2
                 hints.Add("Aim to break tether!");
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return _playerIcons[pcSlot] == 0 ? PlayerPriority.Irrelevant :
                 !_brokenTethers[pcSlot] && _playerIcons[pcSlot] == _playerIcons[playerSlot] ? PlayerPriority.Interesting
@@ -109,16 +109,16 @@ namespace BossMod.Endwalker.Ultimate.DSW2
                 return;
 
             foreach (var hint in PositionHints(module, pcSlot))
-                module.Arena.AddCircle(hint, 1, ArenaColor.Safe);
+                module.Arena.AddCircle(hint, 1, ComponentType.Safe);
 
             int partner = FindTetheredPartner(pcSlot);
             if (partner >= 0)
-                arena.AddLine(pc.Position, module.Raid[partner]!.Position, ArenaColor.Safe);
+                arena.AddLine(pc.Position, module.Raid[partner]!.Position, ComponentType.Safe);
 
             DrawKnockback(pc, _playerAdjustedPositions[pcSlot], arena);
 
             foreach (var (slot, _) in module.Raid.WithSlot().Exclude(pc))
-                arena.AddCircle(_playerAdjustedPositions[slot], _aoeRadius, ArenaColor.Danger);
+                arena.AddCircle(_playerAdjustedPositions[slot], _aoeRadius, ComponentType.Danger);
         }
 
         public override void OnCastStarted(BossModule module, Actor caster, ActorCastInfo spell)

--- a/BossMod/Modules/Endwalker/Ultimate/DSW2/P5WrathOfTheHeavens.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/DSW2/P5WrathOfTheHeavens.cs
@@ -11,14 +11,14 @@ namespace BossMod.Endwalker.Ultimate.DSW2
         {
             base.AddHints(module, slot, actor, hints, movementHints);
             if (movementHints != null && IsSpreadTarget(actor) && SafeSpot(module) is var safespot && safespot != default)
-                movementHints.Add(actor.Position, safespot, ArenaColor.Safe);
+                movementHints.Add(actor.Position, safespot, ComponentType.Safe);
         }
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             base.DrawArenaForeground(module, pcSlot, pc, arena);
             if (IsSpreadTarget(pc) && SafeSpot(module) is var safespot && safespot != default)
-                arena.AddCircle(safespot, 1, ArenaColor.Safe);
+                arena.AddCircle(safespot, 1, ComponentType.Safe);
         }
 
         public override void OnEventIcon(BossModule module, Actor actor, uint iconID)
@@ -52,14 +52,14 @@ namespace BossMod.Endwalker.Ultimate.DSW2
         {
             base.AddHints(module, slot, actor, hints, movementHints);
             if (movementHints != null && SafeSpot(module, actor) is var safespot && safespot != default)
-                movementHints.Add(actor.Position, safespot, ArenaColor.Safe);
+                movementHints.Add(actor.Position, safespot, ComponentType.Safe);
         }
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             base.DrawArenaForeground(module, pcSlot, pc, arena);
             if (SafeSpot(module, pc) is var safespot && safespot != default)
-                arena.AddCircle(safespot, 1, ArenaColor.Safe);
+                arena.AddCircle(safespot, 1, ComponentType.Safe);
         }
 
         private WPos SafeSpot(BossModule module, Actor actor)
@@ -92,7 +92,7 @@ namespace BossMod.Endwalker.Ultimate.DSW2
             base.AddHints(module, slot, actor, hints, movementHints);
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return Targets[playerSlot] ? PlayerPriority.Danger : PlayerPriority.Irrelevant;
         }
@@ -157,13 +157,13 @@ namespace BossMod.Endwalker.Ultimate.DSW2
                 return;
             hints.Add("Prepare for divebomb!", false);
             if (movementHints != null)
-                movementHints.Add(actor.Position, SafeSpot(module), ArenaColor.Safe);
+                movementHints.Add(actor.Position, SafeSpot(module), ComponentType.Safe);
         }
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (_target == pc)
-                arena.AddCircle(SafeSpot(module), 1, ArenaColor.Safe);
+                arena.AddCircle(SafeSpot(module), 1, ComponentType.Safe);
         }
 
         public override void OnEventIcon(BossModule module, Actor actor, uint iconID)
@@ -215,7 +215,7 @@ namespace BossMod.Endwalker.Ultimate.DSW2
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (Casters.Count == 0 && KnowPosition)
-                arena.AddCircle(_predicted, 6, ArenaColor.Safe, 2);
+                arena.AddCircle(_predicted, 6, ComponentType.Safe, 2);
         }
 
         public override void OnActorPlayActionTimelineEvent(BossModule module, Actor actor, ushort id)

--- a/BossMod/Modules/Endwalker/Ultimate/DSW2/P6HallowedWings.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/DSW2/P6HallowedWings.cs
@@ -106,7 +106,7 @@ namespace BossMod.Endwalker.Ultimate.DSW2
 
             if (movementHints != null)
                 foreach (var p in SafeSpots(module, actor))
-                    movementHints.Add(actor.Position, p, ArenaColor.Safe);
+                    movementHints.Add(actor.Position, p, ComponentType.Safe);
         }
 
         public override void AddGlobalHints(BossModule module, GlobalHints hints)
@@ -119,7 +119,7 @@ namespace BossMod.Endwalker.Ultimate.DSW2
         {
             base.DrawArenaForeground(module, pcSlot, pc, arena);
             foreach (var p in SafeSpots(module, pc))
-                arena.AddCircle(p, 1, ArenaColor.Safe);
+                arena.AddCircle(p, 1, ComponentType.Safe);
         }
 
         public override void OnCastStarted(BossModule module, Actor caster, ActorCastInfo spell)

--- a/BossMod/Modules/Endwalker/Ultimate/DSW2/P6MortalVow.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/DSW2/P6MortalVow.cs
@@ -36,14 +36,14 @@ namespace BossMod.Endwalker.Ultimate.DSW2
         {
             base.AddHints(module, slot, actor, hints, movementHints);
             if (movementHints != null && _vow != null && _target != null && (actor == _vow || actor == _target))
-                movementHints.Add(actor.Position, (actor == _vow ? _target : _vow).Position, ArenaColor.Safe);
+                movementHints.Add(actor.Position, (actor == _vow ? _target : _vow).Position, ComponentType.Safe);
         }
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             base.DrawArenaForeground(module, pcSlot, pc, arena);
             if (_vow != null && _target != null && (pc == _vow || pc == _target))
-                arena.AddCircle(module.Bounds.Center, 1, ArenaColor.Safe);
+                arena.AddCircle(module.Bounds.Center, 1, ComponentType.Safe);
         }
 
         public override void OnStatusGain(BossModule module, Actor actor, ActorStatus status)

--- a/BossMod/Modules/Endwalker/Ultimate/DSW2/P6WrothFlames.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/DSW2/P6WrothFlames.cs
@@ -30,13 +30,13 @@ namespace BossMod.Endwalker.Ultimate.DSW2
         {
             base.AddHints(module, slot, actor, hints, movementHints);
             if (movementHints != null && ShowStartingSpot)
-                movementHints.Add(actor.Position, _startingSpot, ArenaColor.Safe);
+                movementHints.Add(actor.Position, _startingSpot, ComponentType.Safe);
         }
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (ShowStartingSpot)
-                arena.AddCircle(_startingSpot, 1, ArenaColor.Safe);
+                arena.AddCircle(_startingSpot, 1, ComponentType.Safe);
         }
 
         public override void OnActorCreated(BossModule module, Actor actor)
@@ -104,14 +104,14 @@ namespace BossMod.Endwalker.Ultimate.DSW2
             base.AddHints(module, slot, actor, hints, movementHints);
             if (movementHints != null)
                 foreach (var p in SafeSpots(module, actor))
-                    movementHints.Add(actor.Position, p, ArenaColor.Safe);
+                    movementHints.Add(actor.Position, p, ComponentType.Safe);
         }
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             base.DrawArenaForeground(module, pcSlot, pc, arena);
             foreach (var p in SafeSpots(module, pc))
-                arena.AddCircle(p, 1, ArenaColor.Safe);
+                arena.AddCircle(p, 1, ComponentType.Safe);
         }
 
         public override void OnStatusGain(BossModule module, Actor actor, ActorStatus status)

--- a/BossMod/Modules/Endwalker/Ultimate/DSW2/P7ExaflaresEdge.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/DSW2/P7ExaflaresEdge.cs
@@ -8,13 +8,13 @@ namespace BossMod.Endwalker.Ultimate.DSW2
     {
         public P7ExaflaresEdge() : base(6)
         {
-            ImminentColor = ArenaColor.AOE;
+            ImminentType = ComponentType.AOE;
         }
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var p in SafeSpots(module))
-                arena.AddCircle(p, 1, ArenaColor.Safe);
+                arena.AddCircle(p, 1, ComponentType.Safe);
         }
 
         public override void OnCastStarted(BossModule module, Actor caster, ActorCastInfo spell)

--- a/BossMod/Modules/Endwalker/Ultimate/TOP/CommonAssignments.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/TOP/CommonAssignments.cs
@@ -21,7 +21,7 @@ namespace BossMod.Endwalker.Ultimate.TOP
                 hints.Add($"Order: {ps.Order}, group: {ps.Group}", false);
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             var playerOrder = PlayerStates[playerSlot].Order;
             return playerOrder == 0 ? PlayerPriority.Irrelevant : playerOrder == PlayerStates[pcSlot].Order ? PlayerPriority.Danger : PlayerPriority.Normal;

--- a/BossMod/Modules/Endwalker/Ultimate/TOP/P1Pantokrator.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/TOP/P1Pantokrator.cs
@@ -19,9 +19,9 @@ namespace BossMod.Endwalker.Ultimate.TOP
         public override IEnumerable<AOEInstance> ActiveAOEs(BossModule module, int slot, Actor actor)
         {
             foreach (var c in Casters.Skip(2))
-                yield return new(_shape, c.Position, c.CastInfo!.Rotation, c.CastInfo.FinishAt, ArenaColor.AOE, false);
+                yield return new(_shape, c.Position, c.CastInfo!.Rotation, c.CastInfo.FinishAt, ComponentType.AOE, false);
             foreach (var c in Casters.Take(2))
-                yield return new(_shape, c.Position, c.CastInfo!.Rotation, c.CastInfo.FinishAt, ArenaColor.Danger, true);
+                yield return new(_shape, c.Position, c.CastInfo!.Rotation, c.CastInfo.FinishAt, ComponentType.Danger, true);
         }
 
         public override void Init(BossModule module)
@@ -48,7 +48,7 @@ namespace BossMod.Endwalker.Ultimate.TOP
                 };
                 var offset = 12 * (module.PrimaryActor.Rotation + dir).ToDirection();
                 var pos = group == 1 ? module.Bounds.Center + offset : module.Bounds.Center - offset;
-                arena.AddCircle(pos, 1, ArenaColor.Safe);
+                arena.AddCircle(pos, 1, ComponentType.Safe);
             }
         }
 
@@ -117,11 +117,11 @@ namespace BossMod.Endwalker.Ultimate.TOP
                 var order = PlayerStates[i].Order;
                 if (order == spreadOrder)
                 {
-                    arena.AddCircle(p.Position, _spreadRadius, i == pcSlot ? ArenaColor.Safe : ArenaColor.Danger);
+                    arena.AddCircle(p.Position, _spreadRadius, i == pcSlot ? ComponentType.Safe : ComponentType.Danger);
                 }
                 else if (order == stackOrder)
                 {
-                    _stackShape.Outline(arena, module.PrimaryActor.Position, Angle.FromDirection(p.Position - module.PrimaryActor.Position), i == pcSlot ? ArenaColor.Safe : ArenaColor.Danger);
+                    _stackShape.Outline(arena, module.PrimaryActor.Position, Angle.FromDirection(p.Position - module.PrimaryActor.Position), i == pcSlot ? ComponentType.Safe : ComponentType.Danger);
                 }
             }
         }

--- a/BossMod/Modules/Endwalker/Ultimate/TOP/P1ProgramLoop.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/TOP/P1ProgramLoop.cs
@@ -51,9 +51,9 @@ namespace BossMod.Endwalker.Ultimate.TOP
             }
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
-            return PlayerStates[playerSlot].Order == PlayerStates[pcSlot].Order % 4 + 1 ? PlayerPriority.Interesting : base.CalcPriority(module, pcSlot, pc, playerSlot, player, ref customColor);
+            return PlayerStates[playerSlot].Order == PlayerStates[pcSlot].Order % 4 + 1 ? PlayerPriority.Interesting : base.CalcPriority(module, pcSlot, pc, playerSlot, player, ref type);
         }
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
@@ -63,7 +63,7 @@ namespace BossMod.Endwalker.Ultimate.TOP
             var towerToSoak = soakTowers ? SelectTowerForGroup(module, ps.Group) : null;
             foreach (var t in _towers.Skip(NumTowersDone).Take(2))
             {
-                arena.AddCircle(t.Position, _towerRadius, soakTowers && (towerToSoak == null || towerToSoak == t) ? ArenaColor.Safe : ArenaColor.Danger, 2);
+                arena.AddCircle(t.Position, _towerRadius, soakTowers && (towerToSoak == null || towerToSoak == t) ? ComponentType.Safe : ComponentType.Danger, 2);
             }
 
             if (ps.Order == NextTowersOrder(1))
@@ -71,7 +71,7 @@ namespace BossMod.Endwalker.Ultimate.TOP
                 // show next tower to soak if possible
                 var futureTowerToSoak = SelectTowerForGroup(module, ps.Group, 1);
                 if (futureTowerToSoak != null)
-                    arena.AddCircle(futureTowerToSoak.Position, _towerRadius, ArenaColor.Safe);
+                    arena.AddCircle(futureTowerToSoak.Position, _towerRadius, ComponentType.Safe);
             }
 
             bool grabThisTether = ps.Order == NextTethersOrder();
@@ -81,8 +81,8 @@ namespace BossMod.Endwalker.Ultimate.TOP
                 var ts = PlayerStates[s];
                 bool correctSoaker = ts.Order == NextTethersOrder();
                 bool tetherToGrab = ts.Group == ps.Group && (grabNextTether ? correctSoaker : grabThisTether ? NumTethersDone > 0 && ts.Order == NextTethersOrder(-1) : false);
-                arena.AddCircle(t.Position, _tetherRadius, t == pc ? ArenaColor.Safe : ArenaColor.Danger);
-                arena.AddLine(t.Position, module.PrimaryActor.Position, correctSoaker ? ArenaColor.Safe : ArenaColor.Danger, tetherToGrab ? 2 : 1);
+                arena.AddCircle(t.Position, _tetherRadius, t == pc ? ComponentType.Safe : ComponentType.Danger);
+                arena.AddLine(t.Position, module.PrimaryActor.Position, correctSoaker ? ComponentType.Safe : ComponentType.Danger, tetherToGrab ? 2 : 1);
             }
 
             if (grabThisTether && NumTethersDone == NumTowersDone)
@@ -90,7 +90,7 @@ namespace BossMod.Endwalker.Ultimate.TOP
                 // show hint for tether position
                 var spot = GetTetherDropSpot(module, ps.Group);
                 if (spot != null)
-                    arena.AddCircle(spot.Value, 1, ArenaColor.Safe);
+                    arena.AddCircle(spot.Value, 1, ComponentType.Safe);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Ultimate/TOP/P2LimitlessSynergy.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/TOP/P2LimitlessSynergy.cs
@@ -50,7 +50,7 @@ namespace BossMod.Endwalker.Ultimate.TOP
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
-            arena.Actor(_source, ArenaColor.Object, true);
+            arena.Actor(_source, ComponentType.ActorObject, true);
             base.DrawArenaForeground(module, pcSlot, pc, arena);
         }
 

--- a/BossMod/Modules/Endwalker/Ultimate/TOP/P2PartySynergy.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/TOP/P2PartySynergy.cs
@@ -44,7 +44,7 @@ namespace BossMod.Endwalker.Ultimate.TOP
             {
                 var distSq = (partner.Position - pc.Position).LengthSq();
                 var range = DistanceRange;
-                arena.AddLine(pc.Position, partner.Position, distSq < range.min * range.min || distSq > range.max * range.max ? ArenaColor.Danger : ArenaColor.Safe);
+                arena.AddLine(pc.Position, partner.Position, distSq < range.min * range.min || distSq > range.max * range.max ? ComponentType.Danger : ComponentType.Safe);
             }
         }
 
@@ -175,10 +175,10 @@ namespace BossMod.Endwalker.Ultimate.TOP
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
-            arena.Actor(_source, ArenaColor.Object, true);
+            arena.Actor(_source, ComponentType.ActorObject, true);
             var pos = AssignedPosition(module, pcSlot);
             if (pos != default)
-                arena.AddCircle(module.Bounds.Center + pos, 1, ArenaColor.Safe);
+                arena.AddCircle(module.Bounds.Center + pos, 1, ComponentType.Safe);
         }
 
         private WDir AssignedPosition(BossModule module, int slot)
@@ -251,7 +251,7 @@ namespace BossMod.Endwalker.Ultimate.TOP
         {
             var pos = AssignedPosition(module, pcSlot);
             if (pos != default)
-                arena.AddCircle(module.Bounds.Center + pos, 1, ArenaColor.Safe);
+                arena.AddCircle(module.Bounds.Center + pos, 1, ComponentType.Safe);
         }
 
         public override void OnActorPlayActionTimelineEvent(BossModule module, Actor actor, ushort id)

--- a/BossMod/Modules/Endwalker/Ultimate/TOP/P3HelloWorld.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/TOP/P3HelloWorld.cs
@@ -81,7 +81,7 @@ namespace BossMod.Endwalker.Ultimate.TOP
                 hints.Add($"Defamation color: {_defamationTowerColor}");
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             var initialPCRole = _initialRoles[pcSlot];
             var initialPlayerRole = _initialRoles[playerSlot];
@@ -89,7 +89,7 @@ namespace BossMod.Endwalker.Ultimate.TOP
                 return PlayerPriority.Irrelevant; // mechanic not started yet
             if (initialPCRole == initialPlayerRole)
             {
-                customColor = ArenaColor.Vulnerable;
+                type = ComponentType.ActorVulnerable;
                 return PlayerPriority.Interesting; // partner
             }
             var avoidPlayer = (RoleForNextTowers(initialPCRole), RoleForNextTowers(initialPlayerRole)) switch
@@ -120,19 +120,19 @@ namespace BossMod.Endwalker.Ultimate.TOP
                         _ => (0, PlayerRole.None)
                     };
                     if (radius != 0)
-                        arena.AddCircle(p.Position, radius, pcRole == share ? ArenaColor.Safe : ArenaColor.Danger);
+                        arena.AddCircle(p.Position, radius, pcRole == share ? ComponentType.Safe : ComponentType.Danger);
                 }
 
                 // draw safespots for next towers
                 foreach (var p in PositionsForTowers(module, pcSlot))
-                    arena.AddCircle(p, 1, ArenaColor.Safe);
+                    arena.AddCircle(p, 1, ComponentType.Safe);
             }
             else if (NumRotExplodes < NumCasts)
             {
                 // draw rot 'spreads' (rots will explode on players who used to have defamation/stack role and thus now have one of the tether roles)
                 foreach (var (i, p) in module.Raid.WithSlot(true))
                     if (PendingRot(i))
-                        arena.AddCircle(p.Position, 5, ArenaColor.Danger);
+                        arena.AddCircle(p.Position, 5, ComponentType.Danger);
             }
 
             if (NumTetherBreaks < 16)
@@ -144,7 +144,7 @@ namespace BossMod.Endwalker.Ultimate.TOP
                 //    arena.AddLine(pc.Position, partner.Position, ArenaColor.Danger);
                 var partner = module.Raid[PartnerSlot(pcSlot)];
                 if (partner != null && (pc.Tether.Target == partner.InstanceID || partner.Tether.Target == pc.InstanceID))
-                    arena.AddLine(pc.Position, partner.Position, ArenaColor.Danger);
+                    arena.AddLine(pc.Position, partner.Position, ComponentType.Danger);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Ultimate/TOP/P3Intermission.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/TOP/P3Intermission.cs
@@ -23,7 +23,7 @@ namespace BossMod.Endwalker.Ultimate.TOP
         {
             base.DrawArenaForeground(module, pcSlot, pc, arena);
             foreach (var s in EnumerateSafeSpots(module, pcSlot))
-                arena.AddCircle(s, 1, ArenaColor.Safe);
+                arena.AddCircle(s, 1, ComponentType.Safe);
         }
 
         public override void OnStatusGain(BossModule module, Actor actor, ActorStatus status)

--- a/BossMod/Modules/Endwalker/Ultimate/TOP/P3OversampledWaveCannon.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/TOP/P3OversampledWaveCannon.cs
@@ -25,19 +25,19 @@ namespace BossMod.Endwalker.Ultimate.TOP
 
             if (movementHints != null)
                 foreach (var p in SafeSpots(module, slot).Where(p => p.assigned))
-                    movementHints.Add(actor.Position, p.pos, ArenaColor.Safe);
+                    movementHints.Add(actor.Position, p.pos, ComponentType.Safe);
         }
 
         public override void DrawArenaBackground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var a in AOEs(module, pcSlot))
-                _shape.Draw(arena, a.origin, a.rot, a.safe ? ArenaColor.SafeFromAOE : ArenaColor.AOE);
+                _shape.Draw(arena, a.origin, a.rot, a.safe ? ComponentType.SafeFromAOE : ComponentType.AOE);
         }
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var p in SafeSpots(module, pcSlot))
-                arena.AddCircle(p.pos, 1, p.assigned ? ArenaColor.Safe : ArenaColor.Danger);
+                arena.AddCircle(p.pos, 1, p.assigned ? ComponentType.Safe : ComponentType.Danger);
         }
 
         public override void OnStatusGain(BossModule module, Actor actor, ActorStatus status)

--- a/BossMod/Modules/Endwalker/Ultimate/TOP/P4WaveCannon.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/TOP/P4WaveCannon.cs
@@ -64,18 +64,18 @@ namespace BossMod.Endwalker.Ultimate.TOP
                 hints.Add(clips == 0 ? "Share the stack!" : "GTFO from second stack!");
 
             if (movementHints != null && SafeDir(slot) is var safeDir && safeDir != default)
-                movementHints.Add(actor.Position, module.Bounds.Center + 12 * safeDir.ToDirection(), ArenaColor.Safe);
+                movementHints.Add(actor.Position, module.Bounds.Center + 12 * safeDir.ToDirection(), ComponentType.Safe);
         }
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (Imminent)
                 foreach (var (_, p) in module.Raid.WithSlot(true).IncludedInMask(_targets))
-                    _shape.Outline(arena, module.Bounds.Center, Angle.FromDirection(p.Position - module.Bounds.Center), ArenaColor.Safe);
+                    _shape.Outline(arena, module.Bounds.Center, Angle.FromDirection(p.Position - module.Bounds.Center), ComponentType.Safe);
 
             var safeDir = SafeDir(pcSlot);
             if (safeDir != default)
-                arena.AddCircle(module.Bounds.Center + 12 * safeDir.ToDirection(), 1, ArenaColor.Safe);
+                arena.AddCircle(module.Bounds.Center + 12 * safeDir.ToDirection(), 1, ComponentType.Safe);
         }
 
         public override void OnEventCast(BossModule module, Actor caster, ActorCastEvent spell)

--- a/BossMod/Modules/Endwalker/Ultimate/TOP/P5Delta.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/TOP/P5Delta.cs
@@ -36,7 +36,7 @@ namespace BossMod.Endwalker.Ultimate.TOP
         private List<(int, int)> _localTethers = new();
         private List<(int, int)> _remoteTethers = new();
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             var pcState = Players[pcSlot];
             var playerState = Players[playerSlot];
@@ -50,10 +50,10 @@ namespace BossMod.Endwalker.Ultimate.TOP
             var p = Players[pcSlot];
             var partner = p.TetherBroken ? null : module.Raid[p.PartnerSlot];
             if (partner != null)
-                arena.AddLine(pc.Position, partner.Position, ArenaColor.Danger);
+                arena.AddLine(pc.Position, partner.Position, ComponentType.Danger);
 
             foreach (var safeSpot in SafeSpotOffsets(module, pcSlot))
-                arena.AddCircle(module.Bounds.Center + safeSpot, 1, ArenaColor.Safe);
+                arena.AddCircle(module.Bounds.Center + safeSpot, 1, ComponentType.Safe);
         }
 
         public override void OnActorCreated(BossModule module, Actor actor)
@@ -395,7 +395,7 @@ namespace BossMod.Endwalker.Ultimate.TOP
             var ps = _delta.Players[pcSlot];
             var partner = module.Raid.WithSlot(true).WhereSlot(i => _delta.Players[i].IsLocal == ps.IsLocal && i != ps.PartnerSlot && _delta.Players[i].RocketPunch?.OID != ps.RocketPunch?.OID).FirstOrDefault().Item2;
             if (partner != null)
-                arena.AddCircle(partner.Position, Shape.Radius, ArenaColor.Safe);
+                arena.AddCircle(partner.Position, Shape.Radius, ComponentType.Safe);
         }
     }
 
@@ -502,9 +502,9 @@ namespace BossMod.Endwalker.Ultimate.TOP
         public override void DrawArenaBackground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (_boss != null)
-                _shape.Draw(arena, _boss.Position, _boss.Rotation + _bossAngle, _bossIntendedTargets[pcSlot] ? ArenaColor.SafeFromAOE : ArenaColor.AOE);
+                _shape.Draw(arena, _boss.Position, _boss.Rotation + _bossAngle, _bossIntendedTargets[pcSlot] ? ComponentType.SafeFromAOE : ComponentType.AOE);
             if (_player != null)
-                _shape.Draw(arena, _player.Position, _player.Rotation + _playerAngle, _playerIntendedTargets[pcSlot] ? ArenaColor.SafeFromAOE : ArenaColor.AOE);
+                _shape.Draw(arena, _player.Position, _player.Rotation + _playerAngle, _playerIntendedTargets[pcSlot] ? ComponentType.SafeFromAOE : ComponentType.AOE);
         }
 
         public override void OnStatusGain(BossModule module, Actor actor, ActorStatus status)

--- a/BossMod/Modules/Endwalker/Ultimate/TOP/P5Omega.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/TOP/P5Omega.cs
@@ -145,14 +145,14 @@ namespace BossMod.Endwalker.Ultimate.TOP
         public override void DrawArenaBackground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (_boss != null)
-                _shape.Draw(arena, _boss.Position, _boss.Rotation + _bossAngle, ArenaColor.AOE);
+                _shape.Draw(arena, _boss.Position, _boss.Rotation + _bossAngle, ComponentType.AOE);
         }
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             base.DrawArenaForeground(module, pcSlot, pc, arena);
             foreach (var p in SafeSpots(module, pcSlot, pc))
-                arena.AddCircle(p, 1, ArenaColor.Safe);
+                arena.AddCircle(p, 1, ComponentType.Safe);
         }
 
         public override void OnCastStarted(BossModule module, Actor caster, ActorCastInfo spell)
@@ -222,7 +222,7 @@ namespace BossMod.Endwalker.Ultimate.TOP
         {
             base.DrawArenaForeground(module, pcSlot, pc, arena);
             foreach (var p in SafeSpots(module, pcSlot, pc))
-                arena.AddCircle(p, 1, ArenaColor.Safe);
+                arena.AddCircle(p, 1, ComponentType.Safe);
         }
 
         public override void OnStatusGain(BossModule module, Actor actor, ActorStatus status)

--- a/BossMod/Modules/Endwalker/Ultimate/TOP/P5Sigma.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/TOP/P5Sigma.cs
@@ -43,11 +43,11 @@ namespace BossMod.Endwalker.Ultimate.TOP
             {
                 var distSq = (partner.Position - pc.Position).LengthSq();
                 var range = DistanceRange;
-                arena.AddLine(pc.Position, partner.Position, distSq < range.min * range.min || distSq > range.max * range.max ? ArenaColor.Danger : ArenaColor.Safe);
+                arena.AddLine(pc.Position, partner.Position, distSq < range.min * range.min || distSq > range.max * range.max ? ComponentType.Danger : ComponentType.Safe);
             }
 
             foreach (var safeSpot in SafeSpotOffsets(module, pcSlot))
-                arena.AddCircle(module.Bounds.Center + safeSpot, 1, ArenaColor.Safe);
+                arena.AddCircle(module.Bounds.Center + safeSpot, 1, ComponentType.Safe);
         }
 
         public override void OnTethered(BossModule module, Actor source, ActorTetherInfo tether)
@@ -216,7 +216,7 @@ namespace BossMod.Endwalker.Ultimate.TOP
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var b in CurrentBaits)
-                arena.Actor(b.Source, ArenaColor.Object, true);
+                arena.Actor(b.Source, ComponentType.ActorObject, true);
             base.DrawArenaForeground(module, pcSlot, pc, arena);
         }
     }
@@ -337,7 +337,7 @@ namespace BossMod.Endwalker.Ultimate.TOP
             for (int i = NumCasts + 1; i < 14; ++i)
                 yield return new(_shape, module.Bounds.Center, StartingDir + i * Rotation, _activation.AddSeconds(0.6 * i), risky: false);
             if (NumCasts < 14)
-                yield return new(_shape, module.Bounds.Center, StartingDir + NumCasts * Rotation, _activation.AddSeconds(0.6 * NumCasts), ArenaColor.Danger);
+                yield return new(_shape, module.Bounds.Center, StartingDir + NumCasts * Rotation, _activation.AddSeconds(0.6 * NumCasts), ComponentType.Danger);
         }
 
         public override void OnEventIcon(BossModule module, Actor actor, uint iconID)
@@ -405,7 +405,7 @@ namespace BossMod.Endwalker.Ultimate.TOP
         {
             base.DrawArenaForeground(module, pcSlot, pc, arena);
             foreach (var p in SafeSpots(module, pcSlot, pc))
-                arena.AddCircle(p, 1, ArenaColor.Safe);
+                arena.AddCircle(p, 1, ComponentType.Safe);
         }
 
         public override void OnStatusGain(BossModule module, Actor actor, ActorStatus status)

--- a/BossMod/Modules/Endwalker/Ultimate/TOP/TOP.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/TOP/TOP.cs
@@ -55,12 +55,12 @@ namespace BossMod.Endwalker.Ultimate.TOP
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
-            Arena.Actor(_omegaM, ArenaColor.Enemy);
-            Arena.Actor(_omegaF, ArenaColor.Enemy);
-            Arena.Actor(_bossP3, ArenaColor.Enemy);
-            Arena.Actor(_bossP5, ArenaColor.Enemy);
-            Arena.Actor(_bossP6, ArenaColor.Enemy);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
+            Arena.Actor(_omegaM, ComponentType.ActorEnemy);
+            Arena.Actor(_omegaF, ComponentType.ActorEnemy);
+            Arena.Actor(_bossP3, ComponentType.ActorEnemy);
+            Arena.Actor(_bossP5, ComponentType.ActorEnemy);
+            Arena.Actor(_bossP6, ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/Endwalker/Unreal/Un1Ultima/Garuda.cs
+++ b/BossMod/Modules/Endwalker/Unreal/Un1Ultima/Garuda.cs
@@ -39,8 +39,8 @@
             var adjPos = _vulcanBurstImminent ? arena.Bounds.ClampToBounds(Components.Knockback.AwayFromSource(pc.Position, _mistralSong, 30)) : pc.Position;
             if (adjPos != pc.Position)
             {
-                arena.AddLine(pc.Position, adjPos, ArenaColor.Danger);
-                arena.Actor(adjPos, 0.Degrees(), ArenaColor.Danger);
+                arena.AddLine(pc.Position, adjPos, ComponentType.Danger);
+                arena.Actor(adjPos, 0.Degrees(), ComponentType.Danger);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Unreal/Un1Ultima/Mechanics.cs
+++ b/BossMod/Modules/Endwalker/Unreal/Un1Ultima/Mechanics.cs
@@ -97,9 +97,9 @@ namespace BossMod.Endwalker.Unreal.Un1Ultima
         {
             var mt = module.WorldState.Actors.Find(module.PrimaryActor.TargetID);
             foreach (var player in module.Raid.WithoutSlot().Exclude(pc))
-                arena.Actor(player, _orbKiters.Contains(player.InstanceID) ? ArenaColor.Danger : player == mt ? ArenaColor.PlayerInteresting : ArenaColor.PlayerGeneric);
+                arena.Actor(player, _orbKiters.Contains(player.InstanceID) ? ComponentType.Danger : player == mt ? ComponentType.PlayerInteresting : ComponentType.PlayerGeneric);
             if (mt != null)
-                arena.AddCircle(mt.Position, _aoeCleave.Radius, ArenaColor.Danger);
+                arena.AddCircle(mt.Position, _aoeCleave.Radius, ComponentType.Danger);
 
             //if (pc.Role is Role.Healer or Role.Ranged)
             //    arena.AddCircle(module.PrimaryActor.Position, _ceruleumVentRange, ArenaColor.Danger);
@@ -107,20 +107,20 @@ namespace BossMod.Endwalker.Unreal.Un1Ultima
             foreach (var orb in module.Enemies(OID.Ultimaplasm).Where(orb => !_orbsSharedExploded.Contains(orb.InstanceID)))
             {
                 // TODO: line between paired orbs
-                arena.Actor(orb, ArenaColor.Danger, true);
-                arena.AddCircle(orb.Position, _orbSharedRange, ArenaColor.Safe);
+                arena.Actor(orb, ComponentType.Danger, true);
+                arena.AddCircle(orb.Position, _orbSharedRange, ComponentType.Safe);
             }
 
             foreach (var orb in module.Enemies(OID.Aetheroplasm).Where(orb => !_orbsKitedExploded.Contains(orb.InstanceID)))
             {
                 // TODO: line from corresponding target
-                arena.Actor(orb, ArenaColor.Danger, true);
-                arena.AddCircle(orb.Position, _orbFixateRange, ArenaColor.Danger);
+                arena.Actor(orb, ComponentType.Danger, true);
+                arena.AddCircle(orb.Position, _orbFixateRange, ComponentType.Danger);
             }
 
             foreach (var bit in module.Enemies(OID.MagitekBit))
             {
-                arena.Actor(bit, ArenaColor.Danger);
+                arena.Actor(bit, ComponentType.Danger);
             }
         }
 

--- a/BossMod/Modules/Endwalker/Unreal/Un2Sephirot/P1FiendishRage.cs
+++ b/BossMod/Modules/Endwalker/Unreal/Un2Sephirot/P1FiendishRage.cs
@@ -29,7 +29,7 @@ namespace BossMod.Endwalker.Unreal.Un2Sephirot
             }
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return _targets[playerSlot] ? PlayerPriority.Danger : PlayerPriority.Irrelevant;
         }
@@ -37,7 +37,7 @@ namespace BossMod.Endwalker.Unreal.Un2Sephirot
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var target in module.Raid.WithSlot(true).IncludedInMask(_targets))
-                arena.AddCircle(target.Item2.Position, _range, ArenaColor.Danger);
+                arena.AddCircle(target.Item2.Position, _range, ComponentType.Danger);
         }
 
         public override void OnEventIcon(BossModule module, Actor actor, uint iconID)

--- a/BossMod/Modules/Endwalker/Unreal/Un2Sephirot/P1Ratzon.cs
+++ b/BossMod/Modules/Endwalker/Unreal/Un2Sephirot/P1Ratzon.cs
@@ -21,7 +21,7 @@ namespace BossMod.Endwalker.Unreal.Un2Sephirot
             hints.Add($"Spread! (debuff: {(_greenTargets[slot] ? "green" : _purpleTargets[slot] ? "purple" : "none")})", clippedByGreen || clippedByPurple);
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return (_greenTargets | _purpleTargets)[playerSlot] ? PlayerPriority.Interesting : PlayerPriority.Irrelevant;
         }
@@ -29,9 +29,9 @@ namespace BossMod.Endwalker.Unreal.Un2Sephirot
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var (slot, actor) in module.Raid.WithSlot().IncludedInMask(_greenTargets))
-                arena.AddCircle(actor.Position, _greenRadius, 0xff00ff00, slot == pcSlot ? 2 : 1);
+                arena.AddCircle(actor.Position, _greenRadius, ComponentType.Safe, slot == pcSlot ? 2 : 1);
             foreach (var (slot, actor) in module.Raid.WithSlot().IncludedInMask(_purpleTargets))
-                arena.AddCircle(actor.Position, _purpleRadius, 0xffff00ff, slot == pcSlot ? 2 : 1);
+                arena.AddCircle(actor.Position, _purpleRadius, ComponentType.ActorVulnerable, slot == pcSlot ? 2 : 1);
         }
 
         public override void OnEventCast(BossModule module, Actor caster, ActorCastEvent spell)

--- a/BossMod/Modules/Endwalker/Unreal/Un2Sephirot/P3Daat.cs
+++ b/BossMod/Modules/Endwalker/Unreal/Un2Sephirot/P3Daat.cs
@@ -16,7 +16,7 @@ namespace BossMod.Endwalker.Unreal.Un2Sephirot
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
-            arena.AddCircle(pc.Position, radius, ArenaColor.Danger);
+            arena.AddCircle(pc.Position, radius, ComponentType.Danger);
         }
     }
 }

--- a/BossMod/Modules/Endwalker/Unreal/Un2Sephirot/P3Earthshaker.cs
+++ b/BossMod/Modules/Endwalker/Unreal/Un2Sephirot/P3Earthshaker.cs
@@ -24,7 +24,7 @@ namespace BossMod.Endwalker.Unreal.Un2Sephirot
                 yield return new(_shape, origin.Position, Angle.FromDirection(target.Item2.Position - origin.Position));
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return _targets[playerSlot] ? PlayerPriority.Interesting : PlayerPriority.Irrelevant;
         }

--- a/BossMod/Modules/Endwalker/Unreal/Un2Sephirot/P3FiendishWail.cs
+++ b/BossMod/Modules/Endwalker/Unreal/Un2Sephirot/P3FiendishWail.cs
@@ -30,7 +30,7 @@ namespace BossMod.Endwalker.Unreal.Un2Sephirot
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var t in _towers)
-                arena.AddCircle(t.Position, _radius, ArenaColor.Danger);
+                arena.AddCircle(t.Position, _radius, ComponentType.Danger);
         }
 
         public override void OnStatusGain(BossModule module, Actor actor, ActorStatus status)

--- a/BossMod/Modules/Endwalker/Unreal/Un2Sephirot/Un2Sephirot.cs
+++ b/BossMod/Modules/Endwalker/Unreal/Un2Sephirot/Un2Sephirot.cs
@@ -78,9 +78,9 @@ namespace BossMod.Endwalker.Unreal.Un2Sephirot
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             if (StateMachine.ActivePhaseIndex <= 0)
-                Arena.Actor(PrimaryActor, ArenaColor.Enemy);
+                Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
             else if (StateMachine.ActivePhaseIndex == 2)
-                Arena.Actor(_bossP3, ArenaColor.Enemy);
+                Arena.Actor(_bossP3, ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/Endwalker/Unreal/Un3Sophia/Demiurges.cs
+++ b/BossMod/Modules/Endwalker/Unreal/Un3Sophia/Demiurges.cs
@@ -23,8 +23,8 @@ namespace BossMod.Endwalker.Unreal.Un3Sophia
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             base.DrawArenaForeground(module, pcSlot, pc, arena);
-            arena.Actors(_second, ArenaColor.Enemy);
-            arena.Actors(_third, ArenaColor.Enemy);
+            arena.Actors(_second, ComponentType.ActorEnemy);
+            arena.Actors(_third, ComponentType.ActorEnemy);
         }
 
         public override void OnCastStarted(BossModule module, Actor caster, ActorCastInfo spell)

--- a/BossMod/Modules/Endwalker/Unreal/Un3Sophia/Pairs.cs
+++ b/BossMod/Modules/Endwalker/Unreal/Un3Sophia/Pairs.cs
@@ -33,9 +33,9 @@ namespace BossMod.Endwalker.Unreal.Un3Sophia
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var p in module.Raid.WithSlot().IncludedInMask(_players1).Exclude(pc))
-                arena.AddCircle(p.Item2.Position, _radius, _players1[pcSlot] ? ArenaColor.Danger : ArenaColor.Safe);
+                arena.AddCircle(p.Item2.Position, _radius, _players1[pcSlot] ? ComponentType.Danger : ComponentType.Safe);
             foreach (var p in module.Raid.WithSlot().IncludedInMask(_players2).Exclude(pc))
-                arena.AddCircle(p.Item2.Position, _radius, _players2[pcSlot] ? ArenaColor.Danger : ArenaColor.Safe);
+                arena.AddCircle(p.Item2.Position, _radius, _players2[pcSlot] ? ComponentType.Danger : ComponentType.Safe);
         }
 
         public override void OnEventIcon(BossModule module, Actor actor, uint iconID)

--- a/BossMod/Modules/Endwalker/Unreal/Un4Zurvan/P2BrokenSeal.cs
+++ b/BossMod/Modules/Endwalker/Unreal/Un4Zurvan/P2BrokenSeal.cs
@@ -45,7 +45,7 @@ namespace BossMod.Endwalker.Unreal.Un4Zurvan
                 hints.Add("Soak the tower!");
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return _playerStates[pcSlot].Color != Color.None && _playerStates[pcSlot].Partner == playerSlot ? PlayerPriority.Interesting : PlayerPriority.Irrelevant;
         }
@@ -59,13 +59,13 @@ namespace BossMod.Endwalker.Unreal.Un4Zurvan
             var partner = state.Color != Color.None && state.Partner >= 0 ? module.Raid[state.Partner] : null;
             if (partner != null)
             {
-                arena.AddLine(pc.Position, partner.Position, state.Color == Color.Fire ? 0xff0080ff : 0xffff8000, state.TooFar ? 2 : 1);
+                arena.AddLine(pc.Position, partner.Position, state.Color == Color.Fire ? ComponentType.TetherMoveAway : ComponentType.TetherMoveToward, state.TooFar ? 2 : 1);
             }
 
             foreach (var t in _fireTowers)
-                arena.AddCircle(t.Position, 2, state.Color == Color.Fire ? ArenaColor.Safe : ArenaColor.Danger);
+                arena.AddCircle(t.Position, 2, state.Color == Color.Fire ? ComponentType.Safe : ComponentType.Danger);
             foreach (var t in _iceTowers)
-                arena.AddCircle(t.Position, 2, state.Color == Color.Ice ? ArenaColor.Safe : ArenaColor.Danger);
+                arena.AddCircle(t.Position, 2, state.Color == Color.Ice ? ComponentType.Safe : ComponentType.Danger);
         }
 
         public override void OnEventCast(BossModule module, Actor caster, ActorCastEvent spell)

--- a/BossMod/Modules/Endwalker/Unreal/Un4Zurvan/Un4Zurvan.cs
+++ b/BossMod/Modules/Endwalker/Unreal/Un4Zurvan/Un4Zurvan.cs
@@ -87,8 +87,8 @@ namespace BossMod.Endwalker.Unreal.Un4Zurvan
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
-            Arena.Actor(_bossP2, ArenaColor.Enemy);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
+            Arena.Actor(_bossP2, ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/Endwalker/Unreal/Un5Thordan/BurningChains.cs
+++ b/BossMod/Modules/Endwalker/Unreal/Un5Thordan/BurningChains.cs
@@ -17,7 +17,7 @@ class BurningChains : Components.CastCounter
     {
         var partner = module.Raid[_tetherPartners[pcSlot]];
         if (partner != null)
-            arena.AddLine(pc.Position, partner.Position, ArenaColor.Danger);
+            arena.AddLine(pc.Position, partner.Position, ComponentType.Danger);
     }
 
     public override void OnTethered(BossModule module, Actor source, ActorTetherInfo tether)

--- a/BossMod/Modules/Endwalker/Unreal/Un5Thordan/DragonsGaze.cs
+++ b/BossMod/Modules/Endwalker/Unreal/Un5Thordan/DragonsGaze.cs
@@ -14,7 +14,7 @@ class DragonsGaze : Components.GenericGaze
     {
         base.DrawArenaForeground(module, pcSlot, pc, arena);
         if (_posHint != default)
-            arena.AddCircle(_posHint, 1, ArenaColor.Safe);
+            arena.AddCircle(_posHint, 1, ComponentType.Safe);
     }
 
     public override void OnCastStarted(BossModule module, Actor caster, ActorCastInfo spell)

--- a/BossMod/Modules/Endwalker/Unreal/Un5Thordan/HolyShieldBash.cs
+++ b/BossMod/Modules/Endwalker/Unreal/Un5Thordan/HolyShieldBash.cs
@@ -4,7 +4,7 @@ class HolyShieldBash : Components.GenericWildCharge
 {
     public HolyShieldBash() : base(5) { } // TODO: width could be smaller...
 
-    public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+    public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
     {
         return PlayerRoles[playerSlot] == PlayerRole.Target ? PlayerPriority.Interesting : PlayerPriority.Irrelevant;
     }

--- a/BossMod/Modules/Endwalker/Unreal/Un5Thordan/Intermission2.cs
+++ b/BossMod/Modules/Endwalker/Unreal/Un5Thordan/Intermission2.cs
@@ -38,7 +38,7 @@ class SwordShieldOfTheHeavens : BossComponent
     public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
     {
         foreach (var a in _adds)
-            arena.Actor(a.actor, ArenaColor.Enemy);
+            arena.Actor(a.actor, ComponentType.ActorEnemy);
     }
 
     public override void OnStatusGain(BossModule module, Actor actor, ActorStatus status)

--- a/BossMod/Modules/MaskedCarnivale/ObstacleLayouts.cs
+++ b/BossMod/Modules/MaskedCarnivale/ObstacleLayouts.cs
@@ -26,8 +26,8 @@ namespace BossMod.MaskedCarnivale
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
-            arena.AddPolygon(Wall1(),ArenaColor.Border);
-            arena.AddPolygon(Wall2(),ArenaColor.Border);
+            arena.AddPolygon(Wall1(),ComponentType.Border);
+            arena.AddPolygon(Wall2(),ComponentType.Border);
         }
     }
 
@@ -35,10 +35,10 @@ namespace BossMod.MaskedCarnivale
     {
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
-            arena.AddQuad(new(107,110),new(110,113),new(113,110),new(110,107), ArenaColor.Border, 2);
-            arena.AddQuad(new(93,110),new(90,107),new(87,110),new(90,113), ArenaColor.Border, 2);
-            arena.AddQuad(new(90,93),new(93,90),new(90,87),new(87,90), ArenaColor.Border, 2);
-            arena.AddQuad(new(110,93),new(113,90),new(110,87),new(107,90), ArenaColor.Border, 2);
+            arena.AddQuad(new(107,110),new(110,113),new(113,110),new(110,107), ComponentType.Border, 2);
+            arena.AddQuad(new(93,110),new(90,107),new(87,110),new(90,113), ComponentType.Border, 2);
+            arena.AddQuad(new(90,93),new(93,90),new(90,87),new(87,90), ComponentType.Border, 2);
+            arena.AddQuad(new(110,93),new(113,90),new(110,87),new(107,90), ComponentType.Border, 2);
         }
     }
  
@@ -46,7 +46,7 @@ namespace BossMod.MaskedCarnivale
     {
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
-            arena.AddQuad(new(100,107),new(107,100),new(100,93),new(93,100), ArenaColor.Border, 2);
+            arena.AddQuad(new(100,107),new(107,100),new(100,93),new(93,100), ComponentType.Border, 2);
         }
     }
 }

--- a/BossMod/Modules/MaskedCarnivale/Stage01AllsWellThatStartsWell/Stage01.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage01AllsWellThatStartsWell/Stage01.cs
@@ -54,9 +54,9 @@ namespace BossMod.MaskedCarnivale.Stage01
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.Slime))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
         }
     }
 }

--- a/BossMod/Modules/MaskedCarnivale/Stage02MuchAdoAboutPudding/Stage02Act1.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage02MuchAdoAboutPudding/Stage02Act1.cs
@@ -64,11 +64,11 @@ namespace BossMod.MaskedCarnivale.Stage02.Act1
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.Marshmallow))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.Bavarois))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
         }
     }
 }

--- a/BossMod/Modules/MaskedCarnivale/Stage02MuchAdoAboutPudding/Stage02Act2.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage02MuchAdoAboutPudding/Stage02Act2.cs
@@ -51,11 +51,11 @@ namespace BossMod.MaskedCarnivale.Stage02.Act2
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.Flan))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.Licorice))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
         }
     }
 }

--- a/BossMod/Modules/MaskedCarnivale/Stage03WaitingForGolem/Stage03.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage03WaitingForGolem/Stage03.cs
@@ -71,7 +71,7 @@ namespace BossMod.MaskedCarnivale.Stage03
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy, true);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy, true);
         }
     }
 }

--- a/BossMod/Modules/MaskedCarnivale/Stage04GentlemanPreferSwords/Stage04Act1.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage04GentlemanPreferSwords/Stage04Act1.cs
@@ -57,9 +57,9 @@ namespace BossMod.MaskedCarnivale.Stage04.Act1
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.Bat))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
         }
     }
 }

--- a/BossMod/Modules/MaskedCarnivale/Stage04GentlemanPreferSwords/Stage04Act2.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage04GentlemanPreferSwords/Stage04Act2.cs
@@ -73,9 +73,9 @@ namespace BossMod.MaskedCarnivale.Stage04.Act2
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy, true);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy, true);
             foreach (var s in Enemies(OID.Beetle))
-                Arena.Actor(s, ArenaColor.Object, false);
+                Arena.Actor(s, ComponentType.ActorObject, false);
         }
 
         public override void CalculateAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)

--- a/BossMod/Modules/MaskedCarnivale/Stage05TheThreepennyTurtles/Stage05.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage05TheThreepennyTurtles/Stage05.cs
@@ -34,7 +34,7 @@ namespace BossMod.MaskedCarnivale.Stage05
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
         }
     }
 }

--- a/BossMod/Modules/MaskedCarnivale/Stage06EyeSociety/Stage06Act1.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage06EyeSociety/Stage06Act1.cs
@@ -134,9 +134,9 @@ namespace BossMod.MaskedCarnivale.Stage06.Act1
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.Mandragora))
-                Arena.Actor(s, ArenaColor.Object, false);
+                Arena.Actor(s, ComponentType.ActorObject, false);
         }
 
         public override void CalculateAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)

--- a/BossMod/Modules/MaskedCarnivale/Stage06EyeSociety/Stage06Act2.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage06EyeSociety/Stage06Act2.cs
@@ -160,11 +160,11 @@ namespace BossMod.MaskedCarnivale.Stage06.Act2
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.Eye))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.Mandragora))
-                Arena.Actor(s, ArenaColor.Object, false);
+                Arena.Actor(s, ComponentType.ActorObject, false);
         }
 
         public override void CalculateAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)

--- a/BossMod/Modules/MaskedCarnivale/Stage07AChorusSlime/Stage07Act1.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage07AChorusSlime/Stage07Act1.cs
@@ -21,7 +21,7 @@ namespace BossMod.MaskedCarnivale.Stage07.Act1
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var p in module.Enemies(OID.Boss).Where(x => x.HP.Cur > 0))
-                arena.AddCircle(p.Position, 7.6f, ArenaColor.Danger);
+                arena.AddCircle(p.Position, 7.6f, ComponentType.Danger);
         }
         public override void AddHints(BossModule module, int slot, Actor actor, TextHints hints, MovementHints? movementHints)
         {
@@ -76,9 +76,9 @@ namespace BossMod.MaskedCarnivale.Stage07.Act1
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.Sprite))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
         }
     }
 }

--- a/BossMod/Modules/MaskedCarnivale/Stage07AChorusSlime/Stage07Act2.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage07AChorusSlime/Stage07Act2.cs
@@ -21,7 +21,7 @@ namespace BossMod.MaskedCarnivale.Stage07.Act2
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var p in module.Enemies(OID.Boss).Where(x => x.HP.Cur > 0))
-                arena.AddCircle(p.Position, 7.6f, ArenaColor.Danger);
+                arena.AddCircle(p.Position, 7.6f, ComponentType.Danger);
         }
 
         public override void AddHints(BossModule module, int slot, Actor actor, TextHints hints, MovementHints? movementHints)
@@ -70,9 +70,9 @@ namespace BossMod.MaskedCarnivale.Stage07.Act2
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.Sprite))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
         }
     }
 }

--- a/BossMod/Modules/MaskedCarnivale/Stage07AChorusSlime/Stage07Act3.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage07AChorusSlime/Stage07Act3.cs
@@ -27,7 +27,7 @@ namespace BossMod.MaskedCarnivale.Stage07.Act3
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var p in module.Enemies(OID.Slime).Where(x => x.HP.Cur > 0))
-                arena.AddCircle(p.Position, 7.5f, ArenaColor.Danger);
+                arena.AddCircle(p.Position, 7.5f, ComponentType.Danger);
         }
 
         public override void AddHints(BossModule module, int slot, Actor actor, TextHints hints, MovementHints? movementHints)
@@ -75,9 +75,9 @@ namespace BossMod.MaskedCarnivale.Stage07.Act3
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.Slime))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
         }
     }
 }

--- a/BossMod/Modules/MaskedCarnivale/Stage08BombedyOfErrors/Stage08Act1.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage08BombedyOfErrors/Stage08Act1.cs
@@ -24,11 +24,11 @@ namespace BossMod.MaskedCarnivale.Stage08.Act1
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var p in module.Enemies(OID.Boss).Where(x => x.HP.Cur > 0))
-                arena.AddCircle(p.Position, 10, ArenaColor.Danger);
+                arena.AddCircle(p.Position, 10, ComponentType.Danger);
             foreach (var p in module.Enemies(OID.Bomb).Where(x => x.HP.Cur > 0))
-                arena.AddCircle(p.Position, 6, ArenaColor.Danger);
+                arena.AddCircle(p.Position, 6, ComponentType.Danger);
             foreach (var p in module.Enemies(OID.Snoll).Where(x => x.HP.Cur > 0))
-                arena.AddCircle(p.Position, 6, ArenaColor.Danger);
+                arena.AddCircle(p.Position, 6, ComponentType.Danger);
         }
 
         public override void AddHints(BossModule module, int slot, Actor actor, TextHints hints, MovementHints? movementHints)
@@ -96,11 +96,11 @@ namespace BossMod.MaskedCarnivale.Stage08.Act1
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.Bomb))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.Snoll))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
         }
 
         public override void CalculateAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)

--- a/BossMod/Modules/MaskedCarnivale/Stage08BombedyOfErrors/Stage08Act2.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage08BombedyOfErrors/Stage08Act2.cs
@@ -36,9 +36,9 @@ namespace BossMod.MaskedCarnivale.Stage08.Act2
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var p in module.Enemies(OID.Bomb).Where(x => x.HP.Cur > 0))
-                arena.AddCircle(p.Position, 10, ArenaColor.Danger);
+                arena.AddCircle(p.Position, 10, ComponentType.Danger);
             foreach (var p in module.Enemies(OID.Snoll).Where(x => x.HP.Cur > 0))
-                arena.AddCircle(p.Position, 6, ArenaColor.Danger);
+                arena.AddCircle(p.Position, 6, ComponentType.Danger);
         }
 
         public override void AddHints(BossModule module, int slot, Actor actor, TextHints hints, MovementHints? movementHints)
@@ -94,11 +94,11 @@ namespace BossMod.MaskedCarnivale.Stage08.Act2
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.Bomb))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.Snoll))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
         }
 
         public override void CalculateAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)

--- a/BossMod/Modules/MaskedCarnivale/Stage09ToKillaMockingslime/Stage09.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage09ToKillaMockingslime/Stage09.cs
@@ -88,19 +88,19 @@ namespace BossMod.MaskedCarnivale.Stage09
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.Licorice))
-                Arena.Actor(s, ArenaColor.Object, false);
+                Arena.Actor(s, ComponentType.ActorObject, false);
             foreach (var s in Enemies(OID.Flan))
-                Arena.Actor(s, ArenaColor.Object, false);
+                Arena.Actor(s, ComponentType.ActorObject, false);
             foreach (var s in Enemies(OID.Pudding))
-                Arena.Actor(s, ArenaColor.Object, false);
+                Arena.Actor(s, ComponentType.ActorObject, false);
             foreach (var s in Enemies(OID.Marshmallow))
-                Arena.Actor(s, ArenaColor.Object, false);
+                Arena.Actor(s, ComponentType.ActorObject, false);
             foreach (var s in Enemies(OID.Bavarois))
-                Arena.Actor(s, ArenaColor.Object, false);
+                Arena.Actor(s, ComponentType.ActorObject, false);
             foreach (var s in Enemies(OID.Gelato))
-                Arena.Actor(s, ArenaColor.Object, false);
+                Arena.Actor(s, ComponentType.ActorObject, false);
         }
     }
 }

--- a/BossMod/Modules/MaskedCarnivale/Stage10ALittleKnightMusic/Stage10.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage10ALittleKnightMusic/Stage10.cs
@@ -110,7 +110,7 @@ namespace BossMod.MaskedCarnivale.Stage10
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
         }
     }
 }

--- a/BossMod/Modules/MaskedCarnivale/Stage11SomeLikeItExcruciatinglyHot/Stage11Act1.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage11SomeLikeItExcruciatinglyHot/Stage11Act1.cs
@@ -42,7 +42,7 @@ namespace BossMod.MaskedCarnivale.Stage11.Act1
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
         }
     }
 }

--- a/BossMod/Modules/MaskedCarnivale/Stage11SomeLikeItExcruciatinglyHot/Stage11Act2.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage11SomeLikeItExcruciatinglyHot/Stage11Act2.cs
@@ -43,7 +43,7 @@ namespace BossMod.MaskedCarnivale.Stage11.Act2
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
         }
     }
 }

--- a/BossMod/Modules/MaskedCarnivale/Stage12ThePlantomOfTheOpera/Stage12Act1.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage12ThePlantomOfTheOpera/Stage12Act1.cs
@@ -39,7 +39,7 @@ namespace BossMod.MaskedCarnivale.Stage12.Act1
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
         }
     }
 }

--- a/BossMod/Modules/MaskedCarnivale/Stage12ThePlantomOfTheOpera/Stage12Act2.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage12ThePlantomOfTheOpera/Stage12Act2.cs
@@ -70,9 +70,9 @@ namespace BossMod.MaskedCarnivale.Stage12.Act2
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.Roselet))
-                Arena.Actor(s, ArenaColor.Object, false);
+                Arena.Actor(s, ComponentType.ActorObject, false);
         }
 
         public override void CalculateAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)

--- a/BossMod/Modules/MaskedCarnivale/Stage13BeautyandaBeast/Stage13Act1.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage13BeautyandaBeast/Stage13Act1.cs
@@ -53,9 +53,9 @@ namespace BossMod.MaskedCarnivale.Stage13.Act1
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.Vodoriga))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
         }
     }
 }

--- a/BossMod/Modules/MaskedCarnivale/Stage13BeautyandaBeast/Stage13Act2.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage13BeautyandaBeast/Stage13Act2.cs
@@ -109,9 +109,9 @@ namespace BossMod.MaskedCarnivale.Stage13.Act2
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.Succubus))
-                Arena.Actor(s, ArenaColor.Object, false);
+                Arena.Actor(s, ComponentType.ActorObject, false);
         }
     }
 }

--- a/BossMod/Modules/MaskedCarnivale/Stage14BlobsintheWoods/Stage14Act1.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage14BlobsintheWoods/Stage14Act1.cs
@@ -74,7 +74,7 @@ namespace BossMod.MaskedCarnivale.Stage14.Act1
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
         }
     }
 }

--- a/BossMod/Modules/MaskedCarnivale/Stage14BlobsintheWoods/Stage14Act2.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage14BlobsintheWoods/Stage14Act2.cs
@@ -74,7 +74,7 @@ namespace BossMod.MaskedCarnivale.Stage14.Act2
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
         }
     }
 }

--- a/BossMod/Modules/MaskedCarnivale/Stage15TheMeNobodyNodes/Stage15.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage15TheMeNobodyNodes/Stage15.cs
@@ -182,11 +182,11 @@ namespace BossMod.MaskedCarnivale.Stage15
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.Shabti))
-                Arena.Actor(s, ArenaColor.Object, false);
+                Arena.Actor(s, ComponentType.ActorObject, false);
             foreach (var s in Enemies(OID.Serpent))
-                Arena.Actor(s, ArenaColor.Object, false);
+                Arena.Actor(s, ComponentType.ActorObject, false);
         }
 
         public override void CalculateAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)

--- a/BossMod/Modules/MaskedCarnivale/Stage16SunsetBullevard/Stage16Act1.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage16SunsetBullevard/Stage16Act1.cs
@@ -42,7 +42,7 @@ namespace BossMod.MaskedCarnivale.Stage16.Act1
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
         }
     }
 }

--- a/BossMod/Modules/MaskedCarnivale/Stage16SunsetBullevard/Stage16Act2.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage16SunsetBullevard/Stage16Act2.cs
@@ -165,9 +165,9 @@ namespace BossMod.MaskedCarnivale.Stage16.Act2
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.Cyclops))
-                Arena.Actor(s, ArenaColor.Object, false);
+                Arena.Actor(s, ComponentType.ActorObject, false);
         }
 
         public override void CalculateAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)

--- a/BossMod/Modules/MaskedCarnivale/Stage17TheSwordofMusic/Stage17Act1.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage17TheSwordofMusic/Stage17Act1.cs
@@ -103,9 +103,9 @@ namespace BossMod.MaskedCarnivale.Stage17.Act1
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.RightClaw))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
         }
 
         public override void CalculateAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)

--- a/BossMod/Modules/MaskedCarnivale/Stage17TheSwordofMusic/Stage17Act2.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage17TheSwordofMusic/Stage17Act2.cs
@@ -124,11 +124,11 @@ namespace BossMod.MaskedCarnivale.Stage17.Act2
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.LeftClaw))
-                Arena.Actor(s, ArenaColor.Object, false);
+                Arena.Actor(s, ComponentType.ActorObject, false);
             foreach (var s in Enemies(OID.RightClaw))
-                Arena.Actor(s, ArenaColor.Object, false);
+                Arena.Actor(s, ComponentType.ActorObject, false);
         }
 
         public override void CalculateAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)

--- a/BossMod/Modules/MaskedCarnivale/Stage18MidsummerNightsExplosion/Stage18Act1.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage18MidsummerNightsExplosion/Stage18Act1.cs
@@ -86,7 +86,7 @@ namespace BossMod.MaskedCarnivale.Stage18.Act1
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var p in module.Enemies(OID.Keg).Where(x => x.HP.Cur > 0))
-                arena.AddCircle(p.Position, 10, ArenaColor.Danger);
+                arena.AddCircle(p.Position, 10, ComponentType.Danger);
         }
         public override void AddHints(BossModule module, int slot, Actor actor, TextHints hints, MovementHints? movementHints)
         {
@@ -138,9 +138,9 @@ namespace BossMod.MaskedCarnivale.Stage18.Act1
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.Keg))
-                Arena.Actor(s, ArenaColor.Object, false);
+                Arena.Actor(s, ComponentType.ActorObject, false);
         }
 
         public override void CalculateAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)

--- a/BossMod/Modules/MaskedCarnivale/Stage18MidsummerNightsExplosion/Stage18Act2.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage18MidsummerNightsExplosion/Stage18Act2.cs
@@ -86,7 +86,7 @@ namespace BossMod.MaskedCarnivale.Stage18.Act2
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var p in module.Enemies(OID.Keg).Where(x => x.HP.Cur > 0))
-                arena.AddCircle(p.Position, 10, ArenaColor.Danger);
+                arena.AddCircle(p.Position, 10, ComponentType.Danger);
         }
 
         public override void AddHints(BossModule module, int slot, Actor actor, TextHints hints, MovementHints? movementHints)
@@ -139,9 +139,9 @@ namespace BossMod.MaskedCarnivale.Stage18.Act2
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.Keg))
-                Arena.Actor(s, ArenaColor.Object, false);
+                Arena.Actor(s, ComponentType.ActorObject, false);
         }
 
         public override void CalculateAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)

--- a/BossMod/Modules/MaskedCarnivale/Stage19OnaClearDayYouCanSmellForever/Stage19Act1.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage19OnaClearDayYouCanSmellForever/Stage19Act1.cs
@@ -109,7 +109,7 @@ namespace BossMod.MaskedCarnivale.Stage19.Act1
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
         }
     }
 }

--- a/BossMod/Modules/MaskedCarnivale/Stage19OnaClearDayYouCanSmellForever/Stage19Act2.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage19OnaClearDayYouCanSmellForever/Stage19Act2.cs
@@ -163,9 +163,9 @@ namespace BossMod.MaskedCarnivale.Stage19.Act2
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.HotHip))
-                Arena.Actor(s, ArenaColor.Enemy, true);
+                Arena.Actor(s, ComponentType.ActorEnemy, true);
         }
     }
 }

--- a/BossMod/Modules/MaskedCarnivale/Stage20MissTyphon/Stage20Act1.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage20MissTyphon/Stage20Act1.cs
@@ -68,7 +68,7 @@ namespace BossMod.MaskedCarnivale.Stage20.Act1
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
         }
     }
 }

--- a/BossMod/Modules/MaskedCarnivale/Stage20MissTyphon/Stage20Act2.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage20MissTyphon/Stage20Act2.cs
@@ -77,7 +77,7 @@ namespace BossMod.MaskedCarnivale.Stage20.Act2
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
         }
     }
 }

--- a/BossMod/Modules/MaskedCarnivale/Stage20MissTyphon/Stage20Act3.cs
+++ b/BossMod/Modules/MaskedCarnivale/Stage20MissTyphon/Stage20Act3.cs
@@ -110,11 +110,11 @@ namespace BossMod.MaskedCarnivale.Stage20.Act3
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.Ultros))
-                Arena.Actor(s, ArenaColor.Object, false);
+                Arena.Actor(s, ComponentType.ActorObject, false);
             foreach (var s in Enemies(OID.Tentacle))
-                Arena.Actor(s, ArenaColor.Object, false);
+                Arena.Actor(s, ComponentType.ActorObject, false);
         }
 
         public override void CalculateAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)

--- a/BossMod/Modules/RealmReborn/Dungeon/D08Qarn/D081Teratotaur.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D08Qarn/D081Teratotaur.cs
@@ -81,7 +81,7 @@ namespace BossMod.RealmReborn.Dungeon.D08Qarn.D081Teratotaur
         public override void DrawArenaBackground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (_dooms[pcSlot])
-                _platformShape.Draw(arena, ActivePlatform, ArenaColor.SafeFromAOE);
+                _platformShape.Draw(arena, ActivePlatform, ComponentType.SafeFromAOE);
         }
 
         public override void OnStatusGain(BossModule module, Actor actor, ActorStatus status)

--- a/BossMod/Modules/RealmReborn/Dungeon/D14Praetorium/D142Nero.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D14Praetorium/D142Nero.cs
@@ -92,9 +92,9 @@
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
             foreach (var claw in Enemies(OID.MagitekDeathClaw))
-                Arena.Actor(claw, ArenaColor.Danger);
+                Arena.Actor(claw, ComponentType.Danger);
         }
     }
 }

--- a/BossMod/Modules/RealmReborn/Dungeon/D14Praetorium/D143Gaius.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D14Praetorium/D143Gaius.cs
@@ -119,9 +119,9 @@ namespace BossMod.RealmReborn.Dungeon.D14Praetorium.D143Gaius
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
             foreach (var add in Enemies(OID.PhantomGaiusAdd))
-                Arena.Actor(add, ArenaColor.Enemy);
+                Arena.Actor(add, ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/RealmReborn/Dungeon/D16Amdapor/D161Psycheflayer.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D16Amdapor/D161Psycheflayer.cs
@@ -119,8 +119,8 @@ namespace BossMod.RealmReborn.Dungeon.D16Amdapor.D161Psycheflayer
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
-            Arena.Actor(_bossP2, ArenaColor.Enemy);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
+            Arena.Actor(_bossP2, ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/RealmReborn/Dungeon/D16Amdapor/D163Anantaboga.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D16Amdapor/D163Anantaboga.cs
@@ -79,7 +79,7 @@ namespace BossMod.RealmReborn.Dungeon.D16Amdapor.D163Anantaboga
             }
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return player == _target ? PlayerPriority.Danger : PlayerPriority.Irrelevant;
         }
@@ -146,11 +146,11 @@ namespace BossMod.RealmReborn.Dungeon.D16Amdapor.D163Anantaboga
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
             foreach (var add in Enemies(OID.DarkHelot))
-                Arena.Actor(add, ArenaColor.Enemy);
+                Arena.Actor(add, ComponentType.ActorEnemy);
             foreach (var p in ActivePillars())
-                Arena.Actor(p, ArenaColor.Object, true);
+                Arena.Actor(p, ComponentType.ActorObject, true);
         }
 
         // TODO: blocker coordinates are slightly different, find out correct coords...

--- a/BossMod/Modules/RealmReborn/Extreme/Ex1Ultima/AethericBoom.cs
+++ b/BossMod/Modules/RealmReborn/Extreme/Ex1Ultima/AethericBoom.cs
@@ -109,8 +109,8 @@ namespace BossMod.RealmReborn.Extreme.Ex1Ultima
         {
             foreach (var orb in _activeOrbs)
             {
-                arena.Actor(orb, ArenaColor.Object, true);
-                arena.AddCircle(orb.Position, _explosionRadius, ArenaColor.Danger);
+                arena.Actor(orb, ComponentType.ActorObject, true);
+                arena.AddCircle(orb.Position, _explosionRadius, ComponentType.Danger);
             }
         }
 

--- a/BossMod/Modules/RealmReborn/Extreme/Ex1Ultima/Aetheroplasm.cs
+++ b/BossMod/Modules/RealmReborn/Extreme/Ex1Ultima/Aetheroplasm.cs
@@ -32,7 +32,7 @@ namespace BossMod.RealmReborn.Extreme.Ex1Ultima
             }
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return _kiters[playerSlot] ? PlayerPriority.Danger : PlayerPriority.Irrelevant;
         }
@@ -41,11 +41,11 @@ namespace BossMod.RealmReborn.Extreme.Ex1Ultima
         {
             foreach (var orb in module.Enemies(OID.Aetheroplasm).Where(a => !_explodedOrbs.Contains(a.InstanceID)))
             {
-                arena.Actor(orb, ArenaColor.Object, true);
-                arena.AddCircle(orb.Position, _explosionRadius, ArenaColor.Danger);
+                arena.Actor(orb, ComponentType.ActorObject, true);
+                arena.AddCircle(orb.Position, _explosionRadius, ComponentType.Danger);
                 var kiter = MostLikelyKiter(module, orb);
                 if (kiter != null)
-                    arena.AddLine(orb.Position, kiter.Position, ArenaColor.Danger);
+                    arena.AddLine(orb.Position, kiter.Position, ComponentType.Danger);
             }
         }
 

--- a/BossMod/Modules/RealmReborn/Extreme/Ex1Ultima/Ex1Ultima.cs
+++ b/BossMod/Modules/RealmReborn/Extreme/Ex1Ultima/Ex1Ultima.cs
@@ -73,8 +73,8 @@
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.MagitekBit), ArenaColor.Enemy);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.MagitekBit), ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/RealmReborn/Extreme/Ex2Garuda/Ex2Garuda.cs
+++ b/BossMod/Modules/RealmReborn/Extreme/Ex2Garuda/Ex2Garuda.cs
@@ -75,13 +75,13 @@ namespace BossMod.RealmReborn.Extreme.Ex2Garuda
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
-            Arena.Actors(Monoliths.Where(a => !a.IsDead), ArenaColor.Object, true);
-            Arena.Actors(RazorPlumes, ArenaColor.Enemy);
-            Arena.Actors(SpinyPlumes, ArenaColor.Enemy);
-            Arena.Actors(SatinPlumes, ArenaColor.Enemy);
-            Arena.Actors(Chirada, ArenaColor.Enemy);
-            Arena.Actors(Suparna, ArenaColor.Enemy);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
+            Arena.Actors(Monoliths.Where(a => !a.IsDead), ComponentType.ActorObject, true);
+            Arena.Actors(RazorPlumes, ComponentType.ActorEnemy);
+            Arena.Actors(SpinyPlumes, ComponentType.ActorEnemy);
+            Arena.Actors(SatinPlumes, ComponentType.ActorEnemy);
+            Arena.Actors(Chirada, ComponentType.ActorEnemy);
+            Arena.Actors(Suparna, ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/RealmReborn/Extreme/Ex2Garuda/SpinyShield.cs
+++ b/BossMod/Modules/RealmReborn/Extreme/Ex2Garuda/SpinyShield.cs
@@ -33,7 +33,7 @@ namespace BossMod.RealmReborn.Extreme.Ex2Garuda
         {
             var shield = ActiveShield;
             if (shield != null)
-                arena.ZoneCircle(shield.Position, _radius, ArenaColor.SafeFromAOE);
+                arena.ZoneCircle(shield.Position, _radius, ComponentType.SafeFromAOE);
         }
     }
 }

--- a/BossMod/Modules/RealmReborn/Extreme/Ex2Garuda/WickedWheel.cs
+++ b/BossMod/Modules/RealmReborn/Extreme/Ex2Garuda/WickedWheel.cs
@@ -31,7 +31,7 @@ namespace BossMod.RealmReborn.Extreme.Ex2Garuda
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (_expectedNext != default && (_expectedNext - module.WorldState.CurrentTime).TotalSeconds < 3)
-                arena.AddCircle(module.PrimaryActor.Position, _radius, ArenaColor.Danger);
+                arena.AddCircle(module.PrimaryActor.Position, _radius, ComponentType.Danger);
         }
 
         public override void OnEventCast(BossModule module, Actor caster, ActorCastEvent spell)

--- a/BossMod/Modules/RealmReborn/Extreme/Ex3Titan/Ex3Titan.cs
+++ b/BossMod/Modules/RealmReborn/Extreme/Ex3Titan/Ex3Titan.cs
@@ -52,10 +52,10 @@ namespace BossMod.RealmReborn.Extreme.Ex3Titan
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy, true);
-            Arena.Actors(Gaolers, ArenaColor.Enemy);
-            Arena.Actors(Gaols, ArenaColor.Object);
-            Arena.Actors(Bombs, ArenaColor.Object);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy, true);
+            Arena.Actors(Gaolers, ComponentType.ActorEnemy);
+            Arena.Actors(Gaols, ComponentType.ActorObject);
+            Arena.Actors(Bombs, ComponentType.ActorObject);
         }
     }
 }

--- a/BossMod/Modules/RealmReborn/Extreme/Ex3Titan/Geocrush.cs
+++ b/BossMod/Modules/RealmReborn/Extreme/Ex3Titan/Geocrush.cs
@@ -27,8 +27,8 @@
 
         public override void DrawArenaBackground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
-            arena.ZoneDonut(module.Bounds.Center, _radius, 25, ArenaColor.AOE);
-            arena.ZoneDonut(module.Bounds.Center, _radius - _ringWidth, _radius, ArenaColor.SafeFromAOE);
+            arena.ZoneDonut(module.Bounds.Center, _radius, 25, ComponentType.AOE);
+            arena.ZoneDonut(module.Bounds.Center, _radius - _ringWidth, _radius, ComponentType.SafeFromAOE);
         }
     }
 

--- a/BossMod/Modules/RealmReborn/Extreme/Ex3Titan/GraniteGaol.cs
+++ b/BossMod/Modules/RealmReborn/Extreme/Ex3Titan/GraniteGaol.cs
@@ -7,7 +7,7 @@ namespace BossMod.RealmReborn.Extreme.Ex3Titan
         public BitMask PendingFetters;
         public DateTime ResolveAt;
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return PendingFetters[playerSlot] ? PlayerPriority.Interesting : PlayerPriority.Irrelevant;
         }

--- a/BossMod/Modules/RealmReborn/Extreme/Ex4Ifrit/Ex4Ifrit.cs
+++ b/BossMod/Modules/RealmReborn/Extreme/Ex4Ifrit/Ex4Ifrit.cs
@@ -34,9 +34,9 @@ namespace BossMod.RealmReborn.Extreme.Ex4Ifrit
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
-            Arena.Actors(SmallNails, ArenaColor.Object);
-            Arena.Actors(LargeNails, ArenaColor.Object);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
+            Arena.Actors(SmallNails, ComponentType.ActorObject);
+            Arena.Actors(LargeNails, ComponentType.ActorObject);
         }
     }
 }

--- a/BossMod/Modules/RealmReborn/Extreme/Ex4Ifrit/Ex4IfritAI.cs
+++ b/BossMod/Modules/RealmReborn/Extreme/Ex4Ifrit/Ex4IfritAI.cs
@@ -184,7 +184,7 @@ namespace BossMod.RealmReborn.Extreme.Ex4Ifrit
             if (module.PrimaryActor.TargetID == pc.InstanceID)
             {
                 // cone to help mt with proper positioning
-                arena.AddCone(module.PrimaryActor.Position, 2, Angle.FromDirection(module.PrimaryActor.Position - module.Bounds.Center), Incinerate.CleaveShape.HalfAngle, ArenaColor.Safe);
+                arena.AddCone(module.PrimaryActor.Position, 2, Angle.FromDirection(module.PrimaryActor.Position - module.Bounds.Center), Incinerate.CleaveShape.HalfAngle, ComponentType.Safe);
             }
         }
     }
@@ -304,7 +304,7 @@ namespace BossMod.RealmReborn.Extreme.Ex4Ifrit
             base.DrawArenaForeground(module, pcSlot, pc, arena);
             var nextNail = NailKillOrder.FirstOrDefault();
             if (nextNail != null)
-                arena.AddCircle(nextNail.Position, 2, ArenaColor.Safe);
+                arena.AddCircle(nextNail.Position, 2, ComponentType.Safe);
         }
 
         private (float, float) NailDirDist(WDir offset, Angle startingDir)
@@ -409,7 +409,7 @@ namespace BossMod.RealmReborn.Extreme.Ex4Ifrit
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
-            arena.AddCircle(module.Bounds.Center + _safespotOffset, 2, ArenaColor.Safe);
+            arena.AddCircle(module.Bounds.Center + _safespotOffset, 2, ComponentType.Safe);
         }
     }
     class Ex4IfritAIHellfire1 : Ex4IfritAIHellfire { public Ex4IfritAIHellfire1() : base(150.Degrees(), PartyRolesConfig.Assignment.MT) { } }

--- a/BossMod/Modules/RealmReborn/Extreme/Ex4Ifrit/InfernalFetters.cs
+++ b/BossMod/Modules/RealmReborn/Extreme/Ex4Ifrit/InfernalFetters.cs
@@ -17,7 +17,7 @@ namespace BossMod.RealmReborn.Extreme.Ex4Ifrit
             }
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return Fetters[playerSlot] ? PlayerPriority.Normal : PlayerPriority.Irrelevant;
         }
@@ -29,7 +29,7 @@ namespace BossMod.RealmReborn.Extreme.Ex4Ifrit
                 var from = module.Raid[Fetters.LowestSetBit()];
                 var to = module.Raid[Fetters.HighestSetBit()];
                 if (from != null && to != null)
-                    arena.AddLine(from.Position, to.Position, _fettersStrength > 1 ? ArenaColor.Danger : ArenaColor.Safe);
+                    arena.AddLine(from.Position, to.Position, _fettersStrength > 1 ? ComponentType.Danger : ComponentType.Safe);
             }
         }
 

--- a/BossMod/Modules/RealmReborn/Raid/T01Caduceus/Platforms.cs
+++ b/BossMod/Modules/RealmReborn/Raid/T01Caduceus/Platforms.cs
@@ -118,9 +118,9 @@ namespace BossMod.RealmReborn.Raid.T01Caduceus
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (int i in (ActivePlatforms ^ AllPlatforms).SetBits())
-                arena.AddPolygon(PlatformPoly(i), ArenaColor.Border);
+                arena.AddPolygon(PlatformPoly(i), ComponentType.Border);
             foreach (int i in ActivePlatforms.SetBits())
-                arena.AddPolygon(PlatformPoly(i), ArenaColor.Enemy);
+                arena.AddPolygon(PlatformPoly(i), ComponentType.ActorEnemy);
         }
 
         public override void OnActorEState(BossModule module, Actor actor, ushort state)

--- a/BossMod/Modules/RealmReborn/Raid/T01Caduceus/T01ADS.cs
+++ b/BossMod/Modules/RealmReborn/Raid/T01Caduceus/T01ADS.cs
@@ -94,13 +94,13 @@
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
             foreach (var e in Enemies(OID.PatrolNode))
-                Arena.Actor(e, ArenaColor.Enemy);
+                Arena.Actor(e, ComponentType.ActorEnemy);
             foreach (var e in Enemies(OID.AttackNode))
-                Arena.Actor(e, ArenaColor.Enemy);
+                Arena.Actor(e, ComponentType.ActorEnemy);
             foreach (var e in Enemies(OID.DefenseNode))
-                Arena.Actor(e, ArenaColor.Enemy);
+                Arena.Actor(e, ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/RealmReborn/Raid/T01Caduceus/T01Caduceus.cs
+++ b/BossMod/Modules/RealmReborn/Raid/T01Caduceus/T01Caduceus.cs
@@ -98,7 +98,7 @@ namespace BossMod.RealmReborn.Raid.T01Caduceus
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
-            arena.Actor(Clone, ArenaColor.Enemy);
+            arena.Actor(Clone, ComponentType.ActorEnemy);
         }
     }
 

--- a/BossMod/Modules/RealmReborn/Raid/T02MultiADS/AllaganRot.cs
+++ b/BossMod/Modules/RealmReborn/Raid/T02MultiADS/AllaganRot.cs
@@ -33,7 +33,7 @@ namespace BossMod.RealmReborn.Raid.T02MultiADS
                 hints.AddForbiddenZone(ShapeDistance.Circle(rotHolder.Position, _rotPassRadius + 4), _immunityExpiration[slot]);
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return _rotHolderSlot == playerSlot ? PlayerPriority.Danger : PlayerPriority.Irrelevant;
         }

--- a/BossMod/Modules/RealmReborn/Raid/T04Gauntlet/T04Gauntlet.cs
+++ b/BossMod/Modules/RealmReborn/Raid/T04Gauntlet/T04Gauntlet.cs
@@ -123,17 +123,17 @@ namespace BossMod.RealmReborn.Raid.T04Gauntlet
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var e in P1Bugs)
-                Arena.Actor(e, ArenaColor.Enemy);
+                Arena.Actor(e, ComponentType.ActorEnemy);
             foreach (var e in Bugs)
-                Arena.Actor(e, ArenaColor.Enemy);
+                Arena.Actor(e, ComponentType.ActorEnemy);
             foreach (var e in Soldiers)
-                Arena.Actor(e, ArenaColor.Enemy);
+                Arena.Actor(e, ComponentType.ActorEnemy);
             foreach (var e in Knights)
-                Arena.Actor(e, ArenaColor.Enemy);
+                Arena.Actor(e, ComponentType.ActorEnemy);
             foreach (var e in Rooks)
-                Arena.Actor(e, ArenaColor.Enemy);
+                Arena.Actor(e, ComponentType.ActorEnemy);
             foreach (var e in Dreadnaughts)
-                Arena.Actor(e, ArenaColor.Enemy);
+                Arena.Actor(e, ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/RealmReborn/Raid/T05Twintania/Phase2.cs
+++ b/BossMod/Modules/RealmReborn/Raid/T05Twintania/Phase2.cs
@@ -25,7 +25,7 @@ namespace BossMod.RealmReborn.Raid.T05Twintania
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (Target != null)
-                arena.AddCircle(Target.Position, Radius, ArenaColor.Safe);
+                arena.AddCircle(Target.Position, Radius, ComponentType.Safe);
         }
 
         public override void OnEventCast(BossModule module, Actor caster, ActorCastEvent spell)

--- a/BossMod/Modules/RealmReborn/Raid/T05Twintania/Phase3.cs
+++ b/BossMod/Modules/RealmReborn/Raid/T05Twintania/Phase3.cs
@@ -93,11 +93,11 @@ namespace BossMod.RealmReborn.Raid.T05Twintania
         {
             foreach (var a in ActiveHygieia)
             {
-                arena.Actor(a, ArenaColor.Enemy);
-                arena.AddCircle(a.Position, _explosionRadius, ArenaColor.Danger);
+                arena.Actor(a, ComponentType.ActorEnemy);
+                arena.AddCircle(a.Position, _explosionRadius, ComponentType.Danger);
             }
             foreach (var a in Asclepius)
-                arena.Actor(a, ArenaColor.Enemy);
+                arena.Actor(a, ComponentType.ActorEnemy);
         }
     }
 
@@ -139,7 +139,7 @@ namespace BossMod.RealmReborn.Raid.T05Twintania
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var neurolink in module.Enemies(OID.Neurolink))
-                arena.AddCircle(neurolink.Position, T05Twintania.NeurolinkRadius, ArenaColor.Safe);
+                arena.AddCircle(neurolink.Position, T05Twintania.NeurolinkRadius, ComponentType.Safe);
         }
     }
 }

--- a/BossMod/Modules/RealmReborn/Raid/T05Twintania/Phase4.cs
+++ b/BossMod/Modules/RealmReborn/Raid/T05Twintania/Phase4.cs
@@ -44,7 +44,7 @@ namespace BossMod.RealmReborn.Raid.T05Twintania
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var twister in ActiveTwisters)
-                arena.AddCircle(twister.Position, twister.HitboxRadius, ArenaColor.Danger);
+                arena.AddCircle(twister.Position, twister.HitboxRadius, ComponentType.Danger);
         }
     }
 
@@ -91,9 +91,9 @@ namespace BossMod.RealmReborn.Raid.T05Twintania
         {
             foreach (var a in ActiveDreadknights)
             {
-                arena.Actor(a, ArenaColor.Enemy);
+                arena.Actor(a, ComponentType.ActorEnemy);
                 if (_target != null)
-                    arena.AddLine(a.Position, _target.Position, ArenaColor.Danger);
+                    arena.AddLine(a.Position, _target.Position, ComponentType.Danger);
             }
         }
 

--- a/BossMod/Modules/RealmReborn/Raid/T05Twintania/Phase5.cs
+++ b/BossMod/Modules/RealmReborn/Raid/T05Twintania/Phase5.cs
@@ -44,7 +44,7 @@ namespace BossMod.RealmReborn.Raid.T05Twintania
                 hints.Add("Go to neurolink!", !Neurolinks.InRadius(actor.Position, T05Twintania.NeurolinkRadius).Any());
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return player == Target ? PlayerPriority.Danger : PlayerPriority.Irrelevant;
         }
@@ -53,9 +53,9 @@ namespace BossMod.RealmReborn.Raid.T05Twintania
         {
             if (Target != null)
                 foreach (var orb in Orbs)
-                    arena.AddLine(orb.Position, Target.Position, ArenaColor.Danger);
+                    arena.AddLine(orb.Position, Target.Position, ComponentType.Danger);
             foreach (var neurolink in Neurolinks)
-                arena.AddCircle(neurolink.Position, T05Twintania.NeurolinkRadius, Target == pc ? ArenaColor.Safe : ArenaColor.Danger);
+                arena.AddCircle(neurolink.Position, T05Twintania.NeurolinkRadius, Target == pc ? ComponentType.Safe : ComponentType.Danger);
         }
 
         public override void OnEventCast(BossModule module, Actor caster, ActorCastEvent spell)

--- a/BossMod/Modules/RealmReborn/Raid/T05Twintania/T05Twintania.cs
+++ b/BossMod/Modules/RealmReborn/Raid/T05Twintania/T05Twintania.cs
@@ -157,9 +157,9 @@ namespace BossMod.RealmReborn.Raid.T05Twintania
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy, true);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy, true);
             foreach (var a in ScourgeOfMeracydia)
-                Arena.Actor(a, ArenaColor.Enemy);
+                Arena.Actor(a, ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/RealmReborn/Trial/T03GarudaN/T03GarudaN.cs
+++ b/BossMod/Modules/RealmReborn/Trial/T03GarudaN/T03GarudaN.cs
@@ -115,9 +115,9 @@ namespace BossMod.RealmReborn.Trial.T03GarudaN
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
             foreach (var m in Enemies(OID.Monolith))
-                Arena.Actor(m, ArenaColor.Danger, true);
+                Arena.Actor(m, ComponentType.Danger, true);
         }
     }
 }

--- a/BossMod/Modules/RealmReborn/Trial/T05IfritH/T05IfritH.cs
+++ b/BossMod/Modules/RealmReborn/Trial/T05IfritH/T05IfritH.cs
@@ -124,9 +124,9 @@ namespace BossMod.RealmReborn.Trial.T05IfritH
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
             foreach (var n in ActiveNails)
-                Arena.Actor(n, ArenaColor.Enemy);
+                Arena.Actor(n, ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/RealmReborn/Trial/T06GarudaH/T06GarudaH.cs
+++ b/BossMod/Modules/RealmReborn/Trial/T06GarudaH/T06GarudaH.cs
@@ -133,13 +133,13 @@ namespace BossMod.RealmReborn.Trial.T06GarudaH
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
             foreach (var m in ActiveMonoliths)
-                Arena.Actor(m, ArenaColor.Object, true);
+                Arena.Actor(m, ComponentType.ActorObject, true);
             foreach (var e in Enemies(OID.Suparna))
-                Arena.Actor(e, ArenaColor.Enemy);
+                Arena.Actor(e, ComponentType.ActorEnemy);
             foreach (var e in Enemies(OID.Chirada))
-                Arena.Actor(e, ArenaColor.Enemy);
+                Arena.Actor(e, ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/RealmReborn/Trial/T08ThornmarchH/PomMeteor.cs
+++ b/BossMod/Modules/RealmReborn/Trial/T08ThornmarchH/PomMeteor.cs
@@ -54,7 +54,7 @@ namespace BossMod.RealmReborn.Trial.T08ThornmarchH
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (int i in _activeTowers.SetBits())
-                arena.AddCircle(module.Bounds.Center + _towerOffsets[i], _towerRadius, _soakedTowers[i] ? ArenaColor.Safe : ArenaColor.Danger);
+                arena.AddCircle(module.Bounds.Center + _towerOffsets[i], _towerRadius, _soakedTowers[i] ? ComponentType.Safe : ComponentType.Danger);
         }
 
         public override void OnCastStarted(BossModule module, Actor caster, ActorCastInfo spell)

--- a/BossMod/Modules/RealmReborn/Trial/T08ThornmarchH/T08ThornmarchH.cs
+++ b/BossMod/Modules/RealmReborn/Trial/T08ThornmarchH/T08ThornmarchH.cs
@@ -165,14 +165,14 @@ namespace BossMod.RealmReborn.Trial.T08ThornmarchH
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.RuffletuftKuptaKapa), ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.WoolywartKupquKogi), ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.FurryfootKupliKipp), ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.PuksiPikoTheShaggysong), ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.PuklaPukiThePomburner), ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.PuknaPakoTheTailturner), ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.GoodKingMoggleMogXII), ArenaColor.Enemy);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.RuffletuftKuptaKapa), ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.WoolywartKupquKogi), ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.FurryfootKupliKipp), ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.PuksiPikoTheShaggysong), ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.PuklaPukiThePomburner), ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.PuknaPakoTheTailturner), ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.GoodKingMoggleMogXII), ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/RealmReborn/Trial/T09WhorleaterH/T09WhorleaterH.cs
+++ b/BossMod/Modules/RealmReborn/Trial/T09WhorleaterH/T09WhorleaterH.cs
@@ -38,17 +38,17 @@ namespace BossMod.Modules.RealmReborn.Trial.T09WhorleaterH
     {
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(PrimaryActor, ArenaColor.Enemy, true);
+            Arena.Actor(PrimaryActor, ComponentType.ActorEnemy, true);
             foreach (var s in Enemies(OID.Spume))
-                Arena.Actor(s, ArenaColor.PlayerInteresting, false);
+                Arena.Actor(s, ComponentType.PlayerInteresting, false);
             foreach (var e in Enemies(OID.Tail))
-                Arena.Actor(e, ArenaColor.Enemy, false);
+                Arena.Actor(e, ComponentType.ActorEnemy, false);
             foreach (var e in Enemies(OID.Sahagin))
-                Arena.Actor(e, ArenaColor.Enemy, false);
+                Arena.Actor(e, ComponentType.ActorEnemy, false);
             foreach (var e in Enemies(OID.DangerousSahagins))
-                Arena.Actor(e, ArenaColor.Enemy, false);
+                Arena.Actor(e, ComponentType.ActorEnemy, false);
             foreach (var c in Enemies(OID.Converter))
-                Arena.Actor(c, ArenaColor.Object, false);
+                Arena.Actor(c, ComponentType.ActorObject, false);
         }
 
         public override void CalculateAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)

--- a/BossMod/Modules/RealmReborn/Trial/T09WhorleaterH/T09WhorleaterHHints.cs
+++ b/BossMod/Modules/RealmReborn/Trial/T09WhorleaterH/T09WhorleaterHHints.cs
@@ -31,7 +31,7 @@ namespace BossMod.Modules.RealmReborn.Trial.T09WhorleaterH
             var converter1 = module.Enemies(OID.Converter).FirstOrDefault();
             var convertertargetable = module.Enemies(OID.Converter).Where(x => x.IsTargetable).FirstOrDefault();
             if (converter1 != null && convertertargetable != null)
-                arena.AddCircle(converter1.Position, 1.4f, ArenaColor.Safe);
+                arena.AddCircle(converter1.Position, 1.4f, ComponentType.Safe);
         }
     }
 }

--- a/BossMod/Modules/Shadowbringers/FATE/Formidable.cs
+++ b/BossMod/Modules/Shadowbringers/FATE/Formidable.cs
@@ -133,8 +133,8 @@ namespace BossMod.Shadowbringers.FATE.Formidable
         {
             foreach (var m in _activeMissiles)
             {
-                arena.Actor(m, ArenaColor.Object, true);
-                arena.AddCircle(m.Position, 6, ArenaColor.Danger);
+                arena.Actor(m, ComponentType.ActorObject, true);
+                arena.AddCircle(m.Position, 6, ComponentType.Danger);
             }
         }
 

--- a/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE11ShadowOfDeathHand.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE11ShadowOfDeathHand.cs
@@ -132,8 +132,8 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE11ShadowOfDeathHand
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             base.DrawEnemies(pcSlot, pc);
-            Arena.Actors(Enemies(OID.Beastmaster), ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.TamedCarrionCrow), ArenaColor.Enemy);
+            Arena.Actors(Enemies(OID.Beastmaster), ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.TamedCarrionCrow), ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE21FinalFurlong.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE21FinalFurlong.cs
@@ -47,7 +47,7 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE21FinalFurlong
 
         public GraspingRancor() : base(ActionID.MakeSpell(AID.PurifyingLight), 12)
         {
-            Color = ArenaColor.SafeFromAOE;
+            Type = ComponentType.SafeFromAOE;
             Risky = false;
         }
 
@@ -77,8 +77,8 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE21FinalFurlong
             if (hand != null)
             {
                 bool isFrozen = hand.Tether.ID == (uint)TetherID.Frozen;
-                arena.Actor(hand, ArenaColor.Object, true);
-                arena.AddLine(hand.Position, pc.Position, isFrozen ? ArenaColor.Safe : ArenaColor.Danger);
+                arena.Actor(hand, ComponentType.ActorObject, true);
+                arena.AddLine(hand.Position, pc.Position, isFrozen ? ComponentType.Safe : ComponentType.Danger);
             }
         }
     }

--- a/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE31MetalFoxChaos.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE31MetalFoxChaos.cs
@@ -51,11 +51,11 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE31MetalFoxChaos
                         if (numcasts < 5 && p.Rotation.AlmostEqual(180.Degrees(), MathF.PI / 180))
                             yield return new(rect, p.Position, p.Rotation, new());
                         if (numcasts < 5 && (p.Rotation.AlmostEqual(90.Degrees(), MathF.PI / 180) || p.Rotation.AlmostEqual(-90.Degrees(), MathF.PI / 180)))
-                            yield return new(rect, p.Position, p.Rotation, default, ArenaColor.Danger);
+                            yield return new(rect, p.Position, p.Rotation, default, ComponentType.Danger);
                         if (numcasts >= 5 && numcasts < 9 && (p.Rotation.AlmostEqual(90.Degrees(), MathF.PI / 180) || p.Rotation.AlmostEqual(-90.Degrees(), MathF.PI / 180)))
                             yield return new(rect, p.Position, p.Rotation, new());
                         if (numcasts >= 5 && numcasts < 9 && p.Rotation.AlmostEqual(0.Degrees(), MathF.PI / 180))
-                            yield return new(rect, p.Position, p.Rotation, default, ArenaColor.Danger);
+                            yield return new(rect, p.Position, p.Rotation, default, ComponentType.Danger);
                         if (numcasts >= 9 && p.Rotation.AlmostEqual(0.Degrees(), MathF.PI / 180))
                             yield return new(rect, p.Position, p.Rotation, new());
                     }
@@ -64,11 +64,11 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE31MetalFoxChaos
                         if (numcasts < 5 && p.Rotation.AlmostEqual(90.Degrees(), MathF.PI / 180))
                             yield return new(rect, p.Position, p.Rotation, new());
                         if (numcasts < 5 && (p.Rotation.AlmostEqual(0.Degrees(), MathF.PI / 180) || p.Rotation.AlmostEqual(180.Degrees(), MathF.PI / 180)))
-                            yield return new(rect, p.Position, p.Rotation, default, ArenaColor.Danger);
+                            yield return new(rect, p.Position, p.Rotation, default, ComponentType.Danger);
                         if (numcasts >= 5 && numcasts < 9 && (p.Rotation.AlmostEqual(0.Degrees(), MathF.PI / 180) || p.Rotation.AlmostEqual(180.Degrees(), MathF.PI / 180)))
                             yield return new(rect, p.Position, p.Rotation, new());
                         if (numcasts >= 5 && numcasts < 9 && p.Rotation.AlmostEqual(-90.Degrees(), MathF.PI / 180))
-                            yield return new(rect, p.Position, p.Rotation, default, ArenaColor.Danger);
+                            yield return new(rect, p.Position, p.Rotation, default, ComponentType.Danger);
                         if (numcasts >= 9 && p.Rotation.AlmostEqual(-90.Degrees(), MathF.PI / 180))
                             yield return new(rect, p.Position, p.Rotation, new());
                     }
@@ -77,11 +77,11 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE31MetalFoxChaos
                         if (numcasts < 5 && p.Rotation.AlmostEqual(-90.Degrees(), MathF.PI / 180))
                             yield return new(rect, p.Position, p.Rotation, new());
                         if (numcasts < 5 && (p.Rotation.AlmostEqual(0.Degrees(), MathF.PI / 180) || p.Rotation.AlmostEqual(180.Degrees(), MathF.PI / 180)))
-                            yield return new(rect, p.Position, p.Rotation, default, ArenaColor.Danger);
+                            yield return new(rect, p.Position, p.Rotation, default, ComponentType.Danger);
                         if (numcasts >= 5 && numcasts < 9 && (p.Rotation.AlmostEqual(0.Degrees(), MathF.PI / 180) || p.Rotation.AlmostEqual(180.Degrees(), MathF.PI / 180)))
                             yield return new(rect, p.Position, p.Rotation, new());
                         if (numcasts >= 5 && numcasts < 9 && p.Rotation.AlmostEqual(90.Degrees(), MathF.PI / 180))
-                            yield return new(rect, p.Position, p.Rotation, default, ArenaColor.Danger);
+                            yield return new(rect, p.Position, p.Rotation, default, ComponentType.Danger);
                         if (numcasts >= 9 && p.Rotation.AlmostEqual(90.Degrees(), MathF.PI / 180))
                             yield return new(rect, p.Position, p.Rotation, new());
                     }
@@ -90,11 +90,11 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE31MetalFoxChaos
                         if (numcasts < 5 && p.Rotation.AlmostEqual(0.Degrees(), MathF.PI / 180))
                             yield return new(rect, p.Position, p.Rotation, new());
                         if (numcasts < 5 && (p.Rotation.AlmostEqual(90.Degrees(), MathF.PI / 180) || p.Rotation.AlmostEqual(-90.Degrees(), MathF.PI / 180)))
-                            yield return new(rect, p.Position, p.Rotation, default, ArenaColor.Danger);
+                            yield return new(rect, p.Position, p.Rotation, default, ComponentType.Danger);
                         if (numcasts >= 5 && numcasts < 9 && (p.Rotation.AlmostEqual(90.Degrees(), MathF.PI / 180) || p.Rotation.AlmostEqual(-90.Degrees(), MathF.PI / 180)))
                             yield return new(rect, p.Position, p.Rotation, new());
                         if (numcasts >= 5 && numcasts < 9 && p.Rotation.AlmostEqual(180.Degrees(), MathF.PI / 180))
-                            yield return new(rect, p.Position, p.Rotation, default, ArenaColor.Danger);
+                            yield return new(rect, p.Position, p.Rotation, default, ComponentType.Danger);
                         if (numcasts >= 9 && p.Rotation.AlmostEqual(180.Degrees(), MathF.PI / 180))
                             yield return new(rect, p.Position, p.Rotation, new());
                     }
@@ -103,11 +103,11 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE31MetalFoxChaos
                         if (numcasts < 5 && p.Rotation.AlmostEqual(90.Degrees(), MathF.PI / 180))
                             yield return new(rect, p.Position, p.Rotation, new());
                         if (numcasts < 5 && (p.Rotation.AlmostEqual(0.Degrees(), MathF.PI / 180) || p.Rotation.AlmostEqual(180.Degrees(), MathF.PI / 180)))
-                            yield return new(rect, p.Position, p.Rotation, default, ArenaColor.Danger);
+                            yield return new(rect, p.Position, p.Rotation, default, ComponentType.Danger);
                         if (numcasts >= 5 && numcasts < 9 && (p.Rotation.AlmostEqual(0.Degrees(), MathF.PI / 180) || p.Rotation.AlmostEqual(180.Degrees(), MathF.PI / 180)))
                             yield return new(rect, p.Position, p.Rotation, new());
                         if (numcasts >= 5 && numcasts < 9 && p.Rotation.AlmostEqual(-90.Degrees(), MathF.PI / 180))
-                            yield return new(rect, p.Position, p.Rotation, default, ArenaColor.Danger);
+                            yield return new(rect, p.Position, p.Rotation, default, ComponentType.Danger);
                         if (numcasts >= 9 && p.Rotation.AlmostEqual(-90.Degrees(), MathF.PI / 180))
                             yield return new(rect, p.Position, p.Rotation, new());
                     }
@@ -116,11 +116,11 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE31MetalFoxChaos
                         if (numcasts < 5 && p.Rotation.AlmostEqual(-90.Degrees(), MathF.PI / 180))
                             yield return new(rect, p.Position, p.Rotation, new());
                         if (numcasts < 5 && (p.Rotation.AlmostEqual(0.Degrees(), MathF.PI / 180) || p.Rotation.AlmostEqual(180.Degrees(), MathF.PI / 180)))
-                            yield return new(rect, p.Position, p.Rotation, default, ArenaColor.Danger);
+                            yield return new(rect, p.Position, p.Rotation, default, ComponentType.Danger);
                         if (numcasts >= 5 && numcasts < 9 && (p.Rotation.AlmostEqual(0.Degrees(), MathF.PI / 180) || p.Rotation.AlmostEqual(180.Degrees(), MathF.PI / 180)))
                             yield return new(rect, p.Position, p.Rotation, new());
                         if (numcasts >= 5 && numcasts < 9 && p.Rotation.AlmostEqual(90.Degrees(), MathF.PI / 180))
-                            yield return new(rect, p.Position, p.Rotation, default, ArenaColor.Danger);
+                            yield return new(rect, p.Position, p.Rotation, default, ComponentType.Danger);
                         if (numcasts >= 9 && p.Rotation.AlmostEqual(90.Degrees(), MathF.PI / 180))
                             yield return new(rect, p.Position, p.Rotation, new());
                     }
@@ -129,11 +129,11 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE31MetalFoxChaos
                         if (numcasts < 5 && p.Rotation.AlmostEqual(0.Degrees(), MathF.PI / 180))
                             yield return new(rect, p.Position, p.Rotation, new());
                         if (numcasts < 5 && (p.Rotation.AlmostEqual(90.Degrees(), MathF.PI / 180) || p.Rotation.AlmostEqual(-90.Degrees(), MathF.PI / 180)))
-                            yield return new(rect, p.Position, p.Rotation, default, ArenaColor.Danger);
+                            yield return new(rect, p.Position, p.Rotation, default, ComponentType.Danger);
                         if (numcasts >= 5 && numcasts < 9 && (p.Rotation.AlmostEqual(90.Degrees(), MathF.PI / 180) || p.Rotation.AlmostEqual(-90.Degrees(), MathF.PI / 180)))
                             yield return new(rect, p.Position, p.Rotation, new());
                         if (numcasts >= 5 && numcasts < 9 && p.Rotation.AlmostEqual(180.Degrees(), MathF.PI / 180))
-                            yield return new(rect, p.Position, p.Rotation, default, ArenaColor.Danger);
+                            yield return new(rect, p.Position, p.Rotation, default, ComponentType.Danger);
                         if (numcasts >= 9 && p.Rotation.AlmostEqual(180.Degrees(), MathF.PI / 180))
                             yield return new(rect, p.Position, p.Rotation, new());
                     }
@@ -142,11 +142,11 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE31MetalFoxChaos
                         if (numcasts < 5 && p.Rotation.AlmostEqual(180.Degrees(), MathF.PI / 180))
                             yield return new(rect, p.Position, p.Rotation, new());
                         if (numcasts < 5 && (p.Rotation.AlmostEqual(90.Degrees(), MathF.PI / 180) || p.Rotation.AlmostEqual(-90.Degrees(), MathF.PI / 180)))
-                            yield return new(rect, p.Position, p.Rotation, default, ArenaColor.Danger);
+                            yield return new(rect, p.Position, p.Rotation, default, ComponentType.Danger);
                         if (numcasts >= 5 && numcasts < 9 && (p.Rotation.AlmostEqual(90.Degrees(), MathF.PI / 180) || p.Rotation.AlmostEqual(-90.Degrees(), MathF.PI / 180)))
                             yield return new(rect, p.Position, p.Rotation, new());
                         if (numcasts >= 5 && numcasts < 9 && p.Rotation.AlmostEqual(0.Degrees(), MathF.PI / 180))
-                            yield return new(rect, p.Position, p.Rotation, default, ArenaColor.Danger);
+                            yield return new(rect, p.Position, p.Rotation, default, ComponentType.Danger);
                         if (numcasts >= 9 && p.Rotation.AlmostEqual(0.Degrees(), MathF.PI / 180))
                             yield return new(rect, p.Position, p.Rotation, new());
                     }
@@ -267,9 +267,9 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE31MetalFoxChaos
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             foreach (var s in Enemies(OID.Boss))
-                Arena.Actor(s, ArenaColor.Enemy, false);
+                Arena.Actor(s, ComponentType.ActorEnemy, false);
             foreach (var s in Enemies(OID.MagitekBit))
-                Arena.Actor(s, ArenaColor.Vulnerable, true);
+                Arena.Actor(s, ComponentType.ActorVulnerable, true);
         }
     }
 }

--- a/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE41WithDiremiteAndMain.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE41WithDiremiteAndMain.cs
@@ -141,7 +141,7 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE41WithDiremiteAndMai
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (NextTarget == pc)
-                _shape.Outline(arena, module.PrimaryActor.Position, Angle.FromDirection(pc.Position - module.PrimaryActor.Position), ArenaColor.Danger);
+                _shape.Outline(arena, module.PrimaryActor.Position, Angle.FromDirection(pc.Position - module.PrimaryActor.Position), ComponentType.Danger);
         }
 
         public override void OnEventCast(BossModule module, Actor caster, ActorCastEvent spell)
@@ -206,8 +206,8 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE41WithDiremiteAndMai
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             base.DrawEnemies(pcSlot, pc);
-            Arena.Actors(_dimCrystals.Where(c => !c.IsDead), ArenaColor.Object, true);
-            Arena.Actors(_corruptedCrystals.Where(c => !c.IsDead), ArenaColor.Object, true);
+            Arena.Actors(_dimCrystals.Where(c => !c.IsDead), ComponentType.ActorObject, true);
+            Arena.Actors(_corruptedCrystals.Where(c => !c.IsDead), ComponentType.ActorObject, true);
         }
     }
 }

--- a/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE42FromBeyondTheGrave.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE42FromBeyondTheGrave.cs
@@ -168,7 +168,7 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE42FromBeyondTheGrave
     {
         public PurifyingLight() : base(ActionID.MakeSpell(AID.PurifyingLight), 12)
         {
-            Color = ArenaColor.SafeFromAOE;
+            Type = ComponentType.SafeFromAOE;
             Risky = false;
         }
     }
@@ -201,9 +201,9 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE42FromBeyondTheGrave
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             base.DrawEnemies(pcSlot, pc);
-            Arena.Actors(Enemies(OID.WarWraith), ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.HernaisTheTenacious), ArenaColor.Enemy);
-            Arena.Actors(Enemies(OID.DyunbuTheAccursed), ArenaColor.Enemy);
+            Arena.Actors(Enemies(OID.WarWraith), ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.HernaisTheTenacious), ComponentType.ActorEnemy);
+            Arena.Actors(Enemies(OID.DyunbuTheAccursed), ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE52TimeToBurn.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE52TimeToBurn.cs
@@ -77,7 +77,7 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE52TimeToBurn
         public override void DrawArenaBackground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var p in _eruptionSafeSpots)
-                _shapeEruption.Draw(arena, p, new(), ArenaColor.SafeFromAOE);
+                _shapeEruption.Draw(arena, p, new(), ComponentType.SafeFromAOE);
             base.DrawArenaBackground(module, pcSlot, pc, arena);
         }
 

--- a/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE53HereComesTheCavalry.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE53HereComesTheCavalry.cs
@@ -164,7 +164,7 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE53HereComesTheCavalr
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             base.DrawEnemies(pcSlot, pc);
-            Arena.Actors(Enemies(OID.Cavalry), ArenaColor.Enemy);
+            Arena.Actors(Enemies(OID.Cavalry), ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE54NeverCryWolf.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE54NeverCryWolf.cs
@@ -197,7 +197,7 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE54NeverCryWolf
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             base.DrawEnemies(pcSlot, pc);
-            Arena.Actors(_adds, ArenaColor.Enemy);
+            Arena.Actors(_adds, ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE64FeelingTheBurn.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/CriticalEngagement/CE64FeelingTheBurn.cs
@@ -202,7 +202,7 @@ namespace BossMod.Shadowbringers.Foray.CriticalEngagement.CE64FeelingTheBurn
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             base.DrawEnemies(pcSlot, pc);
-            Arena.Actors(Escorts, ArenaColor.Enemy);
+            Arena.Actors(Escorts, ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS1TrinitySeeker/BalefulBlade.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS1TrinitySeeker/BalefulBlade.cs
@@ -20,7 +20,7 @@ namespace BossMod.Shadowbringers.Foray.DelubrumReginae.DRS1TrinitySeeker
             for (int i = 0; i < 4; ++i)
             {
                 var center = (45 + i * 90).Degrees();
-                shape.Draw(arena, module.Bounds.Center, center, ArenaColor.SafeFromAOE);
+                shape.Draw(arena, module.Bounds.Center, center, ComponentType.SafeFromAOE);
             }
         }
 

--- a/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS1TrinitySeeker/DRS1.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS1TrinitySeeker/DRS1.cs
@@ -45,7 +45,7 @@
             {
                 var center = (45 + i * 90).Degrees();
                 Arena.PathArcTo(Bounds.Center, BarricadeRadius, (center - 22.5f.Degrees()).Rad, (center + 22.5f.Degrees()).Rad);
-                Arena.PathStroke(false, ArenaColor.Border, 2);
+                Arena.PathStroke(false, ComponentType.Border, 2);
             }
         }
     }

--- a/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS1TrinitySeeker/DeadIron.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS1TrinitySeeker/DeadIron.cs
@@ -32,7 +32,7 @@ namespace BossMod.Shadowbringers.Foray.DelubrumReginae.DRS1TrinitySeeker
             }
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return _earthshakers.Any(e => e.target == player) ? PlayerPriority.Interesting : PlayerPriority.Irrelevant;
         }

--- a/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS1TrinitySeeker/MercyFourfold.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS1TrinitySeeker/MercyFourfold.cs
@@ -42,7 +42,7 @@ namespace BossMod.Shadowbringers.Foray.DelubrumReginae.DRS1TrinitySeeker
                 // see whether there is a safezone for two contiguous aoes
                 var mid = dir.ToDirection() + _aoes.Last().Rotation.ToDirection(); // length should be either ~sqrt(2) or ~0
                 if (mid.LengthSq() > 1)
-                    _safezones.Add(new(_shapeSafe, actor.Position, Angle.FromDirection(-mid), new(), ArenaColor.SafeFromAOE, false));
+                    _safezones.Add(new(_shapeSafe, actor.Position, Angle.FromDirection(-mid), new(), ComponentType.SafeFromAOE, false));
                 else
                     _safezones.Add(null);
             }

--- a/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS2Dahu/DRS2.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS2Dahu/DRS2.cs
@@ -33,7 +33,7 @@
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             base.DrawEnemies(pcSlot, pc);
-            Arena.Actors(Enemies(OID.CrownedMarchosias), ArenaColor.Enemy);
+            Arena.Actors(Enemies(OID.CrownedMarchosias), ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS2Dahu/FirebreatheRotating.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS2Dahu/FirebreatheRotating.cs
@@ -15,7 +15,7 @@ namespace BossMod.Shadowbringers.Foray.DelubrumReginae.DRS2Dahu
             if (_increment != default && _nextActivation != default)
             {
                 if (NumCasts < 5)
-                    yield return new(_shape, module.PrimaryActor.Position, _nextRotation, _nextActivation, ArenaColor.Danger);
+                    yield return new(_shape, module.PrimaryActor.Position, _nextRotation, _nextActivation, ComponentType.Danger);
                 if (NumCasts < 4)
                     yield return new(_shape, module.PrimaryActor.Position, _nextRotation + _increment, _nextActivation.AddSeconds(2));
             }

--- a/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS2Dahu/SpitFlame.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS2Dahu/SpitFlame.cs
@@ -29,7 +29,7 @@ namespace BossMod.Shadowbringers.Foray.DelubrumReginae.DRS2Dahu
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
-            arena.Actors(_adds, ArenaColor.Object, true);
+            arena.Actors(_adds, ComponentType.ActorObject, true);
             base.DrawArenaForeground(module, pcSlot, pc, arena);
         }
 

--- a/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS3QueensGuard/DRS3.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS3QueensGuard/DRS3.cs
@@ -72,13 +72,13 @@ namespace BossMod.Shadowbringers.Foray.DelubrumReginae.DRS3QueensGuard
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(Knight(), ArenaColor.Enemy);
-            Arena.Actor(Warrior(), ArenaColor.Enemy);
-            Arena.Actor(Soldier(), ArenaColor.Enemy);
-            Arena.Actor(Gunner(), ArenaColor.Enemy);
-            Arena.Actors(GunTurrets, ArenaColor.Enemy);
-            Arena.Actors(AuraSpheres, ArenaColor.Enemy);
-            Arena.Actors(SpiritualSpheres, ArenaColor.Object);
+            Arena.Actor(Knight(), ComponentType.ActorEnemy);
+            Arena.Actor(Warrior(), ComponentType.ActorEnemy);
+            Arena.Actor(Soldier(), ComponentType.ActorEnemy);
+            Arena.Actor(Gunner(), ComponentType.ActorEnemy);
+            Arena.Actors(GunTurrets, ComponentType.ActorEnemy);
+            Arena.Actors(AuraSpheres, ComponentType.ActorEnemy);
+            Arena.Actors(SpiritualSpheres, ComponentType.ActorObject);
         }
     }
 }

--- a/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS5TrinityAvowed/BladeOfEntropy.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS5TrinityAvowed/BladeOfEntropy.cs
@@ -35,7 +35,7 @@ namespace BossMod.Shadowbringers.Foray.DelubrumReginae.DRS5TrinityAvowed
                     if (numClips > 1)
                         yield return new(_shapeCell, cellCenter, new(), activation);
                     else if (activation != default && temperature == -playerTemp)
-                        yield return new(_shapeCell, cellCenter, new(), activation, ArenaColor.SafeFromAOE, false);
+                        yield return new(_shapeCell, cellCenter, new(), activation, ComponentType.SafeFromAOE, false);
                 }
             }
         }

--- a/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS5TrinityAvowed/Bow.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS5TrinityAvowed/Bow.cs
@@ -69,7 +69,7 @@ namespace BossMod.Shadowbringers.Foray.DelubrumReginae.DRS5TrinityAvowed
 
             var xOffset = _pattern is Pattern.EWNormal or Pattern.EWInverted ? -20 : +20;
             var zOffset = 10 * (cell - 2);
-            yield return new(_shapeCell, module.Bounds.Center + new WDir(xOffset, zOffset), new(), _activation, ArenaColor.SafeFromAOE, false);
+            yield return new(_shapeCell, module.Bounds.Center + new WDir(xOffset, zOffset), new(), _activation, ComponentType.SafeFromAOE, false);
         }
 
         public override void Update(BossModule module)

--- a/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS5TrinityAvowed/Staff.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS5TrinityAvowed/Staff.cs
@@ -21,7 +21,7 @@ namespace BossMod.Shadowbringers.Foray.DelubrumReginae.DRS5TrinityAvowed
         {
             var playerTemp = Temperature(actor);
             foreach (var o in _orbs)
-                yield return new(_shape, o.orb.Position, o.orb.Rotation, _activation, o.temperature == -playerTemp ? ArenaColor.SafeFromAOE : ArenaColor.AOE, _risky);
+                yield return new(_shape, o.orb.Position, o.orb.Rotation, _activation, o.temperature == -playerTemp ? ComponentType.SafeFromAOE : ComponentType.AOE, _risky);
         }
 
         public override void Init(BossModule module)

--- a/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS6StygimolochLord/AddPhaseArena.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS6StygimolochLord/AddPhaseArena.cs
@@ -12,9 +12,9 @@ namespace BossMod.Shadowbringers.Foray.DelubrumReginae.DRS6StygimolochLord
 
         public override void DrawArenaBackground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
-            arena.Zone(module.Bounds.ClipAndTriangulate(InDanger(module)), ArenaColor.AOE);
-            arena.Zone(module.Bounds.ClipAndTriangulate(MidDanger(module)), ArenaColor.AOE);
-            arena.Zone(module.Bounds.ClipAndTriangulate(OutDanger(module)), ArenaColor.AOE);
+            arena.Zone(module.Bounds.ClipAndTriangulate(InDanger(module)), ComponentType.AOE);
+            arena.Zone(module.Bounds.ClipAndTriangulate(MidDanger(module)), ComponentType.AOE);
+            arena.Zone(module.Bounds.ClipAndTriangulate(OutDanger(module)), ComponentType.AOE);
         }
 
         private IEnumerable<WPos> RingBorder(BossModule module, Angle centerOffset, float ringRadius, bool innerBorder)

--- a/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS6StygimolochLord/DRS6.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS6StygimolochLord/DRS6.cs
@@ -50,9 +50,9 @@ namespace BossMod.Shadowbringers.Foray.DelubrumReginae.DRS6StygimolochLord
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
             base.DrawEnemies(pcSlot, pc);
-            Arena.Actors(_monks, ArenaColor.Enemy);
-            Arena.Actors(_ballsEarth, ArenaColor.Object);
-            Arena.Actors(_ballsFire, ArenaColor.Object);
+            Arena.Actors(_monks, ComponentType.ActorEnemy);
+            Arena.Actors(_ballsEarth, ComponentType.ActorObject);
+            Arena.Actors(_ballsFire, ComponentType.ActorObject);
         }
     }
 }

--- a/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS7Queen/Chess.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS7Queen/Chess.cs
@@ -87,7 +87,7 @@ namespace BossMod.Shadowbringers.Foray.DelubrumReginae.DRS7Queen
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var m in GetSafeSpotMoves(module, pc))
-                arena.AddLine(m.from, m.to, m.color);
+                arena.AddLine(m.from, m.to, m.type);
         }
 
         public override void OnStatusGain(BossModule module, Actor actor, ActorStatus status)
@@ -131,7 +131,7 @@ namespace BossMod.Shadowbringers.Foray.DelubrumReginae.DRS7Queen
                 _safespotZOffset = index == 0x1D ? 2 : -2;
         }
 
-        private IEnumerable<(WPos from, WPos to, uint color)> GetSafeSpotMoves(BossModule module, Actor actor)
+        private IEnumerable<(WPos from, WPos to, ComponentType type)> GetSafeSpotMoves(BossModule module, Actor actor)
         {
             var state = _playerStates.GetValueOrDefault(actor.InstanceID);
             if (state == null)
@@ -162,13 +162,13 @@ namespace BossMod.Shadowbringers.Foray.DelubrumReginae.DRS7Queen
                 }
             }
 
-            uint color = ArenaColor.Safe;
+            ComponentType type = ComponentType.Safe;
             var from = actor.Position;
             foreach (var p in state.Safespots.Skip(NumCasts / 2))
             {
-                yield return (from, p, color);
+                yield return (from, p, type);
                 from = p;
-                color = ArenaColor.Danger;
+                type = ComponentType.Danger;
             }
         }
 

--- a/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS7Queen/MaelstromsBolt.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/DelubrumReginae/DRS7Queen/MaelstromsBolt.cs
@@ -21,12 +21,12 @@ namespace BossMod.Shadowbringers.Foray.DelubrumReginae.DRS7Queen
         {
             foreach (var b in _ballLightnings.Where(b => !b.IsDead))
             {
-                arena.Actor(b, ArenaColor.Object, true);
-                arena.AddCircle(b.Position, 8, ArenaColor.Object);
+                arena.Actor(b, ComponentType.ActorObject, true);
+                arena.AddCircle(b.Position, 8, ComponentType.ActorObject);
             }
             foreach (var d in _domes)
             {
-                arena.AddCircle(d.Position, 8, ArenaColor.Safe);
+                arena.AddCircle(d.Position, 8, ComponentType.Safe);
             }
         }
     }

--- a/BossMod/Modules/Shadowbringers/Foray/Duel/Duel4Dabog/RightArmComet.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/Duel/Duel4Dabog/RightArmComet.cs
@@ -19,7 +19,7 @@ namespace BossMod.Shadowbringers.Foray.Duel.Duel4Dabog
         {
             base.DrawArenaForeground(module, pcSlot, pc, arena);
             foreach (var c in Casters)
-                arena.AddCircle(c.Position, _radius, pc.Position.InCircle(c.Position, _radius) ? ArenaColor.Safe : ArenaColor.Danger, 2);
+                arena.AddCircle(c.Position, _radius, pc.Position.InCircle(c.Position, _radius) ? ComponentType.Safe : ComponentType.Danger, 2);
         }
     }
 

--- a/BossMod/Modules/Shadowbringers/Foray/Duel/Duel4Dabog/RightArmRay.cs
+++ b/BossMod/Modules/Shadowbringers/Foray/Duel/Duel4Dabog/RightArmRay.cs
@@ -41,7 +41,7 @@ namespace BossMod.Shadowbringers.Foray.Duel.Duel4Dabog
             foreach (var s in _spheres.Where(s => s.NumCastsLeft > 1))
                 yield return new(_shape, s.Sphere.Position, s.RotNext + s.RotIncrement, _activation, risky: false);
             foreach (var s in _spheres)
-                yield return new(_shape, s.Sphere.Position, s.RotNext, _activation, ArenaColor.Danger);
+                yield return new(_shape, s.Sphere.Position, s.RotNext, _activation, ComponentType.Danger);
         }
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
@@ -61,7 +61,7 @@ namespace BossMod.Shadowbringers.Foray.Duel.Duel4Dabog
                             var midpointOffset = (ccwOffset + cwOffset) * 0.5f;
                             if (midpointOffset.OrthoL().Dot(ccwOffset) < 0)
                             {
-                                arena.AddCircle(module.Bounds.Center + midpointOffset, 1, ArenaColor.Safe);
+                                arena.AddCircle(module.Bounds.Center + midpointOffset, 1, ComponentType.Safe);
                             }
                         }
                     }

--- a/BossMod/Modules/Shadowbringers/Ultimate/TEA/P1Cascade.cs
+++ b/BossMod/Modules/Shadowbringers/Ultimate/TEA/P1Cascade.cs
@@ -6,7 +6,7 @@
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
-            arena.Actors(module.Enemies(OID.Embolus), ArenaColor.Object, true);
+            arena.Actors(module.Enemies(OID.Embolus), ComponentType.ActorObject, true);
         }
     }
 }

--- a/BossMod/Modules/Shadowbringers/Ultimate/TEA/P1JagdDolls.cs
+++ b/BossMod/Modules/Shadowbringers/Ultimate/TEA/P1JagdDolls.cs
@@ -37,17 +37,17 @@ namespace BossMod.Shadowbringers.Ultimate.TEA
         {
             foreach (var doll in ActiveDolls)
             {
-                arena.Actor(doll, doll.HP.Cur < doll.HP.Max / 4 ? ArenaColor.Enemy : ArenaColor.Vulnerable);
+                arena.Actor(doll, doll.HP.Cur < doll.HP.Max / 4 ? ComponentType.ActorEnemy : ComponentType.ActorVulnerable);
 
                 var tether = module.WorldState.Actors.Find(doll.Tether.Target);
                 if (tether != null)
                 {
-                    arena.AddLine(doll.Position, tether.Position, ArenaColor.Danger);
+                    arena.AddLine(doll.Position, tether.Position, ComponentType.Danger);
                 }
 
                 if (NumExhausts < 2)
                 {
-                    arena.AddCircle(doll.Position, _exhaustRadius, ArenaColor.Safe);
+                    arena.AddCircle(doll.Position, _exhaustRadius, ComponentType.Safe);
                 }
             }
         }

--- a/BossMod/Modules/Shadowbringers/Ultimate/TEA/P2CompressedWaterLightning.cs
+++ b/BossMod/Modules/Shadowbringers/Ultimate/TEA/P2CompressedWaterLightning.cs
@@ -18,9 +18,9 @@
                 base.AddAIHints(module, slot, actor, assignment, hints);
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
-            return ResolveImminent ? base.CalcPriority(module, pcSlot, pc, playerSlot, player, ref customColor) : PlayerPriority.Irrelevant;
+            return ResolveImminent ? base.CalcPriority(module, pcSlot, pc, playerSlot, player, ref type) : PlayerPriority.Irrelevant;
         }
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)

--- a/BossMod/Modules/Shadowbringers/Ultimate/TEA/P2Intermission.cs
+++ b/BossMod/Modules/Shadowbringers/Ultimate/TEA/P2Intermission.cs
@@ -23,7 +23,7 @@ namespace BossMod.Shadowbringers.Ultimate.TEA
             foreach (var c in FutureBlasterCenters(module))
                 yield return new(_blasterShape, c, risky: false);
             foreach (var c in ImminentBlasterCenters(module))
-                yield return new(_blasterShape, c, color: ArenaColor.Danger);
+                yield return new(_blasterShape, c, type: ComponentType.Danger);
         }
 
         // TODO: reconsider
@@ -31,14 +31,14 @@ namespace BossMod.Shadowbringers.Ultimate.TEA
         {
             base.AddHints(module, slot, actor, hints, movementHints);
             if (movementHints != null && SafeSpotHint(module, slot) is var safespot && safespot != null)
-                movementHints.Add(actor.Position, safespot.Value, ArenaColor.Safe);
+                movementHints.Add(actor.Position, safespot.Value, ComponentType.Safe);
         }
 
         // TODO: reconsider
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (SafeSpotHint(module, pcSlot) is var safespot && safespot != null)
-                arena.AddCircle(safespot.Value, 1, ArenaColor.Safe);
+                arena.AddCircle(safespot.Value, 1, ComponentType.Safe);
         }
 
         public override void OnEventCast(BossModule module, Actor caster, ActorCastEvent spell)

--- a/BossMod/Modules/Shadowbringers/Ultimate/TEA/P2MissileCommand.cs
+++ b/BossMod/Modules/Shadowbringers/Ultimate/TEA/P2MissileCommand.cs
@@ -71,7 +71,7 @@ namespace BossMod.Shadowbringers.Ultimate.TEA
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var m in _mines)
-                arena.Actor(m, default, ArenaColor.Object);
+                arena.Actor(m, default, ComponentType.ActorObject);
         }
 
         public override void OnCastStarted(BossModule module, Actor caster, ActorCastInfo spell)

--- a/BossMod/Modules/Shadowbringers/Ultimate/TEA/P2Nisi.cs
+++ b/BossMod/Modules/Shadowbringers/Ultimate/TEA/P2Nisi.cs
@@ -45,7 +45,7 @@ namespace BossMod.Shadowbringers.Ultimate.TEA
             var partner = module.Raid[PassPartnerSlot(pcSlot)];
             if (partner != null)
             {
-                arena.AddLine(pc.Position, partner.Position, ArenaColor.Danger);
+                arena.AddLine(pc.Position, partner.Position, ComponentType.Danger);
             }
         }
 

--- a/BossMod/Modules/Shadowbringers/Ultimate/TEA/P3Inception1.cs
+++ b/BossMod/Modules/Shadowbringers/Ultimate/TEA/P3Inception1.cs
@@ -47,14 +47,14 @@ namespace BossMod.Shadowbringers.Ultimate.TEA
                 {
                     if (!sphere.IsDead)
                     {
-                        arena.Actor(sphere, ArenaColor.Object, true);
-                        arena.AddLine(sphere.Position, player.Position, slot == pcSlot ? ArenaColor.Safe : ArenaColor.Danger);
-                        arena.AddCircle(player.Position, _sphereRadius, ArenaColor.Danger);
+                        arena.Actor(sphere, ComponentType.ActorObject, true);
+                        arena.AddLine(sphere.Position, player.Position, slot == pcSlot ? ComponentType.Safe : ComponentType.Danger);
+                        arena.AddCircle(player.Position, _sphereRadius, ComponentType.Danger);
                     }
                 }
                 else if (!CrystalsDone)
                 {
-                    arena.AddCircle(player.Position, _crystalRadius, ArenaColor.Danger);
+                    arena.AddCircle(player.Position, _crystalRadius, ComponentType.Danger);
                 }
             }
 
@@ -63,15 +63,15 @@ namespace BossMod.Shadowbringers.Ultimate.TEA
             {
                 if (!pcSphere.IsDead)
                 {
-                    arena.AddCircle(_assignedPositions[pcSlot], 1, ArenaColor.Safe);
+                    arena.AddCircle(_assignedPositions[pcSlot], 1, ComponentType.Safe);
                 }
             }
             else if (!CrystalsDone)
             {
-                arena.AddCircle(_assignedPositions[pcSlot] + new WDir(-5, -5), 1, ArenaColor.Safe);
-                arena.AddCircle(_assignedPositions[pcSlot] + new WDir(-5, +5), 1, ArenaColor.Safe);
-                arena.AddCircle(_assignedPositions[pcSlot] + new WDir(+5, -5), 1, ArenaColor.Safe);
-                arena.AddCircle(_assignedPositions[pcSlot] + new WDir(+5, +5), 1, ArenaColor.Safe);
+                arena.AddCircle(_assignedPositions[pcSlot] + new WDir(-5, -5), 1, ComponentType.Safe);
+                arena.AddCircle(_assignedPositions[pcSlot] + new WDir(-5, +5), 1, ComponentType.Safe);
+                arena.AddCircle(_assignedPositions[pcSlot] + new WDir(+5, -5), 1, ComponentType.Safe);
+                arena.AddCircle(_assignedPositions[pcSlot] + new WDir(+5, +5), 1, ComponentType.Safe);
             }
         }
 

--- a/BossMod/Modules/Shadowbringers/Ultimate/TEA/P3Inception3.cs
+++ b/BossMod/Modules/Shadowbringers/Ultimate/TEA/P3Inception3.cs
@@ -57,7 +57,7 @@ namespace BossMod.Shadowbringers.Ultimate.TEA
             base.DrawArenaForeground(module, pcSlot, pc, arena);
 
             if (_tethered[pcSlot] && FindPartner(module, pcSlot) is var partner && partner != null)
-                arena.AddLine(pc.Position, partner.Position, (partner.Position - pc.Position).LengthSq() < 30 * 30 ? ArenaColor.Danger : ArenaColor.Safe);
+                arena.AddLine(pc.Position, partner.Position, (partner.Position - pc.Position).LengthSq() < 30 * 30 ? ComponentType.Danger : ComponentType.Safe);
         }
 
         public override void OnStatusGain(BossModule module, Actor actor, ActorStatus status)

--- a/BossMod/Modules/Shadowbringers/Ultimate/TEA/P3TemporalStasis.cs
+++ b/BossMod/Modules/Shadowbringers/Ultimate/TEA/P3TemporalStasis.cs
@@ -40,7 +40,7 @@ namespace BossMod.Shadowbringers.Ultimate.TEA
             }
 
             if (movementHints != null)
-                movementHints.Add(actor.Position, SafeSpot(module, slot, actor), ArenaColor.Safe);
+                movementHints.Add(actor.Position, SafeSpot(module, slot, actor), ComponentType.Safe);
         }
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
@@ -51,17 +51,17 @@ namespace BossMod.Shadowbringers.Ultimate.TEA
             {
                 case Mechanic.StayClose:
                     if (FindPartner(module, pcSlot) is var partner1 && partner1 != null)
-                        arena.AddLine(pc.Position, partner1.Position, (partner1.Position - pc.Position).LengthSq() > 5 * 5 ? ArenaColor.Danger : ArenaColor.Safe);
+                        arena.AddLine(pc.Position, partner1.Position, (partner1.Position - pc.Position).LengthSq() > 5 * 5 ? ComponentType.Danger : ComponentType.Safe);
                     break;
                 case Mechanic.StayFar:
                     if (FindPartner(module, pcSlot) is var partner2 && partner2 != null)
-                        arena.AddLine(pc.Position, partner2.Position, (partner2.Position - pc.Position).LengthSq() < 30 * 30 ? ArenaColor.Danger : ArenaColor.Safe);
+                        arena.AddLine(pc.Position, partner2.Position, (partner2.Position - pc.Position).LengthSq() < 30 * 30 ? ComponentType.Danger : ComponentType.Safe);
                     break;
             }
 
-            arena.Actor(BJ(module), ArenaColor.Enemy, true);
-            arena.Actor(CC(module), ArenaColor.Enemy, true);
-            arena.AddCircle(SafeSpot(module, pcSlot, pc), 1, ArenaColor.Safe);
+            arena.Actor(BJ(module), ComponentType.ActorEnemy, true);
+            arena.Actor(CC(module), ComponentType.ActorEnemy, true);
+            arena.AddCircle(SafeSpot(module, pcSlot, pc), 1, ComponentType.Safe);
         }
 
         public override void OnStatusGain(BossModule module, Actor actor, ActorStatus status)

--- a/BossMod/Modules/Shadowbringers/Ultimate/TEA/P3Wormhole.cs
+++ b/BossMod/Modules/Shadowbringers/Ultimate/TEA/P3Wormhole.cs
@@ -51,7 +51,7 @@ namespace BossMod.Shadowbringers.Ultimate.TEA
             }
 
             if (movementHints != null && (!shouldSoak || !_chakramsDone))
-                movementHints.Add(actor.Position, module.Bounds.Center + SafeSpotOffset(order, dirToAlex, dirToSide), ArenaColor.Safe);
+                movementHints.Add(actor.Position, module.Bounds.Center + SafeSpotOffset(order, dirToAlex, dirToSide), ComponentType.Safe);
         }
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
@@ -69,10 +69,10 @@ namespace BossMod.Shadowbringers.Ultimate.TEA
             var shouldSoak = ShouldSoakWormhole(pcOrder);
 
             foreach (var w in _wormholes)
-                arena.AddCircle(w, _radiuses[NumSoaks], shouldSoak && dirToSide.Dot(w - module.Bounds.Center) > 0 ? ArenaColor.Safe : ArenaColor.Danger);
+                arena.AddCircle(w, _radiuses[NumSoaks], shouldSoak && dirToSide.Dot(w - module.Bounds.Center) > 0 ? ComponentType.Safe : ComponentType.Danger);
 
             if (!shouldSoak || !_chakramsDone)
-                arena.AddCircle(module.Bounds.Center + SafeSpotOffset(pcOrder, dirToAlex, dirToSide), 1, ArenaColor.Safe);
+                arena.AddCircle(module.Bounds.Center + SafeSpotOffset(pcOrder, dirToAlex, dirToSide), 1, ComponentType.Safe);
         }
 
         public override void OnActorCreated(BossModule module, Actor actor)

--- a/BossMod/Modules/Shadowbringers/Ultimate/TEA/P4AlmightyJudgment.cs
+++ b/BossMod/Modules/Shadowbringers/Ultimate/TEA/P4AlmightyJudgment.cs
@@ -21,7 +21,7 @@ namespace BossMod.Shadowbringers.Ultimate.TEA
                 var deadlineFuture = _casters[0].activation.AddSeconds(3);
                 foreach (var c in Enumerable.Reverse(_casters).SkipWhile(c => c.activation > deadlineFuture))
                 {
-                    yield return new(_shape, c.pos, default, c.activation, c.activation < deadlineImminent ? ArenaColor.Danger : ArenaColor.AOE);
+                    yield return new(_shape, c.pos, default, c.activation, c.activation < deadlineImminent ? ComponentType.Danger : ComponentType.AOE);
                 }
             }
         }

--- a/BossMod/Modules/Shadowbringers/Ultimate/TEA/P4FateCalibrationAlpha.cs
+++ b/BossMod/Modules/Shadowbringers/Ultimate/TEA/P4FateCalibrationAlpha.cs
@@ -123,14 +123,14 @@ namespace BossMod.Shadowbringers.Ultimate.TEA
         {
             base.AddHints(module, slot, actor, hints, movementHints);
             if (movementHints != null && _safespots != null)
-                movementHints.Add(actor.Position, _safespots[slot], ArenaColor.Safe);
+                movementHints.Add(actor.Position, _safespots[slot], ComponentType.Safe);
         }
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             base.DrawArenaForeground(module, pcSlot, pc, arena);
             if (_safespots != null)
-                arena.AddCircle(_safespots[pcSlot], 1, ArenaColor.Safe);
+                arena.AddCircle(_safespots[pcSlot], 1, ComponentType.Safe);
         }
 
         public override void OnEventCast(BossModule module, Actor caster, ActorCastEvent spell)

--- a/BossMod/Modules/Shadowbringers/Ultimate/TEA/P4ForcedMarchDebuffs.cs
+++ b/BossMod/Modules/Shadowbringers/Ultimate/TEA/P4ForcedMarchDebuffs.cs
@@ -36,7 +36,7 @@
             }
 
             if (movementHints != null)
-                movementHints.Add(actor.Position, module.Bounds.Center + SafeSpotDirection(slot), ArenaColor.Safe);
+                movementHints.Add(actor.Position, module.Bounds.Center + SafeSpotDirection(slot), ComponentType.Safe);
         }
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
@@ -62,7 +62,7 @@
                     break;
             }
 
-            arena.AddCircle(module.Bounds.Center + SafeSpotDirection(pcSlot), 1, ArenaColor.Safe);
+            arena.AddCircle(module.Bounds.Center + SafeSpotDirection(pcSlot), 1, ComponentType.Safe);
         }
 
         protected abstract WDir SafeSpotDirection(int slot);

--- a/BossMod/Modules/Shadowbringers/Ultimate/TEA/TEA.cs
+++ b/BossMod/Modules/Shadowbringers/Ultimate/TEA/TEA.cs
@@ -126,21 +126,21 @@ namespace BossMod.Shadowbringers.Ultimate.TEA
             {
                 case -1:
                 case 0:
-                    Arena.Actor(BossP1(), ArenaColor.Enemy);
-                    Arena.Actor(LiquidHand(), ArenaColor.Enemy);
+                    Arena.Actor(BossP1(), ComponentType.ActorEnemy);
+                    Arena.Actor(LiquidHand(), ComponentType.ActorEnemy);
                     break;
                 case 1:
-                    Arena.Actor(_bruteJustice, ArenaColor.Enemy, true);
-                    Arena.Actor(_cruiseChaser, ArenaColor.Enemy, true);
+                    Arena.Actor(_bruteJustice, ComponentType.ActorEnemy, true);
+                    Arena.Actor(_cruiseChaser, ComponentType.ActorEnemy, true);
                     break;
                 case 2:
-                    Arena.Actor(_alexPrime, ArenaColor.Enemy);
-                    Arena.Actor(TrueHeart(), ArenaColor.Enemy);
-                    Arena.Actor(_bruteJustice, ArenaColor.Enemy);
-                    Arena.Actor(_cruiseChaser, ArenaColor.Enemy);
+                    Arena.Actor(_alexPrime, ComponentType.ActorEnemy);
+                    Arena.Actor(TrueHeart(), ComponentType.ActorEnemy);
+                    Arena.Actor(_bruteJustice, ComponentType.ActorEnemy);
+                    Arena.Actor(_cruiseChaser, ComponentType.ActorEnemy);
                     break;
                 case 3:
-                    Arena.Actor(_perfectAlex, ArenaColor.Enemy);
+                    Arena.Actor(_perfectAlex, ComponentType.ActorEnemy);
                     break;
             }
         }

--- a/BossMod/Modules/Stormblood/Ultimate/UCOB/P1Hatch.cs
+++ b/BossMod/Modules/Stormblood/Ultimate/UCOB/P1Hatch.cs
@@ -27,7 +27,7 @@ namespace BossMod.Stormblood.Ultimate.UCOB
                 hints.Add("GTFO from neurolink!");
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return _targets[playerSlot] ? PlayerPriority.Danger : PlayerPriority.Irrelevant;
         }
@@ -35,13 +35,13 @@ namespace BossMod.Stormblood.Ultimate.UCOB
         public override void DrawArenaBackground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var o in _orbs.Where(o => !o.IsDead))
-                arena.ZoneCircle(o.Position, 1, ArenaColor.AOE);
+                arena.ZoneCircle(o.Position, 1, ComponentType.AOE);
         }
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var neurolink in _neurolinks)
-                arena.AddCircle(neurolink.Position, 2, _targets[pcSlot] ? ArenaColor.Safe : ArenaColor.Danger);
+                arena.AddCircle(neurolink.Position, 2, _targets[pcSlot] ? ComponentType.Safe : ComponentType.Danger);
         }
 
         public override void OnEventIcon(BossModule module, Actor actor, uint iconID)

--- a/BossMod/Modules/Stormblood/Ultimate/UCOB/P2BahamutsFavor.cs
+++ b/BossMod/Modules/Stormblood/Ultimate/UCOB/P2BahamutsFavor.cs
@@ -210,7 +210,7 @@ namespace BossMod.Stormblood.Ultimate.UCOB
         {
             var doomOrder = _dooms.FindIndex(d => d.player == pc);
             if (doomOrder >= 0 && !_dooms[doomOrder].cleansed && doomOrder < _cleanses.Count)
-                arena.AddCircle(_cleanses[doomOrder].voidzone?.Position ?? _cleanses[doomOrder].predicted, 1, ArenaColor.Safe);
+                arena.AddCircle(_cleanses[doomOrder].voidzone?.Position ?? _cleanses[doomOrder].predicted, 1, ComponentType.Safe);
         }
 
         public override void OnActorCreated(BossModule module, Actor actor)

--- a/BossMod/Modules/Stormblood/Ultimate/UCOB/UCOB.cs
+++ b/BossMod/Modules/Stormblood/Ultimate/UCOB/UCOB.cs
@@ -34,8 +34,8 @@ namespace BossMod.Stormblood.Ultimate.UCOB
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(Twintania(), ArenaColor.Enemy);
-            Arena.Actor(Nael(), ArenaColor.Enemy);
+            Arena.Actor(Twintania(), ComponentType.ActorEnemy);
+            Arena.Actor(Nael(), ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/Stormblood/Ultimate/UWU/P1Mesohigh.cs
+++ b/BossMod/Modules/Stormblood/Ultimate/UWU/P1Mesohigh.cs
@@ -23,13 +23,13 @@ namespace BossMod.Stormblood.Ultimate.UWU
                 var tetherTarget = module.WorldState.Actors.Find(s.Tether.Target);
                 if (tetherTarget != null)
                 {
-                    arena.AddLine(s.Position, tetherTarget.Position, ArenaColor.Danger);
-                    arena.AddCircle(tetherTarget.Position, _radius, ArenaColor.Danger);
+                    arena.AddLine(s.Position, tetherTarget.Position, ComponentType.Danger);
+                    arena.AddCircle(tetherTarget.Position, _radius, ComponentType.Danger);
                 }
             }
         }
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return _sisters.Any(s => s.Tether.Target == player.InstanceID) ? PlayerPriority.Danger : PlayerPriority.Normal;
         }

--- a/BossMod/Modules/Stormblood/Ultimate/UWU/P1Plumes.cs
+++ b/BossMod/Modules/Stormblood/Ultimate/UWU/P1Plumes.cs
@@ -20,9 +20,9 @@ namespace BossMod.Stormblood.Ultimate.UWU
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
-            arena.Actors(_razor, ArenaColor.Enemy);
-            arena.Actors(_spiny, ArenaColor.Enemy);
-            arena.Actors(_satin, ArenaColor.Enemy);
+            arena.Actors(_razor, ComponentType.ActorEnemy);
+            arena.Actors(_spiny, ComponentType.ActorEnemy);
+            arena.Actors(_satin, ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/Stormblood/Ultimate/UWU/P2Eruption.cs
+++ b/BossMod/Modules/Stormblood/Ultimate/UWU/P2Eruption.cs
@@ -24,7 +24,7 @@ namespace BossMod.Stormblood.Ultimate.UWU
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             if (_baiters[pcSlot])
-                arena.AddCircle(pc.Position, Shape.Radius, ArenaColor.Safe);
+                arena.AddCircle(pc.Position, Shape.Radius, ComponentType.Safe);
         }
 
         public override void OnCastStarted(BossModule module, Actor caster, ActorCastInfo spell)

--- a/BossMod/Modules/Stormblood/Ultimate/UWU/P2InfernalFetters.cs
+++ b/BossMod/Modules/Stormblood/Ultimate/UWU/P2InfernalFetters.cs
@@ -5,7 +5,7 @@
         public BitMask Fetters;
         private int _fettersStrength;
 
-        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+        public override PlayerPriority CalcPriority(BossModule module, int pcSlot, Actor pc, int playerSlot, Actor player, ref ComponentType type)
         {
             return Fetters[playerSlot] ? PlayerPriority.Normal : PlayerPriority.Irrelevant;
         }
@@ -17,7 +17,7 @@
                 var from = module.Raid[Fetters.LowestSetBit()];
                 var to = module.Raid[Fetters.HighestSetBit()];
                 if (from != null && to != null)
-                    arena.AddLine(from.Position, to.Position, _fettersStrength > 1 ? ArenaColor.Danger : ArenaColor.Safe);
+                    arena.AddLine(from.Position, to.Position, _fettersStrength > 1 ? ComponentType.Danger : ComponentType.Safe);
             }
         }
 

--- a/BossMod/Modules/Stormblood/Ultimate/UWU/P2Nails.cs
+++ b/BossMod/Modules/Stormblood/Ultimate/UWU/P2Nails.cs
@@ -17,7 +17,7 @@ namespace BossMod.Stormblood.Ultimate.UWU
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
-            arena.Actors(_nails, ArenaColor.Enemy);
+            arena.Actors(_nails, ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/Stormblood/Ultimate/UWU/P4MagitekBits.cs
+++ b/BossMod/Modules/Stormblood/Ultimate/UWU/P4MagitekBits.cs
@@ -16,7 +16,7 @@ namespace BossMod.Stormblood.Ultimate.UWU
 
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
-            arena.Actors(_bits, ArenaColor.Enemy);
+            arena.Actors(_bits, ComponentType.ActorEnemy);
         }
     }
 }

--- a/BossMod/Modules/Stormblood/Ultimate/UWU/P4UltimateAnnihilation.cs
+++ b/BossMod/Modules/Stormblood/Ultimate/UWU/P4UltimateAnnihilation.cs
@@ -18,8 +18,8 @@ namespace BossMod.Stormblood.Ultimate.UWU
         {
             foreach (var orb in _orbs.Where(o => !o.IsDead))
             {
-                arena.Actor(orb, ArenaColor.Object, true);
-                arena.AddCircle(orb.Position, _radius, ArenaColor.Object);
+                arena.Actor(orb, ComponentType.ActorObject, true);
+                arena.AddCircle(orb.Position, _radius, ComponentType.ActorObject);
             }
         }
     }

--- a/BossMod/Modules/Stormblood/Ultimate/UWU/P4UltimatePredation.cs
+++ b/BossMod/Modules/Stormblood/Ultimate/UWU/P4UltimatePredation.cs
@@ -26,7 +26,7 @@ namespace BossMod.Stormblood.Ultimate.UWU
         public override void DrawArenaForeground(BossModule module, int pcSlot, Actor pc, MiniArena arena)
         {
             foreach (var h in EnumerateHints(pc.Position))
-                arena.AddLine(h.from, h.to, h.color);
+                arena.AddLine(h.from, h.to, h.type);
         }
 
         public override void OnActorPlayActionTimelineEvent(BossModule module, Actor actor, ushort id)
@@ -66,14 +66,14 @@ namespace BossMod.Stormblood.Ultimate.UWU
             }
         }
 
-        private IEnumerable<(WPos from, WPos to, uint color)> EnumerateHints(WPos starting)
+        private IEnumerable<(WPos from, WPos to, ComponentType type)> EnumerateHints(WPos starting)
         {
-            uint color = ArenaColor.Safe;
+            ComponentType type = ComponentType.Safe;
             foreach (var p in _hints)
             {
-                yield return (starting, p, color);
+                yield return (starting, p, type);
                 starting = p;
-                color = ArenaColor.Danger;
+                type = ComponentType.Danger;
             }
         }
 

--- a/BossMod/Modules/Stormblood/Ultimate/UWU/UWU.cs
+++ b/BossMod/Modules/Stormblood/Ultimate/UWU/UWU.cs
@@ -155,11 +155,11 @@ namespace BossMod.Stormblood.Ultimate.UWU
 
         protected override void DrawEnemies(int pcSlot, Actor pc)
         {
-            Arena.Actor(Garuda(), ArenaColor.Enemy);
-            Arena.Actor(Ifrit(), ArenaColor.Enemy);
-            Arena.Actor(Titan(), ArenaColor.Enemy);
-            Arena.Actor(Lahabrea(), ArenaColor.Enemy);
-            Arena.Actor(Ultima(), ArenaColor.Enemy);
+            Arena.Actor(Garuda(), ComponentType.ActorEnemy);
+            Arena.Actor(Ifrit(), ComponentType.ActorEnemy);
+            Arena.Actor(Titan(), ComponentType.ActorEnemy);
+            Arena.Actor(Lahabrea(), ComponentType.ActorEnemy);
+            Arena.Actor(Ultima(), ComponentType.ActorEnemy);
         }
     }
 }

--- a/UIDev/MiniArenaTest.cs
+++ b/UIDev/MiniArenaTest.cs
@@ -37,17 +37,17 @@ namespace UIDev
 
             _arena.Begin((float)(Math.PI * _azimuth / 180));
             if (_coneEnabled)
-                _arena.ZoneCone(new(_conePos), _coneRadius.X, _coneRadius.Y, _coneAngles.X.Degrees(), _coneAngles.Y.Degrees(), ArenaColor.Safe);
-            _arena.Border(ArenaColor.Border);
+                _arena.ZoneCone(new(_conePos), _coneRadius.X, _coneRadius.Y, _coneAngles.X.Degrees(), _coneAngles.Y.Degrees(), ComponentType.Safe);
+            _arena.Border(ComponentType.Border);
             if (_lineEnabled)
-                _arena.AddLine(new(_lineEnds.X, _lineEnds.Y), new(_lineEnds.Z, _lineEnds.W), 0xffff0000);
+                _arena.AddLine(new(_lineEnds.X, _lineEnds.Y), new(_lineEnds.Z, _lineEnds.W), ComponentType.TetherMoveToward);
             if (_kbContourEnabled)
             {
                 foreach (var p in KBContour())
                     _arena.PathLineTo(p);
-                _arena.PathStroke(true, 0xffff00ff);
+                _arena.PathStroke(true, ComponentType.ActorVulnerable);
             }
-            _arena.Actor(new(_playerPos), 0.Degrees(), 0xff00ff00);
+            _arena.Actor(new(_playerPos), 0.Degrees(), ComponentType.ActorYou);
             _arena.End();
 
             // arena config


### PR DESCRIPTION
This is a precursor change for supporting configurable colors. This is mostly a 1:1 swap from a user facing perspective, but there are a handful of minor changes to tether colors in P4S, P7S, Zurvan Unreal, and possibly a couple more.