### PR TITLE
"Fly Free, My Pretty" solo duty

### DIFF
--- a/BossMod/AI/AIBehaviour.cs
+++ b/BossMod/AI/AIBehaviour.cs
@@ -38,7 +38,7 @@ sealed class AIBehaviour(AIController ctrl, RotationModuleManager autorot, Prese
             FocusMaster(master);
 
         _afkMode = !master.InCombat && (WorldState.CurrentTime - _masterLastMoved).TotalSeconds > 10;
-        bool forbidActions = _config.ForbidActions || ctrl.IsMounted || _afkMode || autorot.Preset != null && autorot.Preset != AIPreset;
+        bool forbidActions = _config.ForbidActions || _afkMode || autorot.Preset != null && autorot.Preset != AIPreset;
 
         Targeting target = new();
         if (!forbidActions)

--- a/BossMod/AI/AIController.cs
+++ b/BossMod/AI/AIController.cs
@@ -20,7 +20,6 @@ sealed class AIController(ActionManagerEx amex, MovementOverride movement)
     private DateTime _nextJump;
 
     public bool InCutscene => Service.Condition[ConditionFlag.OccupiedInCutSceneEvent] || Service.Condition[ConditionFlag.WatchingCutscene78] || Service.Condition[ConditionFlag.Occupied33] || Service.Condition[ConditionFlag.BetweenAreas] || Service.Condition[ConditionFlag.OccupiedInQuestEvent];
-    public bool IsMounted => Service.Condition[ConditionFlag.Mounted];
     public bool IsVerticalAllowed => Service.Condition[ConditionFlag.InFlight];
     public Angle CameraFacing => (Camera.Instance?.CameraAzimuth ?? 0).Radians() + 180.Degrees();
     public Angle CameraAltitude => (Camera.Instance?.CameraAltitude ?? 0).Radians();

--- a/BossMod/ActionQueue/Roleplay.cs
+++ b/BossMod/ActionQueue/Roleplay.cs
@@ -7,25 +7,6 @@ public enum AID : uint
     PhotonStream = 7620, // range 10 width 4 rect aoe
     DiffractiveMagitekCannon = 7621, // range 30 radius 10 ground targeted aoe
     HighPoweredMagitekCannon = 7622, // range 42 width 8 rect aoe
-
-    // Alphinaud - I forgot the name of this quest and it needs a module
-    RuinIII = 11191,
-    Physick = 11192,
-    TriShackle = 11482,
-
-    // Y'shtola - Will of the Moon (StB)
-    StoneIVSeventhDawn = 13423,
-    AeroIISeventhDawn = 13424,
-    CureIISeventhDawn = 13425,
-    Aetherwell = 13426,
-
-    // Hien - Requiem for Heroes (StB)
-    Kyokufu = 14840,
-    Gofu = 19046,
-    Yagetsu = 19047,
-    Ajisai = 14841,
-    HissatsuGyoten = 14842,
-    SecondWind = 15375,
 }
 
 public enum TraitID : uint { }
@@ -33,9 +14,6 @@ public enum TraitID : uint { }
 public enum SID : uint
 {
     RolePlaying = 1534,
-
-    // Hien
-    Ajisai = 1779,
 }
 
 public sealed class Definitions : IDisposable
@@ -46,22 +24,6 @@ public sealed class Definitions : IDisposable
         d.RegisterSpell(AID.PhotonStream);
         d.RegisterSpell(AID.DiffractiveMagitekCannon);
         d.RegisterSpell(AID.HighPoweredMagitekCannon);
-
-        d.RegisterSpell(AID.RuinIII);
-        d.RegisterSpell(AID.Physick);
-        d.RegisterSpell(AID.TriShackle);
-
-        d.RegisterSpell(AID.StoneIVSeventhDawn);
-        d.RegisterSpell(AID.AeroIISeventhDawn);
-        d.RegisterSpell(AID.CureIISeventhDawn);
-        d.RegisterSpell(AID.Aetherwell);
-
-        d.RegisterSpell(AID.Kyokufu);
-        d.RegisterSpell(AID.Gofu);
-        d.RegisterSpell(AID.Yagetsu);
-        d.RegisterSpell(AID.Ajisai);
-        d.RegisterSpell(AID.HissatsuGyoten);
-        d.RegisterSpell(AID.SecondWind);
     }
 
     public void Dispose() { }

