### PR TITLE
IPC for clear active preset

### DIFF
--- a/BossMod/Framework/IPCProvider.cs
+++ b/BossMod/Framework/IPCProvider.cs
@@ -66,6 +66,14 @@ sealed class IPCProvider : IDisposable
 
             return false;
         });
+        Register("Presets.ClearActive", () =>
+        {
+            if (autorotation.Preset == null)
+                return false;
+
+            autorotation.Preset = null;
+            return true;
+        });
 
         Register("AI.SetPreset", (string name) => ai.SetAIPreset(autorotation.Database.Presets.Presets.FirstOrDefault(x => x.Name == name)));
     }


### PR DESCRIPTION
AI stops performing any actions if your current preset isn't equal to the configured AI preset. `X` is force enabled if the player dies, which "breaks" AI until you turn it off. we have no IPC method to turn off Disabled, so here's one