### PR TITLE
M3S Chain Deathmatch Danger Zones

### DIFF
--- a/BossMod/Modules/Dawntrail/Savage/RM03SBruteBomber/TagTeam.cs
+++ b/BossMod/Modules/Dawntrail/Savage/RM03SBruteBomber/TagTeam.cs
@@ -12,7 +12,15 @@ class TagTeamLariatCombo(BossModule module) : Components.GenericAOEs(module)
         foreach (var aoe in AOEs)
         {
             var safe = _tetherSource[slot]?.Position.AlmostEqual(aoe.Origin, 25) ?? false;
-            yield return aoe with { Color = safe ? ArenaColor.SafeFromAOE : ArenaColor.AOE, Risky = !safe };
+            if (safe)
+                yield return aoe with
+                {
+                    Origin = Module.Center - (aoe.Origin - Module.Center),
+                    Rotation = aoe.Rotation + 180.Degrees(),
+                    Shape = new AOEShapeRect(70, 7f)
+                };
+            else
+                yield return aoe;
         }
     }
 
@@ -74,17 +82,11 @@ class TagTeamLariatCombo(BossModule module) : Components.GenericAOEs(module)
     }
 }
 
-class FusesOfFuryMurderousMist : Components.SelfTargetedAOEs
+class FusesOfFuryMurderousMist(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.FusesOfFuryMurderousMist), new AOEShapeCone(40, 45.Degrees(), 180.Degrees()))
 {
-    public FusesOfFuryMurderousMist(BossModule module) : base(module, ActionID.MakeSpell(AID.FusesOfFuryMurderousMist), new AOEShapeCone(40, 135.Degrees()))
-    {
-        Color = ArenaColor.SafeFromAOE;
-        Risky = false;
-    }
-
     public override void AddHints(int slot, Actor actor, TextHints hints)
     {
-        if (Casters.Any(c => !Shape.Check(actor.Position, c.Position, c.CastInfo!.Rotation)))
-            hints.Add("Go into cone!");
+        if (Casters.Any(c => Shape.Check(actor.Position, c.Position, c.CastInfo!.Rotation)))
+            hints.Add("Get hit by mist!");
     }
 }


### PR DESCRIPTION
The green and yellow in M3S chain deathmatch blur together and it's difficult to discern what is actually safe. This change shows the inverse of the safe zone as a danger zone. This makes it significantly clearer where to stand for chain deathmatch 2.
![cdmdangerzones](https://github.com/user-attachments/assets/51134ae1-2911-472f-a3c2-d30195662fa7)

This PR is more of a suggestion than a perfect implementation. I couldn't figure out a good way to "inverse" the lariat AOE, so I sort of hacked it by flipping the origin and rotation and making it narrower. Also I didn't adjust the "Go into cleave!" hint which isn't displayed anymore with this change.