--- a/BossMod/ActionQueue/Roleplay.cs
+++ b/BossMod/ActionQueue/Roleplay.cs
@@ -1,0 +1,68 @@
+﻿namespace BossMod.Roleplay;
+
+public enum AID : uint
+{
+    // magitek reaper in Fly Free, My Pretty
+    MagitekCannon = 7619, // range 30 radius 6 ground targeted aoe
+    PhotonStream = 7620, // range 10 width 4 rect aoe
+    DiffractiveMagitekCannon = 7621, // range 30 radius 10 ground targeted aoe
+    HighPoweredMagitekCannon = 7622, // range 42 width 8 rect aoe
+
+    // Alphinaud - I forgot the name of this quest and it needs a module
+    RuinIII = 11191,
+    Physick = 11192,
+    TriShackle = 11482,
+
+    // Y'shtola - Will of the Moon (StB)
+    StoneIVSeventhDawn = 13423,
+    AeroIISeventhDawn = 13424,
+    CureIISeventhDawn = 13425,
+    Aetherwell = 13426,
+
+    // Hien - Requiem for Heroes (StB)
+    Kyokufu = 14840,
+    Gofu = 19046,
+    Yagetsu = 19047,
+    Ajisai = 14841,
+    HissatsuGyoten = 14842,
+    SecondWind = 15375,
+}
+
+public enum TraitID : uint { }
+
+public enum SID : uint
+{
+    RolePlaying = 1534,
+
+    // Hien
+    Ajisai = 1779,
+}
+
+public sealed class Definitions : IDisposable
+{
+    public Definitions(ActionDefinitions d)
+    {
+        d.RegisterSpell(AID.MagitekCannon);
+        d.RegisterSpell(AID.PhotonStream);
+        d.RegisterSpell(AID.DiffractiveMagitekCannon);
+        d.RegisterSpell(AID.HighPoweredMagitekCannon);
+
+        d.RegisterSpell(AID.RuinIII);
+        d.RegisterSpell(AID.Physick);
+        d.RegisterSpell(AID.TriShackle);
+
+        d.RegisterSpell(AID.StoneIVSeventhDawn);
+        d.RegisterSpell(AID.AeroIISeventhDawn);
+        d.RegisterSpell(AID.CureIISeventhDawn);
+        d.RegisterSpell(AID.Aetherwell);
+
+        d.RegisterSpell(AID.Kyokufu);
+        d.RegisterSpell(AID.Gofu);
+        d.RegisterSpell(AID.Yagetsu);
+        d.RegisterSpell(AID.Ajisai);
+        d.RegisterSpell(AID.HissatsuGyoten);
+        d.RegisterSpell(AID.SecondWind);
+    }
+
+    public void Dispose() { }
+}

--- a/BossMod/Autorotation/RotationModule.cs
+++ b/BossMod/Autorotation/RotationModule.cs
@@ -23,10 +23,12 @@ public enum RotationModuleQuality
 // the configuration part of the rotation module
 // importantly, it defines constraints (supported classes and level ranges) and strategy configs (with their sets of possible options) used by the module to make its decisions
 // rotation modules can optionally be constrained to a specific boss module, if they are used to implement custom encounter-specific logic - these would only be available in plans for that module
-public sealed record class RotationModuleDefinition(string DisplayName, string Description, string Author, RotationModuleQuality Quality, BitMask Classes, int MaxLevel, int MinLevel = 1, Type? RelatedBossModule = null)
+public sealed record class RotationModuleDefinition(string DisplayName, string Description, string Author, RotationModuleQuality Quality, BitMask Classes, int MaxLevel, int MinLevel = 1, Type? RelatedBossModule = null, bool CanUseWhileMounted = false, bool CanUseWhileRoleplaying = false)
 {
     public readonly BitMask Classes = Classes;
     public readonly List<StrategyConfig> Configs = [];
+    public readonly bool CanUseWhileMounted = CanUseWhileMounted;
+    public readonly bool CanUseWhileRoleplaying = CanUseWhileRoleplaying;
 
     public DefineRef Define<Index>(Index expectedIndex) where Index : Enum => new(Configs, (int)(object)expectedIndex);
 

--- a/BossMod/BossModule/BossComponent.cs
+++ b/BossMod/BossModule/BossComponent.cs
@@ -60,6 +60,7 @@ public class BossComponent(BossModule module)
     public virtual void OnActorNpcYell(Actor actor, ushort id) { }
     public virtual void OnActorModelStateChange(Actor actor, byte modelState, byte animState1, byte animState2) { }
     public virtual void OnEventEnvControl(byte index, uint state) { }
+    public virtual void OnDirectorUpdate(uint directorID, uint updateID, uint[] updateParams) { }
 
     // some commonly used shortcuts
     protected MiniArena Arena => Module.Arena;

--- a/BossMod/BossModule/BossModule.cs
+++ b/BossMod/BossModule/BossModule.cs
@@ -101,7 +101,8 @@ public abstract class BossModule : IDisposable
             WorldState.Actors.PlayActionTimelineEvent.Subscribe(OnActorPlayActionTimelineEvent),
             WorldState.Actors.EventNpcYell.Subscribe(OnActorNpcYell),
             WorldState.Actors.ModelStateChanged.Subscribe(OnActorModelStateChange),
-            WorldState.EnvControl.Subscribe(OnEnvControl)
+            WorldState.EnvControl.Subscribe(OnEnvControl),
+            WorldState.DirectorUpdate.Subscribe(OnDirectorUpdate)
         );
 
         foreach (var v in WorldState.Actors)
