### PR TITLE
Added Dawntrail to list of expansions

### DIFF
--- a/BossMod/BossModule/BossModuleInfo.cs
+++ b/BossMod/BossModule/BossModuleInfo.cs
@@ -21,6 +21,7 @@ public static class BossModuleInfo
         Stormblood,
         Shadowbringers,
         Endwalker,
+        Dawntrail,
         Global,
 
         Count
@@ -75,6 +76,7 @@ public static class BossModuleInfo
         Expansion.Stormblood => "SB",
         Expansion.Shadowbringers => "ShB",
         Expansion.Endwalker => "EW",
+        Expansion.Dawntrail => "DT",
         _ => e.ToString()
     };
 }

--- a/BossMod/Config/ModuleViewer.cs
+++ b/BossMod/Config/ModuleViewer.cs
@@ -45,6 +45,7 @@ public sealed class ModuleViewer : IDisposable
         Customize(BossModuleInfo.Expansion.Stormblood, 61877, exVersion?.GetRow(2)?.Name);
         Customize(BossModuleInfo.Expansion.Shadowbringers, 61878, exVersion?.GetRow(3)?.Name);
         Customize(BossModuleInfo.Expansion.Endwalker, 61879, exVersion?.GetRow(4)?.Name);
+        Customize(BossModuleInfo.Expansion.Dawntrail, 61880, exVersion?.GetRow(5)?.Name);
 
         var contentType = Service.LuminaSheet<ContentType>();
         Customize(BossModuleInfo.Category.Dungeon, contentType?.GetRow(2));


### PR DESCRIPTION
I added Dawntrail (and the icon for it) to the list of expansions on the left side of the settings menu.

![image](https://github.com/awgil/ffxiv_bossmod/assets/1828486/dee92251-4cb6-4013-a38d-e0fcfd0dcba3)