### PR TITLE
added auto recording of replays

### DIFF
--- a/BossMod/Config/ConfigNode.cs
+++ b/BossMod/Config/ConfigNode.cs
@@ -60,6 +60,22 @@ namespace BossMod
         }
     }
 
+    // attribute that specifies slider should be used for displaying float property
+    [AttributeUsage(AttributeTargets.Field)]
+    public class PropertyIntSliderAttribute : Attribute
+    {
+        public float Speed = 1;
+        public int Min;
+        public int Max;
+        public bool Logarithmic;
+
+        public PropertyIntSliderAttribute(int min, int max)
+        {
+            Min = min;
+            Max = max;
+        }
+    }
+
     // base class for configuration nodes
     public abstract class ConfigNode
     {

--- a/BossMod/Config/ConfigUI.cs
+++ b/BossMod/Config/ConfigUI.cs
@@ -154,6 +154,7 @@ namespace BossMod
                         bool v => DrawProperty(props, n.Node, field, v),
                         Enum v => DrawProperty(props, n.Node, field, v),
                         float v => DrawProperty(props, n.Node, field, v),
+                        int v => DrawProperty(props, n.Node, field, v),
                         GroupAssignment v => DrawProperty(props, n.Node, field, v),
                         _ => false
                     };
@@ -216,6 +217,31 @@ namespace BossMod
             else
             {
                 if (ImGui.InputFloat(props.Label, ref v))
+                {
+                    member.SetValue(node, v);
+                    node.NotifyModified();
+                }
+            }
+            return true;
+        }
+
+        private bool DrawProperty(PropertyDisplayAttribute props, ConfigNode node, FieldInfo member, int v)
+        {
+            var slider = member.GetCustomAttribute<PropertyIntSliderAttribute>();
+            if (slider != null)
+            {
+                var flags = ImGuiSliderFlags.None;
+                if (slider.Logarithmic)
+                    flags |= ImGuiSliderFlags.Logarithmic;
+                if (ImGui.DragInt(props.Label, ref v, slider.Speed, slider.Min, slider.Max, "%d", flags))
+                {
+                    member.SetValue(node, v);
+                    node.NotifyModified();
+                }
+            }
+            else
+            {
+                if (ImGui.InputInt(props.Label, ref v))
                 {
                     member.SetValue(node, v);
                     node.NotifyModified();

--- a/BossMod/Framework/Plugin.cs
+++ b/BossMod/Framework/Plugin.cs
@@ -4,6 +4,7 @@ using Dalamud.Game.Command;
 using Dalamud.IoC;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
+using FFXIVClientStructs.FFXIV.Client.Game;
 using System;
 using System.Reflection;
 
@@ -48,6 +49,7 @@ namespace BossMod
             Service.Condition.ConditionChange += OnConditionChanged;
             Service.DutyState.DutyStarted += OnDutyStarted;
             Service.DutyState.DutyCompleted += OnDutyCompleted;
+            Service.ClientState.TerritoryChanged += OnZoneChange;
             MultiboxUnlock.Exec();
             Network.IDScramble.Initialize();
             Camera.Instance = new();
@@ -86,6 +88,7 @@ namespace BossMod
             Service.Condition.ConditionChange -= OnConditionChanged;
             Service.DutyState.DutyStarted -= OnDutyStarted;
             Service.DutyState.DutyCompleted -= OnDutyCompleted;
+            Service.ClientState.TerritoryChanged -= OnZoneChange;
             _wndDebug.Dispose();
             _wndReplay.Dispose();
             _wndBossmodHints.Dispose();
@@ -175,6 +178,21 @@ namespace BossMod
         {
             if (!Service.Config.Get<ReplayManagementConfig>().AutoStop) return;
             _wndReplay.StopRecording();
+        }
+
+        private unsafe void OnZoneChange(ushort obj)
+        {
+            if (GameMain.Instance()->CurrentContentFinderConditionId != 0 && !_wndReplay.IsRecording() && Service.Config.Get<ReplayManagementConfig>().AutoRecord)
+            {
+                _wndReplay.StartRecording();
+                return;
+            }
+
+            if (_wndReplay.IsRecording() && Service.Config.Get<ReplayManagementConfig>().AutoStop)
+            {
+                _wndReplay.StopRecording();
+                return;
+            }
         }
     }
 }

--- a/BossMod/Framework/Plugin.cs
+++ b/BossMod/Framework/Plugin.cs
@@ -47,8 +47,6 @@ namespace BossMod
             Service.WindowSystem = new("vbm");
             //Service.Device = pluginInterface.UiBuilder.Device;
             Service.Condition.ConditionChange += OnConditionChanged;
-            Service.DutyState.DutyStarted += OnDutyStarted;
-            Service.DutyState.DutyCompleted += OnDutyCompleted;
             Service.ClientState.TerritoryChanged += OnZoneChange;
             MultiboxUnlock.Exec();
             Network.IDScramble.Initialize();
@@ -86,8 +84,6 @@ namespace BossMod
         public void Dispose()
         {
             Service.Condition.ConditionChange -= OnConditionChanged;
-            Service.DutyState.DutyStarted -= OnDutyStarted;
-            Service.DutyState.DutyCompleted -= OnDutyCompleted;
             Service.ClientState.TerritoryChanged -= OnZoneChange;
             _wndDebug.Dispose();
             _wndReplay.Dispose();
@@ -166,18 +162,6 @@ namespace BossMod
         private void OnConditionChanged(ConditionFlag flag, bool value)
         {
             Service.Log($"Condition chage: {flag}={value}");
-        }
-
-        private void OnDutyStarted(object? sender, ushort e)
-        {
-            if (!Service.Config.Get<ReplayManagementConfig>().AutoRecord) return;
-            _wndReplay.StartRecording();
-        }
-
-        private void OnDutyCompleted(object? sender, ushort e)
-        {
-            if (!Service.Config.Get<ReplayManagementConfig>().AutoStop) return;
-            _wndReplay.StopRecording();
         }
 
         private unsafe void OnZoneChange(ushort obj)

--- a/BossMod/Framework/Plugin.cs
+++ b/BossMod/Framework/Plugin.cs
@@ -46,6 +46,8 @@ namespace BossMod
             Service.WindowSystem = new("vbm");
             //Service.Device = pluginInterface.UiBuilder.Device;
             Service.Condition.ConditionChange += OnConditionChanged;
+            Service.DutyState.DutyStarted += OnDutyStarted;
+            Service.DutyState.DutyCompleted += OnDutyCompleted;
             MultiboxUnlock.Exec();
             Network.IDScramble.Initialize();
             Camera.Instance = new();
@@ -82,6 +84,8 @@ namespace BossMod
         public void Dispose()
         {
             Service.Condition.ConditionChange -= OnConditionChanged;
+            Service.DutyState.DutyStarted -= OnDutyStarted;
+            Service.DutyState.DutyCompleted -= OnDutyCompleted;
             _wndDebug.Dispose();
             _wndReplay.Dispose();
             _wndBossmodHints.Dispose();
@@ -159,6 +163,18 @@ namespace BossMod
         private void OnConditionChanged(ConditionFlag flag, bool value)
         {
             Service.Log($"Condition chage: {flag}={value}");
+        }
+
+        private void OnDutyStarted(object? sender, ushort e)
+        {
+            if (!Service.Config.Get<ReplayManagementConfig>().AutoRecord) return;
+            _wndReplay.StartRecording();
+        }
+
+        private void OnDutyCompleted(object? sender, ushort e)
+        {
+            if (!Service.Config.Get<ReplayManagementConfig>().AutoStop) return;
+            _wndReplay.StopRecording();
         }
     }
 }

--- a/BossMod/Framework/Service.cs
+++ b/BossMod/Framework/Service.cs
@@ -27,6 +27,7 @@ namespace BossMod
         [PluginService] public static IFramework Framework { get; private set; }
         [PluginService] public static ITextureProvider Texture { get; private set; }
         [PluginService] public static ICommandManager CommandManager { get; private set; }
+        [PluginService] public static IDutyState DutyState { get; private set; }
         [PluginService] public static DalamudPluginInterface PluginInterface { get; private set; }
 #pragma warning restore CS8618
 

--- a/BossMod/Replay/ReplayManagementConfig.cs
+++ b/BossMod/Replay/ReplayManagementConfig.cs
@@ -6,6 +6,12 @@
         [PropertyDisplay("Show replay management UI")]
         public bool ShowUI = false;
 
+        [PropertyDisplay("Auto record replays on duty start")]
+        public bool AutoRecord = false;
+
+        [PropertyDisplay("Auto stop replays on duty end")]
+        public bool AutoStop = false;
+
         [PropertyDisplay("Store server packets in the replay")]
         public bool DumpServerPackets = false;
 

--- a/BossMod/Replay/ReplayManagementConfig.cs
+++ b/BossMod/Replay/ReplayManagementConfig.cs
@@ -12,6 +12,10 @@
         [PropertyDisplay("Auto stop replays on duty end")]
         public bool AutoStop = false;
 
+        [PropertyDisplay("Max replays to keep before removal")]
+        [PropertyIntSlider(0, 1000, Speed = 1f, Logarithmic = false)]
+        public int MaxReplays = 0;
+
         [PropertyDisplay("Store server packets in the replay")]
         public bool DumpServerPackets = false;
 

--- a/BossMod/Replay/ReplayManagementWindow.cs
+++ b/BossMod/Replay/ReplayManagementWindow.cs
@@ -126,6 +126,8 @@ namespace BossMod
             }
         }
 