@@ -441,5 +442,12 @@ public abstract class BossModule : IDisposable
     {
         foreach (var comp in _components)
             comp.OnEventEnvControl(op.Index, op.State);
+    }
+
+    private void OnDirectorUpdate(WorldState.OpDirectorUpdate op)
+    {
+        uint[] prms = [op.Param1, op.Param2, op.Param3, op.Param4];
+        foreach (var comp in _components)
+            comp.OnDirectorUpdate(op.DirectorID, op.UpdateID, prms);
     }
 }

--- a/BossMod/Components/RoleplayModule.cs
+++ b/BossMod/Components/RoleplayModule.cs
@@ -1,0 +1,44 @@
+﻿namespace BossMod.Components;
+public abstract class RoleplayModule(BossModule module) : BossComponent(module)
+{
+    private AIHints? _hints;
+    private Actor? _player;
+    protected AIHints Hints => _hints!;
+    protected Actor Player => _player!;
+
+    protected Roleplay.AID ComboAction => (Roleplay.AID)WorldState.Client.ComboState.Action;
+
+    public abstract void Execute(Actor? primaryTarget);
+
+    public override void AddAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
+    {
+        _hints = hints;
+        _player = actor;
+
+        Execute(WorldState.Actors.Find(actor.TargetID) ?? Module.PrimaryActor);
+    }
+
+    protected void UseGCD(Roleplay.AID action, Actor? target, Vector3 targetPos = default)
+        => Hints.ActionsToExecute.Push(ActionID.MakeSpell(action), target, ActionQueue.Priority.High, targetPos: targetPos);
+
+    protected void UseOGCD(Roleplay.AID action, Actor? target, Vector3 targetPos = default)
+        => Hints.ActionsToExecute.Push(ActionID.MakeSpell(action), target, ActionQueue.Priority.Low, targetPos: targetPos);
+
+    protected float StatusDuration(DateTime expireAt) => Math.Max((float)(expireAt - WorldState.CurrentTime).TotalSeconds, 0.0f);
+
+    protected uint PredictedHP(Actor actor) => (uint)Math.Max(0, actor.HPMP.CurHP + WorldState.PendingEffects.PendingHPDifference(actor.InstanceID));
+
+    // this also checks pending statuses
+    // note that we check pending statuses first - otherwise we get the same problem with double refresh if we try to refresh early (we find old status even though we have pending one)
+    protected (float Left, int Stacks) StatusDetails(Actor? actor, uint sid, ulong sourceID, float pendingDuration = 1000)
+    {
+        if (actor == null)
+            return (0, 0);
+        var pending = WorldState.PendingEffects.PendingStatus(actor.InstanceID, sid, sourceID);
+        if (pending != null)
+            return (pendingDuration, pending.Value);
+        var status = actor.FindStatus(sid, sourceID);
+        return status != null ? (StatusDuration(status.Value.ExpireAt), status.Value.Extra & 0xFF) : (0, 0);
+    }
+    protected (float Left, int Stacks) StatusDetails<SID>(Actor? actor, SID sid, ulong sourceID, float pendingDuration = 1000) where SID : Enum => StatusDetails(actor, (uint)(object)sid, sourceID, pendingDuration);
+}

--- a/BossMod/Data/Actor.cs
+++ b/BossMod/Data/Actor.cs
@@ -102,6 +102,7 @@ public sealed class Actor(ulong instanceID, uint oid, int spawnIndex, string nam
     public ActorCastInfo? CastInfo;
     public ActorTetherInfo Tether;
     public ActorStatus[] Statuses = new ActorStatus[60]; // empty slots have ID=0
+    public uint MountId; // ID of current mount, 0 if not mounted
 
     public Role Role => Class.GetRole();
     public WPos Position => new(PosRot.X, PosRot.Z);

--- a/BossMod/Data/ActorState.cs
+++ b/BossMod/Data/ActorState.cs
@@ -41,6 +41,8 @@ public sealed class ActorState : IEnumerable<Actor>
             for (int i = 0; i < act.Statuses.Length; ++i)
                 if (act.Statuses[i].ID != 0)
                     yield return new OpStatus(act.InstanceID, i, act.Statuses[i]);
+            if (act.MountId != 0)
+                yield return new OpMount(act.InstanceID, act.MountId);
         }
     }
 
