### PR TITLE
Fix issue causing TankAI to throw an exception for GNB and PLD

### DIFF
--- a/BossMod/Autorotation/xan/AI/Tank.cs
+++ b/BossMod/Autorotation/xan/AI/Tank.cs
@@ -83,7 +83,7 @@ public class TankAI(RotationModuleManager manager, Actor player) : AIBase(manage
 
         var attackers = EnemiesAutoingMe.Count();
 
-        if (strategy.Enabled(Track.Mit) && attackers > 0)
+        if (/*strategy.Enabled(Track.Mit) && */attackers > 0)
         {
             if (gauge.OathGauge >= 50 && HPRatio < 0.8)
                 Hints.ActionsToExecute.Push(ActionID.MakeSpell(BossMod.PLD.AID.Sheltron), Player, ActionQueue.Priority.Minimal);
@@ -97,7 +97,7 @@ public class TankAI(RotationModuleManager manager, Actor player) : AIBase(manage
     {
         var attackers = EnemiesAutoingMe.Count();
 
-        if (strategy.Enabled(Track.Mit) && attackers > 0)
+        if (/*strategy.Enabled(Track.Mit) && */attackers > 0)
         {
             if (HPRatio < 0.8 && Cooldown(BossMod.GNB.AID.HeartOfCorundum) == 0)
                 Hints.ActionsToExecute.Push(ActionID.MakeSpell(BossMod.GNB.AID.HeartOfCorundum), Player, ActionQueue.Priority.Minimal);

--- a/BossMod/Autorotation/xan/AI/Tank.cs
+++ b/BossMod/Autorotation/xan/AI/Tank.cs
@@ -4,7 +4,7 @@ namespace BossMod.Autorotation.xan;
 
 public class TankAI(RotationModuleManager manager, Actor player) : AIBase(manager, player)
 {
-    public enum Track { Stance, Ranged, Interject, Stun, ArmsLength, Mit, Invuln }
+    public enum Track { Stance, Ranged, Interject, Stun, ArmsLength, Mit, Invuln, Protect }
     public static RotationModuleDefinition Definition()
     {
         var def = new RotationModuleDefinition("Tank AI", "Utilities for tank AI - stance, provoke, interrupt, ranged attack", "xan", RotationModuleQuality.Basic, BitMask.Build(Class.PLD, Class.GLA, Class.WAR, Class.MRD, Class.DRK, Class.GNB), 100);
@@ -14,8 +14,9 @@ public class TankAI(RotationModuleManager manager, Actor player) : AIBase(manage
         def.AbilityTrack(Track.Interject, "Interject").AddAssociatedActions(ClassShared.AID.Interject);
         def.AbilityTrack(Track.Stun, "Low Blow").AddAssociatedActions(ClassShared.AID.LowBlow);
         def.AbilityTrack(Track.ArmsLength, "Arms' Length").AddAssociatedActions(ClassShared.AID.ArmsLength);
-        //def.AbilityTrack(Track.Mit, "Personal mits");
-        //def.AbilityTrack(Track.Invuln, "Invuln");
+        def.AbilityTrack(Track.Mit, "Personal mits");
+        def.AbilityTrack(Track.Invuln, "Invuln");
+        def.AbilityTrack(Track.Protect, "Protect party members");
 
         return def;
     }

--- a/BossMod/Autorotation/xan/AI/Tank.cs
+++ b/BossMod/Autorotation/xan/AI/Tank.cs
@@ -4,7 +4,7 @@ namespace BossMod.Autorotation.xan;
 
 public class TankAI(RotationModuleManager manager, Actor player) : AIBase(manager, player)
 {
-    public enum Track { Stance, Ranged, Interject, Stun, ArmsLength, Mit, Invuln, Protect }
+    public enum Track { Stance, Ranged, Interject, Stun, ArmsLength, Mit, Invuln }
     public static RotationModuleDefinition Definition()
     {
         var def = new RotationModuleDefinition("Tank AI", "Utilities for tank AI - stance, provoke, interrupt, ranged attack", "xan", RotationModuleQuality.Basic, BitMask.Build(Class.PLD, Class.GLA, Class.WAR, Class.MRD, Class.DRK, Class.GNB), 100);
@@ -14,9 +14,8 @@ public class TankAI(RotationModuleManager manager, Actor player) : AIBase(manage
         def.AbilityTrack(Track.Interject, "Interject").AddAssociatedActions(ClassShared.AID.Interject);
         def.AbilityTrack(Track.Stun, "Low Blow").AddAssociatedActions(ClassShared.AID.LowBlow);
         def.AbilityTrack(Track.ArmsLength, "Arms' Length").AddAssociatedActions(ClassShared.AID.ArmsLength);
-        def.AbilityTrack(Track.Mit, "Personal mits");
-        def.AbilityTrack(Track.Invuln, "Invuln");
-        def.AbilityTrack(Track.Protect, "Protect party members");
+        //def.AbilityTrack(Track.Mit, "Personal mits");
+        //def.AbilityTrack(Track.Invuln, "Invuln");
 
         return def;
     }


### PR DESCRIPTION
`if (strategy.Enabled(Track.Mit) && attackers > 0)` was throwing an exception because `def.AbilityTrack(Track.Mit, "Personal mits");` was commented out.