### PR TITLE
AI Hints for ChainsComponent

### DIFF
--- a/BossMod/Components/Chains.cs
+++ b/BossMod/Components/Chains.cs
@@ -18,7 +18,6 @@ public class Chains(BossModule module, uint tetherID, ActionID aid = default, fl
     {
         return _partner[pcSlot] == player ? PlayerPriority.Danger : PlayerPriority.Irrelevant;
     }
-    
     public override void AddAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
     {
         if (slot < 0 || slot >= _partner.Length || chainLength == 0)
@@ -47,7 +46,7 @@ public class Chains(BossModule module, uint tetherID, ActionID aid = default, fl
             {
                 SetPartner(source.InstanceID, target);
                 SetPartner(target.InstanceID, source);
-                 _initialDistance = (source.Position - target.Position).Length();
+                _initialDistance = (source.Position - target.Position).Length();
             }
         }
     }

--- a/BossMod/Components/Chains.cs
+++ b/BossMod/Components/Chains.cs
@@ -1,11 +1,12 @@
 ﻿namespace BossMod.Components;
 
-// component for breakable chains
-public class Chains(BossModule module, uint tetherID, ActionID aid = default) : CastCounter(module, aid)
+// component for breakable chains - Note that chainLength for AI considers the minimum distance needed for a chain-pair to be broken (assuming perfectly stacked at cast)
+public class Chains(BossModule module, uint tetherID, ActionID aid = default, float chainLength = 0, bool spreadChains = true) : CastCounter(module, aid)
 {
     public uint TID { get; init; } = tetherID;
     public bool TethersAssigned { get; private set; }
     private readonly Actor?[] _partner = new Actor?[PartyState.MaxAllianceSize];
+    private float _initialDistance;
 
     public override void AddHints(int slot, Actor actor, TextHints hints)
     {
@@ -16,6 +17,18 @@ public class Chains(BossModule module, uint tetherID, ActionID aid = default) : 
     public override PlayerPriority CalcPriority(int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
     {
         return _partner[pcSlot] == player ? PlayerPriority.Danger : PlayerPriority.Irrelevant;
+    }
+    
+    public override void AddAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
+    {
+        if (slot < 0 || slot >= _partner.Length || chainLength == 0)
+            return;
+        var partner = _partner[slot];
+        if (partner != null)
+        {
+            var forbiddenZone = spreadChains ? ShapeDistance.Circle(partner.Position, _initialDistance + chainLength) : ShapeDistance.InvertedCircle(partner.Position, chainLength);
+            hints.AddForbiddenZone(forbiddenZone);
+        }
     }
 
     public override void DrawArenaForeground(int pcSlot, Actor pc)
@@ -34,6 +47,7 @@ public class Chains(BossModule module, uint tetherID, ActionID aid = default) : 
             {
                 SetPartner(source.InstanceID, target);
                 SetPartner(target.InstanceID, source);
+                 _initialDistance = (source.Position - target.Position).Length();
             }
         }
     }


### PR DESCRIPTION
- chainLength is the minimum distance players must be apart to break the chain, while initalDistance considers starting distance between the pair
- Additionally added an optional param for rare (I think only Ifrit atm, maybe?) chains that require the pair to stay together, rather than break. (Maybe O12S-P2 Blue/R&G tethers if this component is used for that)  
In that case the minimum distance should represent the distance the pair can move without triggering the chain.