@@ -382,5 +384,17 @@ public sealed class ActorState : IEnumerable<Actor>
     {
         protected override void ExecActor(WorldState ws, Actor actor) => ws.Actors.EventNpcYell.Fire(actor, Message);
         public override void Write(ReplayRecorder.Output output) => output.EmitFourCC("NYEL"u8).EmitActor(InstanceID).Emit(Message);
+    }
+
+    public Event<Actor, uint> EventMount = new();
+    public sealed record class OpMount(ulong InstanceID, uint MountId) : Operation(InstanceID)
+    {
+        protected override void ExecActor(WorldState ws, Actor actor)
+        {
+            actor.MountId = MountId;
+            ws.Actors.EventMount.Fire(actor, MountId);
+        }
+
+        public override void Write(ReplayRecorder.Output output) => output.EmitFourCC("MNTD"u8).EmitActor(InstanceID).Emit(MountId);
     }
 }

--- a/BossMod/Framework/WorldStateGameSync.cs
+++ b/BossMod/Framework/WorldStateGameSync.cs
@@ -247,6 +247,7 @@ sealed class WorldStateGameSync : IDisposable
         var modelState = chr != null ? new ActorModelState(chr->Timeline.ModelState, chr->Timeline.AnimationState[0], chr->Timeline.AnimationState[1]) : default;
         var eventState = obj->EventState;
         var radius = obj->GetRadius();
