### PR TITLE
AI mode: check priority only

### DIFF
--- a/BossMod/BossModule/AIHints.cs
+++ b/BossMod/BossModule/AIHints.cs
@@ -10,7 +10,7 @@ public sealed class AIHints
         public const int PriorityForbidFully = -2; // attacking this enemy is forbidden both by ai or player (e.g. invulnerable, or attacking/killing might lead to a wipe)
 
         public Actor Actor = actor;
-        public int Priority = PriorityForbidAI; // <0 means damaging is actually forbidden, 0 is default (TODO: revise default...)
+        public int Priority = actor.InCombat ? 0 : PriorityForbidAI; // <0 means damaging is actually forbidden, 0 is default (TODO: revise default...)
         //public float TimeToKill;
         public float AttackStrength = 0.05f; // target's predicted HP percent is decreased by this amount (0.05 by default)
         public WPos DesiredPosition = actor.Position; // tank AI will try to move enemy to this position

--- a/BossMod/BossModule/AIHints.cs
+++ b/BossMod/BossModule/AIHints.cs
@@ -10,7 +10,7 @@ public sealed class AIHints
         public const int PriorityForbidFully = -2; // attacking this enemy is forbidden both by ai or player (e.g. invulnerable, or attacking/killing might lead to a wipe)
 
         public Actor Actor = actor;
-        public int Priority = actor.InCombat || actor.FateID != 0 ? 0 : PriorityForbidAI; // <0 means damaging is actually forbidden, 0 is default (TODO: revise default...)
+        public int Priority = PriorityForbidAI; // <0 means damaging is actually forbidden, 0 is default (TODO: revise default...)
         //public float TimeToKill;
         public float AttackStrength = 0.05f; // target's predicted HP percent is decreased by this amount (0.05 by default)
         public WPos DesiredPosition = actor.Position; // tank AI will try to move enemy to this position
@@ -86,9 +86,19 @@ public sealed class AIHints
     {
         bool playerInFate = ws.Client.ActiveFate.ID != 0 && ws.Party.Player()?.Level <= Service.LuminaRow<Lumina.Excel.GeneratedSheets.Fate>(ws.Client.ActiveFate.ID)?.ClassJobLevelMax;
         var allowedFateID = playerInFate ? ws.Client.ActiveFate.ID : 0;
-        foreach (var actor in ws.Actors.Where(a => a.Type == ActorType.Enemy && a.IsTargetable && !a.IsAlly && !a.IsDead && (a.FateID == 0 || a.FateID == allowedFateID)))
+        foreach (var actor in ws.Actors.Where(a => a.Type == ActorType.Enemy && a.IsTargetable && !a.IsAlly && !a.IsDead))
         {
-            PotentialTargets.Add(new(actor, playerIsDefaultTank && (actor.InCombat || actor.FateID != 0)));
+            // fate mob in fate we are NOT a part of, skip entirely. it's okay to "attack" these (i.e., they won't be added as forbidden targets) because we can't even hit them
+            // (though aggro'd mobs will continue attacking us after we unsync, but who really cares)
+            if (actor.FateID > 0 && actor.FateID != allowedFateID)
+                continue;
+
+            var allowedAttack = actor.InCombat && ws.Party.FindSlot(actor.TargetID) >= 0;
+
+            PotentialTargets.Add(new(actor, playerIsDefaultTank)
+            {
+                Priority = allowedAttack ? 0 : Enemy.PriorityForbidAI
+            });
         }
     }
 


### PR DESCRIPTION
this changes AI mode to default to attacking *any* priority target it can get its hands on. this would allow useful features like IPC methods to set specific mob priorities (by instanceid) so that AI mode can be instructed to fight them. it's also a lot easier to read than the previous conditional, OUCHIE

obviously we don't want to constantly try to fight every aggroed mob in the current zone, so i have also modified `FillPotentialTargets` to consider in-combat targets as priority only if they are attacking a party member (or alliance member)

note that this won't work in large scale content like dalriada or DRN where the boss you're fighting might be targeting a tank from another alliance, but anyone who uses full hands-off AI mode in bozja probably doesn't give a shit anyway.