### PR TITLE
TOP p1-p3 adjustments for aether strats

### DIFF
--- a/BossMod/Modules/Endwalker/Ultimate/TOP/P1Pantokrator.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/TOP/P1Pantokrator.cs
@@ -25,7 +25,13 @@ class P1FlameThrower(BossModule module) : Components.GenericAOEs(module)
         var group = _pantokrator != null ? _pantokrator.PlayerStates[pcSlot].Group : 0;
         if (group > 0)
         {
-            var dir = (Casters[0].CastInfo!.Rotation - Module.PrimaryActor.Rotation).Normalized().Deg switch
+            var nesw = Service.Config.Get<TOPConfig>().P1PantokratorNESW;
+            var flame1Dir = Casters[0].CastInfo!.Rotation - Module.PrimaryActor.Rotation;
+            if (nesw)
+                // if NE/SW, treat flamethrower as offset by 45 degrees, since NE/1 marker is pivot point instead of true north/A marker
+                flame1Dir += 45.Degrees();
+
+            var dir = flame1Dir.Normalized().Deg switch
             {
                 (> 15 and < 45) or (> -165 and < -135) => -60.Degrees(),
                 (> 45 and < 75) or (> -135 and < -105) => -30.Degrees(),
@@ -34,6 +40,9 @@ class P1FlameThrower(BossModule module) : Components.GenericAOEs(module)
                 (> 135 and < 165) or (> -45 and < -15) => 60.Degrees(),
                 _ => -90.Degrees(), // assume groups go CW
             };
+            if (nesw)
+                // if NE/SW, the set of correct safespots is offset from the N/S ones by 60 degrees, i.e. one flamethrower rotation
+                dir -= 60.Degrees();
             var offset = 12 * (Module.PrimaryActor.Rotation + dir).ToDirection();
             var pos = group == 1 ? Module.Center + offset : Module.Center - offset;
             Arena.AddCircle(pos, 1, ArenaColor.Safe);

--- a/BossMod/Modules/Endwalker/Ultimate/TOP/P1Pantokrator.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/TOP/P1Pantokrator.cs
@@ -27,9 +27,9 @@ class P1FlameThrower(BossModule module) : Components.GenericAOEs(module)
         {
             var nesw = Service.Config.Get<TOPConfig>().P1PantokratorNESW;
             var flame1Dir = Casters[0].CastInfo!.Rotation - Module.PrimaryActor.Rotation;
+            // if ne/sw, set of safe cones is offset by 1 rotation
             if (nesw)
-                // if NE/SW, treat flamethrower as offset by 45 degrees, since NE/1 marker is pivot point instead of true north/A marker
-                flame1Dir += 45.Degrees();
+                flame1Dir += 60.Degrees();
 
             var dir = flame1Dir.Normalized().Deg switch
             {
@@ -40,8 +40,8 @@ class P1FlameThrower(BossModule module) : Components.GenericAOEs(module)
                 (> 135 and < 165) or (> -45 and < -15) => 60.Degrees(),
                 _ => -90.Degrees(), // assume groups go CW
             };
+            // undo direction adjustment to correct target safe spot
             if (nesw)
-                // if NE/SW, the set of correct safespots is offset from the N/S ones by 60 degrees, i.e. one flamethrower rotation
                 dir -= 60.Degrees();
             var offset = 12 * (Module.PrimaryActor.Rotation + dir).ToDirection();
             var pos = group == 1 ? Module.Center + offset : Module.Center - offset;

--- a/BossMod/Modules/Endwalker/Ultimate/TOP/P3OversampledWaveCannon.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/TOP/P3OversampledWaveCannon.cs
@@ -85,20 +85,30 @@ class P3OversampledWaveCannon(BossModule module) : BossComponent(module)
         if (_numPlayerAngles < 3 || _bossAngle == default)
             yield break;
 
+        var m3South = Service.Config.Get<TOPConfig>().P3LastMonitorSouth;
+
         WPos adjust(float x, float z) => Module.Center + new WDir(_bossAngle.Rad < 0 ? -x : x, z);
         if (IsMonitor(slot))
         {
-            yield return (adjust(10, -11), _playerOrder[slot] == 1);
-            yield return (adjust(-11, -9), _playerOrder[slot] == 2);
-            yield return (adjust(-11, +9), _playerOrder[slot] == 3);
+            var nextSlot = 0;
+            if (!m3South)
+                yield return (adjust(10, -11), _playerOrder[slot] == ++nextSlot);
+            yield return (adjust(-11, -9), _playerOrder[slot] == ++nextSlot);
+            yield return (adjust(-11, +9), _playerOrder[slot] == ++nextSlot);
+            if (m3South)
+                yield return (adjust(10, 11), _playerOrder[slot] == ++nextSlot);
         }
         else
         {
-            yield return (adjust(1, -15), _playerOrder[slot] == 1);
-            yield return (adjust(15, -4), _playerOrder[slot] == 2);
-            yield return (adjust(15, +4), _playerOrder[slot] == 3);
-            yield return (adjust(10, 11), _playerOrder[slot] == 4);
-            yield return (adjust(1, 15), _playerOrder[slot] == 5);
+            var nextSlot = 0;
+            yield return (adjust(1, -15), _playerOrder[slot] == ++nextSlot);
+            if (m3South)
+                yield return (adjust(10, -11), _playerOrder[slot] == ++nextSlot);
+            yield return (adjust(15, -4), _playerOrder[slot] == ++nextSlot);
+            yield return (adjust(15, +4), _playerOrder[slot] == ++nextSlot);
+            if (!m3South)
+                yield return (adjust(10, 11), _playerOrder[slot] == ++nextSlot);
+            yield return (adjust(1, 15), _playerOrder[slot] == ++nextSlot);
         }
     }
 

--- a/BossMod/Modules/Endwalker/Ultimate/TOP/TOPConfig.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/TOP/TOPConfig.cs
@@ -53,6 +53,10 @@ public class TOPConfig() : CooldownPlanningConfigNode(90)
     [GroupPreset("LPDU (HTMR)", [2, 3, 0, 1, 4, 5, 6, 7])]
     public GroupAssignmentUnique P3MonitorsAssignments = new() { Assignments = [2, 3, 0, 1, 4, 5, 6, 7] };
 
+    [PropertyDisplay("P3 Monitors: position for safe side monitor")]
+    [PropertyCombo("North (LPDU)", "South (Aether)")]
+    public bool P3LastMonitorSouth = false;
+
     [PropertyDisplay("P4 Wave Cannon: priority, from North to South (assuming south flex)")]
     [GroupDetails(["W1", "E1", "W2", "E2", "W3", "E3", "W4", "E4"])]
     [GroupPreset("LPDU (TRHM)", [0, 1, 4, 5, 6, 7, 2, 3])]

--- a/BossMod/Modules/Endwalker/Ultimate/TOP/TOPConfig.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/TOP/TOPConfig.cs
@@ -16,6 +16,10 @@ public class TOPConfig() : CooldownPlanningConfigNode(90)
     [GroupPreset("LPDU (light parties): flex T>M>R", [0, 4, 3, 7, 1, 5, 2, 6])]
     public GroupAssignmentUnique P1PantokratorAssignments = new() { Assignments = [0, 4, 3, 7, 1, 5, 2, 6] };
 
+    [PropertyDisplay("P1 Pantokrator: group positions")]
+    [PropertyCombo("North/South", "NE/SW")]
+    public bool P1PantokratorNESW = false;
+
     [PropertyDisplay("P1 Pantokrator: use global priority instead - consider G1 lower-numbered than G2 (so G1 more likely to flex)")]
     public bool P1PantokratorGlobalPriority = false;
 
@@ -26,6 +30,14 @@ public class TOPConfig() : CooldownPlanningConfigNode(90)
 
     [PropertyDisplay("P2 Party Synergy: use global priority instead - consider G1 lower-numbered than G2 (so G1 more likely to flex)")]
     public bool P2PartySynergyGlobalPriority = false;
+
+    [PropertyDisplay("P2 Party Synergy: G2 order for Remote Glitch (far tether)")]
+    [PropertyCombo("GPOB (only B and G swap)", "GOPB (reverse order)")]
+    public bool P2PartySynergyG2ReverseAll = true;
+
+    [PropertyDisplay("P2 Party Synergy: Swap priority if both stacks are in the same group")]
+    [PropertyCombo("Northernmost pair", "Southernmost pair")]
+    public bool P2PartySynergyStackSwapSouth = true;
 
     [PropertyDisplay("P3 Intermission: spread/stack spot assignments, from West to East")]
     [GroupDetails(["1", "2", "3", "4", "5", "6", "7", "8"])]


### PR DESCRIPTION
NA raid community aka Aether generally uses Sausage Roll's strats for TOP

P1 toolbox: https://ff14.toolboxgaming.space/?id=758088204654761&preview=1
P2 toolbox: https://ff14.toolboxgaming.space/?id=043186470764761&preview=1
P3 monitors raidplan: https://raidplan.io/plan/om8w5ea548ajBE45

differences from existing module:

1. Group numbers for P1 are inverted - G1 is NW CCW, G2 is N CW - I didn't change this because I figured it would be too much trouble for a purely aesthetic change, the existing module does priority fine
2. Pivot point for Pantokrator safe spots is NE/SW instead of N/S
3. Party Synergy G2 order for Remote Glitch is GPOB - purple and orange don't swap, they just go to arena edge
4. Swap priority for P2 flare stacks is north rather than south
5. 3rd monitor positions vertically south, instead of 1st monitor positioning vertically north - prio works the same way

There are presumably additional differences in later phases but I haven't gotten that far since I prog in PF