+        var mountId = chr != null ? chr->Mount.MountId : 0;
 
         if (act == null)
         {
@@ -287,6 +288,10 @@ sealed class WorldStateGameSync : IDisposable
             _ws.Execute(new ActorState.OpEventState(act.InstanceID, eventState));
         if (act.TargetID != target)
             _ws.Execute(new ActorState.OpTarget(act.InstanceID, target));
+
+        if (act.MountId != mountId)
+            _ws.Execute(new ActorState.OpMount(act.InstanceID, (uint)mountId));
+
         DispatchActorEvents(act.InstanceID);
 
         var castInfo = chr != null ? chr->GetCastInfo() : null;

--- a/BossMod/Modules/Heavensward/Quest/Heliodrome.cs
+++ b/BossMod/Modules/Heavensward/Quest/Heliodrome.cs
@@ -4,59 +4,42 @@ public enum OID : uint
 {
     Boss = 0x195E,
     Helper = 0x233C,
-    _Gen_ImperialSagittarius = 0x1965, // R0.500, x0 (spawn during fight)
-    _Gen_ImperialEques = 0x1962, // R0.500, x0 (spawn during fight)
-    _Gen_ImperialSecutor = 0x1963, // R0.500, x0 (spawn during fight)
-    _Gen_ImperialSignifer = 0x1964, // R0.500, x0 (spawn during fight)
-    _Gen_ImperialLaquearius = 0x1961, // R0.500, x0 (spawn during fight)
-    _Gen_ImperialHoplomachus = 0x1960, // R0.500, x0 (spawn during fight)
     GrynewahtP2 = 0x195F, // R0.500, x0 (spawn during fight)
-    _Gen_ImperialColossus = 0x1966, // R3.000, x0 (spawn during fight)
+    ImperialColossus = 0x1966, // R3.000, x0 (spawn during fight)
 }
 
 public enum AID : uint
 {
-    _Weaponskill_AugmentedShatter = 7609, // Boss->player/195D, no cast, single-target
-    _Weaponskill_AugmentedUprising = 7608, // Boss->self, 3.0s cast, range 8+R 120-degree cone
-    _Weaponskill_AugmentedSuffering = 7607, // Boss->self, 3.5s cast, range 6+R circle
-    _Weaponskill_Heartstopper = 866, // _Gen_ImperialEques->self, 2.5s cast, range 3+R width 3 rect
-    _Spell_Thunder = 968, // _Gen_ImperialSignifer->player/195C/195B, 1.0s cast, single-target
-    _Ability_FightOrFlight = 20, // _Gen_ImperialHoplomachus->self, no cast, single-target
-    _Weaponskill_Windbite = 113, // _Gen_ImperialSagittarius->player/195B/195C, no cast, single-target
-    _Weaponskill_VenomousBite = 100, // _Gen_ImperialSagittarius->player/195B/195C, no cast, single-target
-    _Weaponskill_Overpower = 720, // _Gen_ImperialLaquearius->self, 2.1s cast, range 6+R 90-degree cone
-    _Ability_SecondWind = 57, // _Gen_ImperialSecutor->self, no cast, single-target
-    _Weaponskill_Feint = 76, // _Gen_ImperialEques->195C/195B, no cast, single-target
-    _Weaponskill_GrandSword = 7615, // _Gen_ImperialColossus->self, 3.0s cast, range 18+R 120-degree cone
-    _Weaponskill_MagitekRay = 7617, // _Gen_ImperialColossus->location, 3.0s cast, range 6 circle
-    _Weaponskill_SelfDetonate = 7618, // _Gen_ImperialColossus->self, 10.0s cast, range 40+R circle
-    _Weaponskill_GrandStrike = 7616, // _Gen_ImperialColossus->self, 2.5s cast, range 45+R width 4 rect
-    _Weaponskill_Firebomb = 7610, // Boss->players, no cast, range 4 circle
-    __ShrapnelShell = 7613, // Boss->self, no cast, single-target
-    _Weaponskill_ShrapnelShell = 7614, // GrynewahtP2->location, 2.5s cast, range 6 circle
-    __MagitekMissiles = 7611, // Boss->self, no cast, single-target
-    _Weaponskill_MagitekMissiles = 7612, // GrynewahtP2->location, 5.0s cast, range 15 circle
+    AugmentedUprising = 7608, // Boss->self, 3.0s cast, range 8+R 120-degree cone
+    AugmentedSuffering = 7607, // Boss->self, 3.5s cast, range 6+R circle
+    Heartstopper = 866, // _Gen_ImperialEques->self, 2.5s cast, range 3+R width 3 rect
+    Overpower = 720, // _Gen_ImperialLaquearius->self, 2.1s cast, range 6+R 90-degree cone
+    GrandSword = 7615, // _Gen_ImperialColossus->self, 3.0s cast, range 18+R 120-degree cone
+    MagitekRay = 7617, // _Gen_ImperialColossus->location, 3.0s cast, range 6 circle
+    GrandStrike = 7616, // _Gen_ImperialColossus->self, 2.5s cast, range 45+R width 4 rect
+    ShrapnelShell = 7614, // GrynewahtP2->location, 2.5s cast, range 6 circle
+    MagitekMissiles = 7612, // GrynewahtP2->location, 5.0s cast, range 15 circle
 
 }
 
-class MagitekMissiles(BossModule module) : Components.LocationTargetedAOEs(module, ActionID.MakeSpell(AID._Weaponskill_MagitekMissiles), 15);
-class ShrapnelShell(BossModule module) : Components.LocationTargetedAOEs(module, ActionID.MakeSpell(AID._Weaponskill_ShrapnelShell), 6);
+class MagitekMissiles(BossModule module) : Components.LocationTargetedAOEs(module, ActionID.MakeSpell(AID.MagitekMissiles), 15);
+class ShrapnelShell(BossModule module) : Components.LocationTargetedAOEs(module, ActionID.MakeSpell(AID.ShrapnelShell), 6);
 class Firebomb(BossModule module) : Components.PersistentVoidzone(module, 4, m => m.Enemies(0x1E86DF).Where(e => e.EventState != 7));
 
-class Uprising(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID._Weaponskill_AugmentedUprising), new AOEShapeCone(8.5f, 60.Degrees()));
-class Suffering(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID._Weaponskill_AugmentedSuffering), new AOEShapeCircle(6.5f));
-class Heartstopper(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID._Weaponskill_Heartstopper), new AOEShapeRect(3.5f, 1.5f));
-class Overpower(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID._Weaponskill_Overpower), new AOEShapeCone(6, 45.Degrees()));
-class GrandSword(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID._Weaponskill_GrandSword), new AOEShapeCone(21, 60.Degrees()));
-class MagitekRay(BossModule module) : Components.LocationTargetedAOEs(module, ActionID.MakeSpell(AID._Weaponskill_MagitekRay), 6);
-class GrandStrike(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID._Weaponskill_GrandStrike), new AOEShapeRect(48, 2));
+class Uprising(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.AugmentedUprising), new AOEShapeCone(8.5f, 60.Degrees()));
+class Suffering(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.AugmentedSuffering), new AOEShapeCircle(6.5f));
+class Heartstopper(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.Heartstopper), new AOEShapeRect(3.5f, 1.5f));
+class Overpower(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.Overpower), new AOEShapeCone(6, 45.Degrees()));
+class GrandSword(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.GrandSword), new AOEShapeCone(21, 60.Degrees()));
+class MagitekRay(BossModule module) : Components.LocationTargetedAOEs(module, ActionID.MakeSpell(AID.MagitekRay), 6);
+class GrandStrike(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.GrandStrike), new AOEShapeRect(48, 2));
 
 class Adds(BossModule module) : Components.AddsMulti(module, [0x1960, 0x1961, 0x1962, 0x1963, 0x1964, 0x1965, 0x1966])
 {
     public override void AddAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
     {
         foreach (var e in hints.PotentialTargets)
-            e.Priority = (OID)e.Actor.OID == OID._Gen_ImperialColossus ? 5 : e.Actor.TargetID == actor.InstanceID ? 1 : 0;
+            e.Priority = (OID)e.Actor.OID == OID.ImperialColossus ? 5 : e.Actor.TargetID == actor.InstanceID ? 1 : 0;
     }
 }
 
