### PR TITLE
[MNK] Yikes

### DIFF
--- a/BossMod/Autorotation/MNK/MNKRotation.cs
+++ b/BossMod/Autorotation/MNK/MNKRotation.cs
@@ -365,9 +365,9 @@ public static class Rotation
                     && state.Unlocked(AID.FormShift)
                 )
                     return AID.FormShift;
-
-                return AID.None;
             }
+
+            return AID.None;
         }
 
         if (!HaveTarget(state, strategy))


### PR DESCRIPTION
Typo results in attacking the boss if there are 10+ seconds remaining on combat timer and boss is already in range, which can happen in p12s p2 and p8s p2