### PR TITLE
Add Forbid Actions and Movement to the AI config

### DIFF
--- a/BossMod/AI/AIConfig.cs
+++ b/BossMod/AI/AIConfig.cs
@@ -17,4 +17,12 @@ sealed class AIConfig : ConfigNode
 
     [PropertyDisplay("Broadcast keypresses to other windows")]
     public bool BroadcastToSlaves = false;
+
+    [PropertyDisplay("Forbid Movement")]
+    public bool ForbidMovement = false;
+
+    [PropertyDisplay("Forbid Actions")]
+    public bool ForbidActions = false;
+
+
 }


### PR DESCRIPTION
This is useful when using together with AutoDuty to disable AoE dodges on bosses without modules, having it just following the NPCs that (most of the times) knows how to resolve a mechanics.