### PR TITLE
[SAM] Level 80 support and smart AOE rotation

### DIFF
--- a/BossMod/Autorotation/Autorotation.cs
+++ b/BossMod/Autorotation/Autorotation.cs
@@ -126,7 +126,7 @@ namespace BossMod
                     Class.SCH => Service.ClientState.LocalPlayer?.Level <= 60 ? typeof(SCH.Actions) : null,
                     Class.RPR => typeof(RPR.Actions),
                     Class.GNB => typeof(GNB.Actions),
-                    Class.SAM => Service.ClientState.LocalPlayer?.Level == 90 ? typeof(SAM.Actions) : null,
+                    Class.SAM => typeof(SAM.Actions),
                     Class.DNC => typeof(DNC.Actions),
                     _ => null
                 };

--- a/BossMod/Autorotation/BLM/BLMActions.cs
+++ b/BossMod/Autorotation/BLM/BLMActions.cs
@@ -24,6 +24,10 @@ namespace BossMod.BLM
             _strategy = new();
             _prevMP = player.CurMP;
 
+            SupportedSpell(AID.Triplecast).Condition = _ => _state.TriplecastLeft == 0;
+            SupportedSpell(AID.Sharpcast).Condition = _ => _state.SharpcastLeft == 0;
+            SupportedSpell(AID.Manafont).Condition = _ => _state.CurMP <= 7000;
+
             _config.Modified += OnConfigModified;
             OnConfigModified(null, EventArgs.Empty);
         }

--- a/BossMod/Autorotation/BLM/BLMActions.cs
+++ b/BossMod/Autorotation/BLM/BLMActions.cs
@@ -24,10 +24,6 @@ namespace BossMod.BLM
             _strategy = new();
             _prevMP = player.CurMP;
 
-            SupportedSpell(AID.Triplecast).Condition = _ => _state.TriplecastLeft == 0;
-            SupportedSpell(AID.Sharpcast).Condition = _ => _state.SharpcastLeft == 0;
-            SupportedSpell(AID.Manafont).Condition = _ => _state.CurMP <= 7000;
-
             _config.Modified += OnConfigModified;
             OnConfigModified(null, EventArgs.Empty);
         }

--- a/BossMod/Autorotation/MNK/MNKActions.cs
+++ b/BossMod/Autorotation/MNK/MNKActions.cs
@@ -26,6 +26,7 @@ namespace BossMod.MNK
             SupportedSpell(AID.Meditation).TransformAction = () => ActionID.MakeSpell(_state.Chakra == 5 ? _state.BestForbiddenChakra : AID.Meditation);
             SupportedSpell(AID.ArmOfTheDestroyer).TransformAction = SupportedSpell(AID.ShadowOfTheDestroyer).TransformAction = () => ActionID.MakeSpell(_state.BestShadowOfTheDestroyer);
             SupportedSpell(AID.MasterfulBlitz).TransformAction = () => ActionID.MakeSpell(_state.BestBlitz);
+            SupportedSpell(AID.PerfectBalance).Condition = _ => _state.PerfectBalanceLeft == 0;
 
             _config.Modified += OnConfigModified;
             OnConfigModified(null, EventArgs.Empty);

--- a/BossMod/Autorotation/SAM/SAMActions.cs
+++ b/BossMod/Autorotation/SAM/SAMActions.cs
@@ -185,6 +185,13 @@ namespace BossMod.SAM
             _state.MeikyoLeft = StatusDetails(Player, SID.MeikyoShisui, Player.InstanceID).Left;
             _state.OgiNamikiriLeft = StatusDetails(Player, SID.OgiNamikiriReady, Player.InstanceID).Left;
 
+            _state.LostExcellenceLeft = MathF.Max(
+                StatusDetails(Player, SID.LostExcellence, Player.InstanceID).Left,
+                StatusDetails(Player, SID.Memorable, Player.InstanceID).Left
+            );
+            _state.FoPLeft = StatusDetails(Player, SID.LostFontofPower, Player.InstanceID).Left;
+            _state.HsacLeft = StatusDetails(Player, SID.BannerHonoredSacrifice, Player.InstanceID).Left;
+
             _state.TargetHiganbanaLeft = _strategy.ForbidDOTs
                 ? float.MaxValue
                 : StatusDetails(Autorot.PrimaryTarget, SID.Higanbana, Player.InstanceID).Left;

--- a/BossMod/Autorotation/SAM/SAMActions.cs
+++ b/BossMod/Autorotation/SAM/SAMActions.cs
@@ -23,6 +23,7 @@ namespace BossMod.SAM
             _strategy = new();
 
             SupportedSpell(AID.Iaijutsu).TransformAction = () => ActionID.MakeSpell(_state.BestIai);
+            SupportedSpell(AID.MeikyoShisui).Condition = _ => _state.MeikyoLeft == 0;
 
             _config.Modified += OnConfigModified;
             OnConfigModified(null, EventArgs.Empty);

--- a/BossMod/Autorotation/SAM/SAMDefinitions.cs
+++ b/BossMod/Autorotation/SAM/SAMDefinitions.cs
@@ -104,6 +104,11 @@ namespace BossMod.SAM
         Bloodbath = 84, // applied by Bloodbath to self, lifesteal
         Feint = 1195, // applied by Feint to target, 30% phys and -5% magic damage dealt
         Stun = 2, // applied by Leg Sweep to target
+
+        LostFontofPower = 2346,
+        BannerHonoredSacrifice = 2327,
+        LostExcellence = 2564,
+        Memorable = 2565,
     }
 
     public static class Definitions

--- a/BossMod/Autorotation/SAM/SAMRotation.cs
+++ b/BossMod/Autorotation/SAM/SAMRotation.cs
@@ -23,6 +23,10 @@ namespace BossMod.SAM
             public bool HasMoonSen;
             public bool HasFlowerSen;
 
+            public float LostExcellenceLeft; // 60(?) max
+            public float FoPLeft; // 30 max
+            public float HsacLeft; // 15 max
+
             public float GCDTime; // TODO: should be moved to base state
             public float LastTsubame; // can be infinite
 

--- a/BossMod/Autorotation/SAM/SAMRotation.cs
+++ b/BossMod/Autorotation/SAM/SAMRotation.cs
@@ -41,7 +41,7 @@ namespace BossMod.SAM
             public float NextMeikyoCharge => CD(CDGroup.MeikyoShisui) - 55;
             public float NextTsubameCharge => CD(CDGroup.TsubameGaeshi) - 60;
 
-            public int GCDsUntilNextTsubame => (int)MathF.Ceiling((NextTsubameCharge - GCD) / AttackGCDTime);
+            public int GCDsUntilNextTsubame => (int)MathF.Ceiling(NextTsubameCharge / AttackGCDTime);
 
             public bool Unlocked(AID aid) => Definitions.Unlocked(aid, Level, UnlockProgress);
 


### PR DESCRIPTION
I removed the constraint for level 90 but didn't change much other than some tweaking for higanbana/tsubame timing. I've had requests to unlock SAM for testing so here it is. This also adds smart AOE behavior like MNK.