@@ -75,7 +58,7 @@ class ReaperAI(BossModule module) : Components.RoleplayModule(module)
     {
         if (primaryTarget != null && Player.MountId == 103)
         {
-            if ((OID)primaryTarget.OID == OID._Gen_ImperialColossus)
+            if ((OID)primaryTarget.OID == OID.ImperialColossus)
                 UseGCD(Roleplay.AID.DiffractiveMagitekCannon, primaryTarget, targetPos: primaryTarget.PosRot.XYZ());
 
             UseGCD(Roleplay.AID.MagitekCannon, primaryTarget, targetPos: primaryTarget.PosRot.XYZ());

--- a/BossMod/Modules/Heavensward/Quest/Heliodrome.cs
+++ b/BossMod/Modules/Heavensward/Quest/Heliodrome.cs
@@ -1,0 +1,129 @@
+﻿namespace BossMod.Heavensward.Quest.Heliodrome;
+
+public enum OID : uint
+{
+    Boss = 0x195E,
+    Helper = 0x233C,
+    _Gen_ImperialSagittarius = 0x1965, // R0.500, x0 (spawn during fight)
+    _Gen_ImperialEques = 0x1962, // R0.500, x0 (spawn during fight)
+    _Gen_ImperialSecutor = 0x1963, // R0.500, x0 (spawn during fight)
+    _Gen_ImperialSignifer = 0x1964, // R0.500, x0 (spawn during fight)
+    _Gen_ImperialLaquearius = 0x1961, // R0.500, x0 (spawn during fight)
+    _Gen_ImperialHoplomachus = 0x1960, // R0.500, x0 (spawn during fight)
+    GrynewahtP2 = 0x195F, // R0.500, x0 (spawn during fight)
+    _Gen_ImperialColossus = 0x1966, // R3.000, x0 (spawn during fight)
+}
+
+public enum AID : uint
+{
+    _Weaponskill_AugmentedShatter = 7609, // Boss->player/195D, no cast, single-target
+    _Weaponskill_AugmentedUprising = 7608, // Boss->self, 3.0s cast, range 8+R 120-degree cone
+    _Weaponskill_AugmentedSuffering = 7607, // Boss->self, 3.5s cast, range 6+R circle
+    _Weaponskill_Heartstopper = 866, // _Gen_ImperialEques->self, 2.5s cast, range 3+R width 3 rect
+    _Spell_Thunder = 968, // _Gen_ImperialSignifer->player/195C/195B, 1.0s cast, single-target
+    _Ability_FightOrFlight = 20, // _Gen_ImperialHoplomachus->self, no cast, single-target
+    _Weaponskill_Windbite = 113, // _Gen_ImperialSagittarius->player/195B/195C, no cast, single-target
+    _Weaponskill_VenomousBite = 100, // _Gen_ImperialSagittarius->player/195B/195C, no cast, single-target
+    _Weaponskill_Overpower = 720, // _Gen_ImperialLaquearius->self, 2.1s cast, range 6+R 90-degree cone
+    _Ability_SecondWind = 57, // _Gen_ImperialSecutor->self, no cast, single-target
+    _Weaponskill_Feint = 76, // _Gen_ImperialEques->195C/195B, no cast, single-target
+    _Weaponskill_GrandSword = 7615, // _Gen_ImperialColossus->self, 3.0s cast, range 18+R 120-degree cone
+    _Weaponskill_MagitekRay = 7617, // _Gen_ImperialColossus->location, 3.0s cast, range 6 circle
+    _Weaponskill_SelfDetonate = 7618, // _Gen_ImperialColossus->self, 10.0s cast, range 40+R circle
+    _Weaponskill_GrandStrike = 7616, // _Gen_ImperialColossus->self, 2.5s cast, range 45+R width 4 rect
+    _Weaponskill_Firebomb = 7610, // Boss->players, no cast, range 4 circle
+    __ShrapnelShell = 7613, // Boss->self, no cast, single-target
+    _Weaponskill_ShrapnelShell = 7614, // GrynewahtP2->location, 2.5s cast, range 6 circle
+    __MagitekMissiles = 7611, // Boss->self, no cast, single-target
+    _Weaponskill_MagitekMissiles = 7612, // GrynewahtP2->location, 5.0s cast, range 15 circle
+
+}
+
+class MagitekMissiles(BossModule module) : Components.LocationTargetedAOEs(module, ActionID.MakeSpell(AID._Weaponskill_MagitekMissiles), 15);
+class ShrapnelShell(BossModule module) : Components.LocationTargetedAOEs(module, ActionID.MakeSpell(AID._Weaponskill_ShrapnelShell), 6);
+class Firebomb(BossModule module) : Components.PersistentVoidzone(module, 4, m => m.Enemies(0x1E86DF).Where(e => e.EventState != 7));
+
+class Uprising(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID._Weaponskill_AugmentedUprising), new AOEShapeCone(8.5f, 60.Degrees()));
+class Suffering(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID._Weaponskill_AugmentedSuffering), new AOEShapeCircle(6.5f));
+class Heartstopper(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID._Weaponskill_Heartstopper), new AOEShapeRect(3.5f, 1.5f));
+class Overpower(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID._Weaponskill_Overpower), new AOEShapeCone(6, 45.Degrees()));
+class GrandSword(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID._Weaponskill_GrandSword), new AOEShapeCone(21, 60.Degrees()));
+class MagitekRay(BossModule module) : Components.LocationTargetedAOEs(module, ActionID.MakeSpell(AID._Weaponskill_MagitekRay), 6);
+class GrandStrike(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID._Weaponskill_GrandStrike), new AOEShapeRect(48, 2));
+
+class Adds(BossModule module) : Components.AddsMulti(module, [0x1960, 0x1961, 0x1962, 0x1963, 0x1964, 0x1965, 0x1966])
+{
+    public override void AddAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
+    {
+        foreach (var e in hints.PotentialTargets)
+            e.Priority = (OID)e.Actor.OID == OID._Gen_ImperialColossus ? 5 : e.Actor.TargetID == actor.InstanceID ? 1 : 0;
+    }
+}
+
+class Bounds(BossModule module) : BossComponent(module)
+{
+    public override void OnDirectorUpdate(uint directorID, uint updateID, uint[] updateParams)
+    {
+        if (updateID == 0x10000002)
+            Arena.Bounds = new ArenaBoundsCircle(20);
+    }
+}
+
+class ReaperAI(BossModule module) : Components.RoleplayModule(module)
+{
+    public override void Execute(Actor? primaryTarget)
+    {
+        if (primaryTarget != null && Player.MountId == 103)
+        {
+            if ((OID)primaryTarget.OID == OID._Gen_ImperialColossus)
+                UseGCD(Roleplay.AID.DiffractiveMagitekCannon, primaryTarget, targetPos: primaryTarget.PosRot.XYZ());
+
+            UseGCD(Roleplay.AID.MagitekCannon, primaryTarget, targetPos: primaryTarget.PosRot.XYZ());
+        }
+    }
+}
+
+class GrynewahtStates : StateMachineBuilder
+{
+    public GrynewahtStates(BossModule module) : base(module)
+    {
+        State build(uint id) => SimpleState(id, 10000, "Enrage")
+            .ActivateOnEnter<Adds>()
+            .ActivateOnEnter<Uprising>()
+            .ActivateOnEnter<Suffering>()
+            .ActivateOnEnter<Overpower>()
+            .ActivateOnEnter<Heartstopper>()
+            .ActivateOnEnter<GrandSword>()
+            .ActivateOnEnter<MagitekRay>()
+            .ActivateOnEnter<GrandStrike>()
+            .ActivateOnEnter<ShrapnelShell>()
+            .ActivateOnEnter<Firebomb>()
+            .ActivateOnEnter<MagitekMissiles>();
+
+        SimplePhase(1, id => build(id).ActivateOnEnter<Bounds>(), "P1")
+            .Raw.Update = () => Module.Enemies(OID.GrynewahtP2).Any();
+        DeathPhase(0x100, id => build(id).ActivateOnEnter<ReaperAI>().OnEnter(() =>
+        {
+            Module.Arena.Bounds = new ArenaBoundsCircle(20);
+        }));
+    }
+}
+
+[ModuleInfo(BossModuleInfo.Maturity.WIP, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 222, NameID = 5576)]
+public class Grynewaht(WorldState ws, Actor primary) : BossModule(ws, primary, new(0, 0), HexBounds)
+{
+    public static readonly ArenaBoundsCustom HexBounds = BuildHexBounds();
+
+    private static ArenaBoundsCustom BuildHexBounds()
+    {
+        var hexSideLen = 20 / MathF.Sqrt(3);
+
+        // slight adjustment to account for player hitbox radius, otherwise dodges can get very sketchy
+        hexSideLen -= 1.5f;
+
+        List<WDir> verts = [new(hexSideLen, 0), hexSideLen * 30.Degrees().ToDirection(), -hexSideLen * 150.Degrees().ToDirection(), new(-hexSideLen, 0), hexSideLen * -30.Degrees().ToDirection(), hexSideLen * 150.Degrees().ToDirection()];
+        return new(hexSideLen, new(verts));
+    }
+
+    protected override bool CheckPull() => true;
+}

