### PR TITLE
GNB Gauge changes

### DIFF
--- a/BossMod/Autorotation/GNB/GNBRotation.cs
+++ b/BossMod/Autorotation/GNB/GNBRotation.cs
@@ -602,11 +602,11 @@ public static class Rotation
 
     public static bool ShouldUseNoMercy(State state, Strategy strategy)
     {
-        if (strategy.NoMercyUse == Strategy.OffensiveAbilityUse.Delay)
+        if (strategy.NoMercyUse == CommonRotation.Strategy.OffensiveAbilityUse.Delay)
         {
             return false;
         }
-        else if (strategy.NoMercyUse == Strategy.OffensiveAbilityUse.Force)
+        else if (strategy.NoMercyUse == CommonRotation.Strategy.OffensiveAbilityUse.Force)
         {
             return true;
         }
@@ -642,25 +642,25 @@ public static class Rotation
 
     public static bool ShouldUseGnash(State state, Strategy strategy) => strategy.GnashUse switch
     {
-        Strategy.OffensiveAbilityUse.Delay => false,
-        Strategy.OffensiveAbilityUse.Force => true,
+        CommonRotation.Strategy.OffensiveAbilityUse.Delay => false,
+        CommonRotation.Strategy.OffensiveAbilityUse.Force => true,
         _ => strategy.CombatTimer >= 0 && state.TargetingEnemy && state.Unlocked(AID.GnashingFang) && state.CD(CDGroup.GnashingFang) < 0.6f && state.Ammo >= 1
     };
 
     public static bool ShouldUseZone(State state, Strategy strategy) => strategy.ZoneUse switch
     {
-        Strategy.OffensiveAbilityUse.Delay => false,
-        Strategy.OffensiveAbilityUse.Force => true,
+        CommonRotation.Strategy.OffensiveAbilityUse.Delay => false,
+        CommonRotation.Strategy.OffensiveAbilityUse.Force => true,
         _ => strategy.CombatTimer >= 0 && state.TargetingEnemy && state.Unlocked(AID.SonicBreak) && state.CD(CDGroup.SonicBreak) > state.AnimationLock && state.CD(CDGroup.NoMercy) > 17
     };
 
     public static bool ShouldUseFest(State state, Strategy strategy)
     {
-        if (strategy.BloodFestUse == Strategy.OffensiveAbilityUse.Delay)
+        if (strategy.BloodFestUse == CommonRotation.Strategy.OffensiveAbilityUse.Delay)
         {
             return false;
         }
-        else if (strategy.BloodFestUse == Strategy.OffensiveAbilityUse.Force)
+        else if (strategy.BloodFestUse == CommonRotation.Strategy.OffensiveAbilityUse.Force)
         {
             return true;
         }
@@ -677,8 +677,8 @@ public static class Rotation
 
     public static bool ShouldUseBow(State state, Strategy strategy) => strategy.BowUse switch
     {
-        Strategy.OffensiveAbilityUse.Delay => false,
-        Strategy.OffensiveAbilityUse.Force => true,
+        CommonRotation.Strategy.OffensiveAbilityUse.Delay => false,
+        CommonRotation.Strategy.OffensiveAbilityUse.Force => true,
         _ => strategy.CombatTimer >= 0 && state.TargetingEnemy && state.Unlocked(AID.BowShock) && state.CD(CDGroup.SonicBreak) > state.AnimationLock && state.CD(CDGroup.NoMercy) > 40
     };
 


### PR DESCRIPTION
Plenty of changes made inside of the "Gauge" tab in CDPlanner for GNB. 
1. Hold Carts (optimally, works for ST and AOE buttons)
2. Force ST combo
3. Force AOE combo
4. Force full Gnashing Fang combo
5. Spend now has a prio system. It will default to the following: Double Down, Gnashing Fang combo, Burst Strike, Combo if no carts left

Probably considering adding a "Hold Double Down" option, but for now this will do until maybe DT. All have been tested and confirmed working, however if there are any issues, feel free. 