### PR TITLE
add ClassJobLevels to ClientState

### DIFF
--- a/BossMod/ActionQueue/ActionDefinition.cs
+++ b/BossMod/ActionQueue/ActionDefinition.cs
@@ -53,6 +53,7 @@ public sealed record class ActionDefinition(ActionID ID)
     public ActionAspect Aspect; // useful for BLM and BLU
     public int MaxChargesBase; // baseline max-charges when action is unlocked
     public readonly List<(int Charges, int Level, uint UnlockLink)> MaxChargesOverride = []; // trait overrides for max-charges (applied in order)
+    public bool IsRoleAction; // unlocked conditions are different for these
     public float InstantAnimLock = 0.6f; // animation lock if ability is instant-cast
     public float CastAnimLock = 0.1f; // animation lock if ability is non-instant
     public ConditionDelegate? ForbidExecute; // optional condition, if it returns true, action is not executed
@@ -104,6 +105,13 @@ public sealed record class ActionDefinition(ActionID ID)
     }
 
     private static bool LinkUnlocked(uint link) => link == 0 || (ActionDefinitions.Instance.UnlockCheck?.Invoke(link) ?? true);
+
+    public bool IsUnlocked(WorldState ws, Actor player)
+    {
+        var checkLevel = IsRoleAction ? ws.Client.ClassJobLevel(player.Class) : player.Level;
+
+        return AllowedClasses[(int)player.Class] && checkLevel >= MinLevel && (ActionDefinitions.Instance.UnlockCheck?.Invoke(UnlockLink) ?? true);
+    }
 }
 
 // database of all supported player-initiated actions
@@ -329,6 +337,7 @@ public sealed class ActionDefinitions : IDisposable
             MaxChargesBase = SpellBaseMaxCharges(data),
             InstantAnimLock = instantAnimLock,
             CastAnimLock = castAnimLock,
+            IsRoleAction = data?.IsRoleAction ?? false
         };
         Register(aid, def);
     }

--- a/BossMod/ActionQueue/ActionQueue.cs
+++ b/BossMod/ActionQueue/ActionQueue.cs
@@ -51,7 +51,7 @@ public sealed class ActionQueue
                 break; // this and further actions are something we don't really want to execute (prio < minimal)
 
             var def = ActionDefinitions.Instance[candidate.Action];
-            if (def == null || !def.AllowedClasses[(int)player.Class] || player.Level < def.MinLevel || !(ActionDefinitions.Instance.UnlockCheck?.Invoke(def.UnlockLink) ?? true))
+            if (def == null || !def.IsUnlocked(ws, player))
                 continue; // unregistered or locked action
 
             var startDelay = Math.Max(Math.Max(candidate.Delay, animationLock), def.ReadyIn(cooldowns));

--- a/BossMod/Autorotation/RotationModule.cs
+++ b/BossMod/Autorotation/RotationModule.cs
@@ -93,12 +93,7 @@ public abstract class RotationModule(RotationModuleManager manager, Actor player
 
     public virtual string DescribeState() => "";
 
-    // utility to check action/trait unlocks
-    public bool ActionUnlocked(ActionID action)
-    {
-        var def = ActionDefinitions.Instance[action];
-        return def != null && def.AllowedClasses[(int)Player.Class] && Player.Level >= def.MinLevel && (ActionDefinitions.Instance.UnlockCheck?.Invoke(def.UnlockLink) ?? true);
-    }
+    public bool ActionUnlocked(ActionID action) => ActionDefinitions.Instance[action]?.IsUnlocked(World, Player) ?? false;
 
     public bool TraitUnlocked(uint id)
     {

--- a/BossMod/Framework/WorldStateGameSync.cs
+++ b/BossMod/Framework/WorldStateGameSync.cs
@@ -569,6 +569,10 @@ sealed class WorldStateGameSync : IDisposable
         ClientState.Fate activeFate = curFate != null ? new(curFate->FateId, curFate->Location, curFate->Radius) : default;
         if (_ws.Client.ActiveFate != activeFate)
             _ws.Execute(new ClientState.OpActiveFateChange(activeFate));
+
+        var levels = uiState->PlayerState.ClassJobLevels;
+        if (!MemoryExtensions.SequenceEqual(_ws.Client.ClassJobLevels.AsSpan(), levels))
+            _ws.Execute(new ClientState.OpClassJobLevelsChange(levels.ToArray()));
     }
 
     private ulong SanitizedObjectID(ulong raw) => raw != InvalidEntityId ? raw : 0;

--- a/BossMod/Replay/ReplayParserLog.cs
+++ b/BossMod/Replay/ReplayParserLog.cs
@@ -1,7 +1,6 @@
 ﻿using System.Globalization;
 using System.IO;
 using System.IO.Compression;
-using System.Text;
 using System.Threading;
 
 namespace BossMod;
@@ -336,6 +335,7 @@ public sealed class ReplayParserLog : IDisposable
             [new("CLDA"u8)] = ParseClientDutyActions,
             [new("CLBH"u8)] = ParseClientBozjaHolster,
             [new("CLAF"u8)] = ParseClientActiveFate,
+            [new("CLVL"u8)] = ParseClientClassJobLevels,
             [new("IPCI"u8)] = ParseNetworkIDScramble,
             [new("IPCS"u8)] = ParseNetworkServerIPC,
         };
@@ -644,6 +644,15 @@ public sealed class ReplayParserLog : IDisposable
     }
 
     private ClientState.OpActiveFateChange ParseClientActiveFate() => new(new(_input.ReadUInt(false), _input.ReadVec3(), _input.ReadFloat()));
+
+    private ClientState.OpClassJobLevelsChange ParseClientClassJobLevels()
+    {
+        List<short> contents = [];
+        contents.Capacity = _input.ReadByte(false);
+        for (int i = 0; i < contents.Capacity; i++)
+            contents.Add(_input.ReadShort());
+        return new([.. contents]);
+    }
 
     private NetworkState.OpIDScramble ParseNetworkIDScramble() => new(_input.ReadUInt(false));
     private NetworkState.OpServerIPC ParseNetworkServerIPC() => new(new((Network.ServerIPC.PacketID)_input.ReadInt(), _input.ReadUShort(false), _input.ReadUInt(false), _input.ReadUInt(true), new(_input.ReadLong()), _input.ReadBytes()));


### PR DESCRIPTION
this fixes the level check for role actions

repro steps:
- load into Sastasha as a phys ranged class, pick unsynced + restricted party (you should be level 18)
- press peloton

on master: nothing happens (level 18 is below 20, which is the level where Peloton is unlocked)
with these changes: Peloton executes