### PR TITLE
ff16 collab fix

### DIFF
--- a/BossMod/Modules/Global/Quest/FF16Collab/InfernalShadow.cs
+++ b/BossMod/Modules/Global/Quest/FF16Collab/InfernalShadow.cs
@@ -71,7 +71,7 @@ class FireRampageCleave : Components.GenericAOEs
         if ((AID)spell.Action.ID is AID.FieryRampageCleaveReal or AID.FieryRampageCleaveReal2)
         {
             _castersunsorted.Add((caster.Position, spell.Rotation, spell.NPCFinishAt, spell.Action.ID)); //casters appear in random order in raw ops
-            _casters = _castersunsorted.OrderBy(x => x.AID).Select(x => (x.position, x.rotation,x.activation)).ToList();
+            _casters = _castersunsorted.OrderBy(x => x.AID).Select(x => (x.position, x.rotation, x.activation)).ToList();
         }
     }
 


### PR DESCRIPTION
Seems like the casters of the left/right cleave can appear in random order in the raw ops, this will hopefully fix the issue by sorting casters by AID