### PR TITLE
Modified ConfigRoot to allow a 2nd optional bool for saving

### DIFF
--- a/BossMod/Config/ConfigRoot.cs
+++ b/BossMod/Config/ConfigRoot.cs
@@ -74,7 +74,7 @@ public class ConfigRoot
         }
     }
 
-    public List<string> ConsoleCommand(IReadOnlyList<string> args)
+    public List<string> ConsoleCommand(IReadOnlyList<string> args, bool save = true)
     {
         List<string> result = [];
         if (args.Count == 0)
@@ -148,7 +148,8 @@ public class ConfigRoot
                             else
                             {
                                 matchingFields[0].SetValue(matchingNodes[0], val);
-                                matchingNodes[0].Modified.Fire();
+                                if (save)
+                                    matchingNodes[0].Modified.Fire();
                             }
                         }
                     }

--- a/BossMod/Framework/IPCProvider.cs
+++ b/BossMod/Framework/IPCProvider.cs
@@ -26,7 +26,7 @@ sealed class IPCProvider : IDisposable
         Register("HasModuleByDataId", (uint dataId) => ModuleRegistry.FindByOID(dataId) != null);
         Register("IsMoving", movement.IsMoving);
         Register("ForbiddenZonesCount", () => autorotation.Hints.ForbiddenZones.Count);
-        Register("Configuration", (IReadOnlyList<string> args) => Service.Config.ConsoleCommand(args));
+        Register("Configuration", (IReadOnlyList<string> args, bool save) => Service.Config.ConsoleCommand(args, save));
         //Register("InitiateCombat", () => autorotation.ClassActions?.UpdateAutoAction(CommonActions.AutoActionAIFight, float.MaxValue, true));
         //Register("SetAutorotationState", (bool state) => Service.Config.Get<AutorotationConfig>().Enabled = state);
 


### PR DESCRIPTION
Modified IPCProvider Configuration to make use of the save bool from ConfigRoot