### PR TITLE
fix for replay filenames

### DIFF
--- a/BossMod/Framework/Utils.cs
+++ b/BossMod/Framework/Utils.cs
@@ -342,4 +342,11 @@ public static class Utils
         v = Regex.Replace(v, "[^a-zA-Z0-9]", "");
         return v;
     }
+
+    // remove illegal characters from a filename
+    public static string CleanFilename(string filename)
+    {
+        var illegalChars = "[<>:\"/\\|?*]";
+        return Regex.Replace(filename, illegalChars, string.Empty);
+    }
 }

--- a/BossMod/Replay/ReplayManagementWindow.cs
+++ b/BossMod/Replay/ReplayManagementWindow.cs
@@ -171,6 +171,6 @@ public class ReplayManagementWindow : UIWindow
         if (cf->IsSilenceEcho)
             prefix += "_NE";
 
-        return prefix;
+        return Utils.CleanFilename(prefix);
     }
 }


### PR DESCRIPTION
forgot that some duties have illegal characters in them which results in a failure to create a replay file for those instances