### PR TITLE
[TOP] P5 Delta Rocket Punch corner case

### DIFF
--- a/BossMod/Modules/Endwalker/Ultimate/TOP/P5Delta.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/TOP/P5Delta.cs
@@ -238,7 +238,7 @@ class P5Delta(BossModule module) : BossComponent(module)
         if (p.PartnerSlot < 0 || _eyeDir == default)
             yield break; // no safe spots yet
 
-        if (p.RocketPunch == null)
+        if (NumPunchesSpawned < PartyState.MaxPartySize)
         {
             // no punches yet, show all 4 possible spots
             if (p.IsLocal)


### PR DESCRIPTION
P5Delta determines that the rocket punch phase has started once all eight players have a punch actor associated with them. bad positioning or extra movement can result in one player having two punches and another having zero. this is already logged as an error in the module, but the mechanic isn't considered started, so hints are slightly broken until the next boss cast starts.