### PR TITLE
AI Hints for ChainsComponent

### DIFF
--- a/BossMod/Components/Chains.cs
+++ b/BossMod/Components/Chains.cs
@@ -1,11 +1,12 @@
 ﻿namespace BossMod.Components;
 
-// component for breakable chains
+// component for breakable chains - Note that chainLength for AI considers the minimum distance needed for a chain-pair to be broken (assuming perfectly stacked at cast)
 public class Chains(BossModule module, uint tetherID, ActionID aid = default) : CastCounter(module, aid)
 {
     public uint TID { get; init; } = tetherID;
     public bool TethersAssigned { get; private set; }
     private readonly Actor?[] _partner = new Actor?[PartyState.MaxAllianceSize];
+    private float _initialDistance;
 
     public override void AddHints(int slot, Actor actor, TextHints hints)
     {
@@ -17,7 +18,17 @@ public class Chains(BossModule module, uint tetherID, ActionID aid = default) : 
     {
         return _partner[pcSlot] == player ? PlayerPriority.Danger : PlayerPriority.Irrelevant;
     }
-
+    public override void AddAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
+    {
+        if (slot < 0 || slot >= _partner.Length || chainLength == 0)
+            return;
+        var partner = _partner[slot];
+        if (partner != null)
+        {
+            var forbiddenZone = spreadChains ? ShapeDistance.Circle(partner.Position, _initialDistance + chainLength) : ShapeDistance.InvertedCircle(partner.Position, chainLength);
+            hints.AddForbiddenZone(forbiddenZone);
+        }
+    }
     public override void DrawArenaForeground(int pcSlot, Actor pc)
     {
         if (_partner[pcSlot] is var partner && partner != null)
@@ -34,6 +45,7 @@ public class Chains(BossModule module, uint tetherID, ActionID aid = default) : 
             {
                 SetPartner(source.InstanceID, target);
                 SetPartner(target.InstanceID, source);
+                _initialDistance = (source.Position - target.Position).Length();
             }
         }
     }

--- a/BossMod/Components/Chains.cs
+++ b/BossMod/Components/Chains.cs
@@ -1,38 +1,41 @@
-﻿namespace BossMod.Components;
+namespace BossMod.Components;
 
 // component for breakable chains - Note that chainLength for AI considers the minimum distance needed for a chain-pair to be broken (assuming perfectly stacked at cast)
 public class Chains(BossModule module, uint tetherID, ActionID aid = default, float chainLength = 0, bool spreadChains = true) : CastCounter(module, aid)
 {
     public uint TID { get; init; } = tetherID;
     public bool TethersAssigned { get; private set; }
-    private readonly Actor?[] _partner = new Actor?[PartyState.MaxAllianceSize];
-    private float _initialDistance;
+    protected readonly (Actor? Partner, float InitialDistance)[] _partner = new (Actor? Partner, float InitialDistance)[PartyState.MaxAllianceSize];
 
     public override void AddHints(int slot, Actor actor, TextHints hints)
     {
-        if (_partner[slot] != null)
+        if (_partner[slot].Partner != null)
             hints.Add("Break the tether!");
+        if (_partner[slot].Partner != null && !spreadChains)
+            hints.Add("Stay with Partner!");
     }
 
     public override PlayerPriority CalcPriority(int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
     {
-        return _partner[pcSlot] == player ? PlayerPriority.Danger : PlayerPriority.Irrelevant;
+        return _partner[pcSlot].Partner == player ? PlayerPriority.Danger : PlayerPriority.Irrelevant;
     }
+
     public override void AddAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
     {
         if (slot < 0 || slot >= _partner.Length || chainLength == 0)
             return;
         var partner = _partner[slot];
-        if (partner != null)
+        if (partner.Partner != null)
         {
-            var forbiddenZone = spreadChains ? ShapeDistance.Circle(partner.Position, _initialDistance + chainLength) : ShapeDistance.InvertedCircle(partner.Position, chainLength);
+            var forbiddenZone = spreadChains ? ShapeDistance.Circle(partner.Partner.Position, partner.InitialDistance + chainLength) : ShapeDistance.InvertedCircle(partner.Partner.Position, chainLength);
             hints.AddForbiddenZone(forbiddenZone);
         }
     }
+
     public override void DrawArenaForeground(int pcSlot, Actor pc)
     {
-        if (_partner[pcSlot] is var partner && partner != null)
-            Arena.AddLine(pc.Position, partner.Position, ArenaColor.Danger);
+        if (_partner[pcSlot] is var partner && partner.Partner != null)
+            Arena.AddLine(pc.Position, partner.Partner.Position, ArenaColor.Danger);
     }
 
     public override void OnTethered(Actor source, ActorTetherInfo tether)
@@ -43,9 +46,9 @@ public class Chains(BossModule module, uint tetherID, ActionID aid = default, fl
             var target = WorldState.Actors.Find(tether.Target);
             if (target != null)
             {
-                SetPartner(source.InstanceID, target);
-                SetPartner(target.InstanceID, source);
-                _initialDistance = (source.Position - target.Position).Length();
+                var initialDistance = (source.Position - target.Position).Length();
+                SetPartner(source.InstanceID, target, initialDistance);
+                SetPartner(target.InstanceID, source, initialDistance);
             }
         }
     }
@@ -54,15 +57,18 @@ public class Chains(BossModule module, uint tetherID, ActionID aid = default, fl
     {
         if (tether.ID == TID)
         {
-            SetPartner(source.InstanceID, null);
-            SetPartner(tether.Target, null);
+            SetPartner(source.InstanceID, null, 0);
+            SetPartner(tether.Target, null, 0);
         }
     }
 
-    private void SetPartner(ulong source, Actor? target)
+    private void SetPartner(ulong source, Actor? target, float initialDistance)
     {
         var slot = Raid.FindSlot(source);
         if (slot >= 0)
-            _partner[slot] = target;
+        {
+            _partner[slot].Partner = target;
+            _partner[slot].InitialDistance = initialDistance;
+        }
     }
 }

--- a/BossMod/Components/Chains.cs
+++ b/BossMod/Components/Chains.cs
@@ -12,7 +12,7 @@ public class Chains(BossModule module, uint tetherID, ActionID aid = default, fl
         if (_partner[slot].Partner != null)
             hints.Add("Break the tether!");
         if (_partner[slot].Partner != null && !spreadChains)
-            hints.Add("Stay with Partner!");
+            hints.Add($"Stay with {_partner[slot].Partner}!");
     }
 
     public override PlayerPriority CalcPriority(int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)

--- a/BossMod/Components/Chains.cs
+++ b/BossMod/Components/Chains.cs
@@ -1,7 +1,7 @@
 ﻿namespace BossMod.Components;
 
 // component for breakable chains - Note that chainLength for AI considers the minimum distance needed for a chain-pair to be broken (assuming perfectly stacked at cast)
-public class Chains(BossModule module, uint tetherID, ActionID aid = default) : CastCounter(module, aid)
+public class Chains(BossModule module, uint tetherID, ActionID aid = default, float chainLength = 0, bool spreadChains = true) : CastCounter(module, aid)
 {
     public uint TID { get; init; } = tetherID;
     public bool TethersAssigned { get; private set; }


### PR DESCRIPTION
- chainLength is the minimum distance players must be apart to break the chain, while initalDistance considers starting distance between the pair
- Additionally added an optional param for rare (I think only Ifrit atm, maybe?) chains that require the pair to stay together, rather than break. (Maybe O12S-P2 Blue/R&G tethers if this component is used for that)
- In that case the minimum distance should represent the distance the pair can move without triggering the chain.

- Reuploaded to address EOL issues (I hope? Sorry Veyn)