--- a/BossMod/Replay/ReplayParserLog.cs
+++ b/BossMod/Replay/ReplayParserLog.cs
@@ -319,6 +319,7 @@ public sealed class ReplayParserLog : IDisposable
             [new("EANM"u8)] = ParseActorEventObjectAnimation,
             [new("PATE"u8)] = ParseActorPlayActionTimelineEvent,
             [new("NYEL"u8)] = ParseActorEventNpcYell,
+            [new("MNTD"u8)] = ParseActorMount,
             [new("PAR "u8)] = ParsePartyModify,
             [new("PAR+"u8)] = ParsePartyModify, // legacy (up to v3)
             [new("PAR-"u8)] = ParsePartyLeave, // legacy (up to v3)
@@ -583,6 +584,7 @@ public sealed class ReplayParserLog : IDisposable
     private ActorState.OpEventObjectAnimation ParseActorEventObjectAnimation() => new(_input.ReadActorID(), _input.ReadUShort(true), _input.ReadUShort(true));
     private ActorState.OpPlayActionTimelineEvent ParseActorPlayActionTimelineEvent() => new(_input.ReadActorID(), _input.ReadUShort(true));
     private ActorState.OpEventNpcYell ParseActorEventNpcYell() => new(_input.ReadActorID(), _input.ReadUShort(false));
