### PR TITLE
Add new IPC HasModuleByDataId with primitive data type

### DIFF
--- a/BossMod/Framework/IPCProvider.cs
+++ b/BossMod/Framework/IPCProvider.cs
@@ -16,6 +16,7 @@ sealed class IPCProvider : IDisposable
         Register("ActiveModuleHasComponent", (string name) => autorotation.Bossmods.ActiveModule?.Components.Any(c => c.GetType().Name == name || c.GetType().BaseType?.Name == name) ?? false);
 
         Register("HasModule", (IGameObject obj) => ModuleRegistry.FindByOID(obj.DataId) != null);
+        Register("HasModuleByDataId", (uint dataId) => ModuleRegistry.FindByOID(dataId) != null);
         Register("IsMoving", autorotation.ActionManager.InputOverride.IsMoving);
         Register("ForbiddenZonesCount", () => autorotation.Hints.ForbiddenZones.Count);
         //Register("InitiateCombat", () => autorotation.ClassActions?.UpdateAutoAction(CommonActions.AutoActionAIFight, float.MaxValue, true));


### PR DESCRIPTION
I'm not too sure since when sending an `IGameObject` over IPC doesn't work anymore, or if it every has, but currently it doesn't.
For example, using the plugin AutoDuty (which calls the `HasModule` IPC from Bossmod) throws lots of exceptions, because Dalamud can't serialize the `IGameObject`:
```
2024-07-06 23:24:55.251 +02:00 [ERR] Exception during raise of Void <InvokeSafely>b__0()
Newtonsoft.Json.JsonSerializationException: Self referencing loop detected for property 'SourceObject' with type 'Dalamud.Game.ClientState.Objects.SubKinds.PlayerCharacter'. Path 'StatusList[1]'.
   at Newtonsoft.Json.Serialization.JsonSerializerInternalWriter.CheckForCircularReference(JsonWriter writer, Object value, JsonProperty property, JsonContract contract, JsonContainerContract containerContract, JsonProperty containerProperty)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalWriter.SerializeObject(JsonWriter writer, Object value, JsonObjectContract contract, JsonProperty member, JsonContainerContract collectionContract, JsonProperty containerProperty)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalWriter.SerializeList(JsonWriter writer, IEnumerable values, JsonArrayContract contract, JsonProperty member, JsonContainerContract collectionContract, JsonProperty containerProperty)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalWriter.SerializeObject(JsonWriter writer, Object value, JsonObjectContract contract, JsonProperty member, JsonContainerContract collectionContract, JsonProperty containerProperty)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalWriter.Serialize(JsonWriter jsonWriter, Object value, Type objectType)
   at Newtonsoft.Json.JsonSerializer.SerializeInternal(JsonWriter jsonWriter, Object value, Type objectType)
   at Newtonsoft.Json.JsonConvert.SerializeObjectInternal(Object value, Type type, JsonSerializer jsonSerializer)
   at Dalamud.Plugin.Ipc.Internal.CallGateChannel.ConvertObject(Object obj, Type type) in C:\goatsoft\companysecrets\dalamud\Plugin\Ipc\Internal\CallGateChannel.cs:line 209
   at Dalamud.Plugin.Ipc.Internal.CallGateChannel.CheckAndConvertArgs(Object[] args, MethodInfo methodInfo) in C:\goatsoft\companysecrets\dalamud\Plugin\Ipc\Internal\CallGateChannel.cs:line 190
   at Dalamud.Plugin.Ipc.Internal.CallGateChannel.InvokeFunc[TRet](Object[] args) in C:\goatsoft\companysecrets\dalamud\Plugin\Ipc\Internal\CallGateChannel.cs:line 136
   at AutoDuty.Helpers.ObjectHelper.<>c.<GetBossObject>b__10_0(IBattleChara b) in C:\Users\Nico\source\repos\AutoDuty\AutoDuty\Helpers\ObjectHelper.cs:line 42
   at System.Linq.Enumerable.TryGetFirst[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
   at System.Linq.Enumerable.FirstOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
   at AutoDuty.Helpers.ObjectHelper.GetBossObject(Int32 radius) in C:\Users\Nico\source\repos\AutoDuty\AutoDuty\Helpers\ObjectHelper.cs:line 42
   at AutoDuty.AutoDuty.Framework_Update(IFramework framework) in C:\Users\Nico\source\repos\AutoDuty\AutoDuty\AutoDuty.cs:line 682
   at Dalamud.Utility.EventHandlerExtensions.HandleInvoke(Action act) in C:\goatsoft\companysecrets\dalamud\Utility\EventHandlerExtensions.cs:line 124
```

Theoretically, this should be a Dalamud issue, but I doubt that they would fix it, because there are likely many other classes which might have the same problem of self-referencing loops, and it can be easily avoided by just passing the bare-minimum data over the IPC call.
An IPC call with a primitive data type like `uint` (which is enough since we only need to pass the `DataId` of an enemy) works fine and should probably be preferred over serializing a whole `IGameObject` anyway.