### PR TITLE
Remove smart targeting from gnb and add it to pld

### DIFF
--- a/BossMod/ActionQueue/Tanks/GNB.cs
+++ b/BossMod/ActionQueue/Tanks/GNB.cs
@@ -161,7 +161,6 @@ public sealed class Definitions : IDisposable
 
         d.Spell(AID.LightningShot)!.ForbidExecute = (ws, player, _, _) => _config.ForbidEarlyLightningShot && !player.InCombat && ws.Client.CountdownRemaining > 0.7f;
         d.Spell(AID.Aurora)!.ForbidExecute = (_, player, _, _) => player.HPMP.CurHP >= player.HPMP.MaxHP; // don't use at full hp
-        d.Spell(AID.HeartOfCorundum)!.SmartTarget = d.Spell(AID.HeartOfStone)!.SmartTarget = ActionDefinitions.SmartTargetCoTank;
 
         // upgrades (TODO: don't think we actually care...)
         //d.Spell(AID.RoyalGuard)!.TransformAction = d.Spell(AID.ReleaseRoyalGuard)!.TransformAction = () => ActionID.MakeSpell(_state.HaveTankStance ? AID.ReleaseRoyalGuard : AID.RoyalGuard);

--- a/BossMod/ActionQueue/Tanks/PLD.cs
+++ b/BossMod/ActionQueue/Tanks/PLD.cs
@@ -147,6 +147,7 @@ public sealed class Definitions : IDisposable
 
     private void Customize(ActionDefinitions d)
     {
+        d.Spell(AID.Intervention)!.SmartTarget = ActionDefinitions.SmartTargetCoTank;
         //d.Spell(AID.LastBastion)!.EffectDuration = 8;
         //d.Spell(AID.FightOrFlight)!.EffectDuration = 20;
         //d.Spell(AID.Sheltron)!.EffectDuration = 4; // TODO: duration increases to 6...


### PR DESCRIPTION
heart of corundum can target self so this isn't needed

intervention can't so it is needed