+        public bool IsRecording() => _recorder != null;
+
         public override void OnClose()
         {
             SetVisible(false);

--- a/BossMod/Replay/ReplayManagementWindow.cs
+++ b/BossMod/Replay/ReplayManagementWindow.cs
@@ -2,7 +2,6 @@
 using ImGuiNET;
 using Lumina.Excel.GeneratedSheets;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 

--- a/BossMod/Replay/ReplayManagementWindow.cs
+++ b/BossMod/Replay/ReplayManagementWindow.cs
@@ -96,13 +96,11 @@ namespace BossMod
             {
                 try
                 {
-                    IEnumerable<FileInfo> filesToDelete = Enumerable.Empty<FileInfo>();
                     if (_config.MaxReplays > 0)
-                        if (_logDir.GetFiles().Length >= _config.MaxReplays)
-                            filesToDelete = _logDir.GetFiles().OrderBy(f => f.LastWriteTime).Take(_logDir.GetFiles().Length - _config.MaxReplays);
-                    if (filesToDelete != null)
-                        foreach (var f in filesToDelete)
-                            f.Delete();
+                    {
+                        var files = _logDir.GetFiles().OrderBy(f => f.LastWriteTime).ToList();
+                        files.Take(files.Count - _config.MaxReplays).ToList().ForEach(f => f.Delete());
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/BossMod/Replay/ReplayManagementWindow.cs
+++ b/BossMod/Replay/ReplayManagementWindow.cs
@@ -2,6 +2,7 @@
 using ImGuiNET;
 using Lumina.Excel.GeneratedSheets;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -93,6 +94,21 @@ namespace BossMod
         {
             if (_recorder == null)
             {
+                try
+                {
+                    IEnumerable<FileInfo> filesToDelete = Enumerable.Empty<FileInfo>();
+                    if (_config.MaxReplays > 0)
+                        if (_logDir.GetFiles().Length >= _config.MaxReplays)
+                            filesToDelete = _logDir.GetFiles().OrderBy(f => f.LastWriteTime).Take(_logDir.GetFiles().Length - _config.MaxReplays);
+                    if (filesToDelete != null)
+                        foreach (var f in filesToDelete)
+                            f.Delete();
+                }
+                catch (Exception ex)
+                {
+                    Service.Log($"Failed to delete old replays: {ex}");
+                }
+
                 try
                 {
                     _recorder = new(_ws, _config.WorldLogFormat, true, _logDir, $"{GetPrefix()}");


### PR DESCRIPTION
options to auto start/stop on duty start/end

changed replay files to be prefixed by the duty name (or zone name if that doesn't exist) instead of "World"
It also adds the appends the duty finder settings (unrestricted, level sync, min ilvl, no echo) as comma separated values after the instance name so `the Bowl of Embers_U,NE_2024_03_22_20_18_27.log` as an example