### PR TITLE
fix AI positional

### DIFF
--- a/BossMod/AI/AIBehaviour.cs
+++ b/BossMod/AI/AIBehaviour.cs
@@ -95,6 +95,11 @@ sealed class AIBehaviour(AIController ctrl, RotationModuleManager autorot, Prese
         // typically it would switch targets for multidotting, or to hit more targets with AOE
         // in case of ties, it should prefer to return original target - this would prevent useless switches
         var targeting = new Targeting(target!, autorot.Hints.RecommendedRangeToTarget - 0.1f);
+
+        var pos = autorot.Hints.RecommendedPositional;
+        if (targeting.Target.Actor == pos.Target)
+            targeting.PreferredPosition = pos.Pos;
+
         return /*autorot.SelectTargetForAI(targeting) ??*/ targeting;
     }
 
@@ -112,7 +117,8 @@ sealed class AIBehaviour(AIController ctrl, RotationModuleManager autorot, Prese
         }
 
         // if target-of-target is player, don't try flanking, it's probably impossible... - unless target is currently casting (TODO: reconsider?)
-        if (targeting.Target.Actor.TargetID == player.InstanceID && targeting.Target.Actor.CastInfo == null)
+        // skip if targeting a dummy, they don't rotate
+        if (targeting.Target.Actor.TargetID == player.InstanceID && targeting.Target.Actor.CastInfo == null && targeting.Target.Actor.OID != 0x385)
             targeting.PreferredPosition = Positional.Any;
     }
 

--- a/BossMod/Pathfinding/NavigationDecision.cs
+++ b/BossMod/Pathfinding/NavigationDecision.cs
@@ -128,11 +128,13 @@ public struct NavigationDecision
                 return new() { Destination = null, LeewaySeconds = float.MaxValue, TimeToGoal = 0, Map = ctx.Map, MapGoal = maxGoal, DecisionType = Decision.SafeBlocked };
             }
 
+            var playerOrientationToTarget = (player.Position - targetPos.Value).Normalized().Dot(targetRot.ToDirection());
+
             bool inPositional = positional switch
             {
-                Positional.Flank => MathF.Abs(targetRot.ToDirection().Dot((targetPos.Value - player.Position).Normalized())) < 0.7071067f,
-                Positional.Rear => targetRot.ToDirection().Dot((targetPos.Value - player.Position).Normalized()) < -0.7071068f,
-                Positional.Front => targetRot.ToDirection().Dot((targetPos.Value - player.Position).Normalized()) > 0.999f, // ~2.5 degrees - assuming max position error of 0.1, this requires us to stay at least at R=~2.25
+                Positional.Rear => playerOrientationToTarget < -0.7071068f,
+                Positional.Flank => MathF.Abs(playerOrientationToTarget) < 0.7071068f,
+                Positional.Front => playerOrientationToTarget > 0.999f, // ~2.5 degrees - assuming max position error of 0.1, this requires us to stay at least at R=~2.25
                 _ => true
             };
             if (!inPositional)


### PR DESCRIPTION
the old version of this code called SelectBetterTarget from the rotation, which would choose target, range, and positional, but now we don't do that.

also the old code had the rear and front positional check inverted, so ai mode didn't like that very much and thought it was always in the wrong place

i would like to separate Positional.Front from PreferTanking - because front positionals are actually a thing for blue mage and you only need to be within the front 90 degrees of the target, like any other positional - but didn't put it in here

tested on striking dummy with dragooner and monk