+    private ActorState.OpMount ParseActorMount() => new(_input.ReadActorID(), _input.ReadUInt(false));
     private PartyState.OpModify ParsePartyModify() => new(_input.ReadInt(), new(_input.ReadULong(true), _input.ReadULong(true), _version >= 15 && _input.ReadBool(), _version < 15 ? "" : _input.ReadString()));
     private PartyState.OpModify ParsePartyLeave() => new(_input.ReadInt(), new(0, 0, false, ""));
     private PartyState.OpLimitBreakChange ParsePartyLimitBreak() => new(_input.ReadInt(), _input.ReadInt());

--- a/BossMod/Replay/Visualization/OpList.cs
+++ b/BossMod/Replay/Visualization/OpList.cs
@@ -160,6 +160,7 @@ class OpList(Replay replay, ModuleRegistry.Info? moduleInfo, IEnumerable<WorldSt
             ActorState.OpEventObjectAnimation op => $"EObjAnim: {ActorString(op.InstanceID, op.Timestamp)} = {((uint)op.Param1 << 16) | op.Param2:X8}",
             ActorState.OpPlayActionTimelineEvent op => $"Play action timeline: {ActorString(op.InstanceID, op.Timestamp)} = {op.ActionTimelineID:X4}",
             ActorState.OpEventNpcYell op => $"Yell: {ActorString(op.InstanceID, op.Timestamp)} = {op.Message} '{Service.LuminaRow<Lumina.Excel.GeneratedSheets.NpcYell>(op.Message)?.Text}'",
+            ActorState.OpMount op => $"Mount: {ActorString(op.InstanceID, op.Timestamp)} = {Service.LuminaRow<Lumina.Excel.GeneratedSheets.Mount>(op.MountId)?.Singular ?? "<unknown>"}",
             ClientState.OpDutyActionsChange op => $"Player duty actions change: {op.Slot0}, {op.Slot1}",
             ClientState.OpBozjaHolsterChange op => $"Player bozja holster change: {string.Join(", ", op.Contents.Select(e => $"{e.count}x {e.entry}"))}",
             _ => DumpOp(o)

--- a/BossMod/Replay/Visualization/ReplayDetailsWindow.cs
+++ b/BossMod/Replay/Visualization/ReplayDetailsWindow.cs
@@ -270,6 +270,11 @@ class ReplayDetailsWindow : UIWindow
             ImGui.TextUnformatted($"{actor.CastInfo.Action}: {Utils.CastTimeString(actor.CastInfo, _player.WorldState.CurrentTime)}");
 
         ImGui.TableNextColumn();
+        if (actor.MountId > 0)
+        {
+            ImGui.TextUnformatted($"'Mounted' ({actor.MountId})");
+            ImGui.SameLine();
+        }
         foreach (var s in actor.Statuses.Where(s => s.ID != 0))
         {
             var src = _player.WorldState.Actors.Find(s.SourceID);


### PR DESCRIPTION
added "first class" mount/RP support to rotation modules, i.e. RMM won't try to activate a module if you're mounted and it doesn't support queuing mounted actions (which currently none do). this will allow users to keep their existing presets activated when using AI mode in MSQ solo duties, since those presets will no longer interfere with whatever module-specific actions are queued