### PR TITLE
PotentialTargets enhancements

### DIFF
--- a/BossMod/BossModule/AIHints.cs
+++ b/BossMod/BossModule/AIHints.cs
@@ -90,17 +90,17 @@ public sealed class AIHints
     {
         bool playerInFate = ws.Client.ActiveFate.ID != 0 && ws.Party.Player()?.Level <= Service.LuminaRow<Lumina.Excel.GeneratedSheets.Fate>(ws.Client.ActiveFate.ID)?.ClassJobLevelMax;
         var allowedFateID = playerInFate ? ws.Client.ActiveFate.ID : 0;
-        foreach (var actor in ws.Actors.Where(a => a.Type is ActorType.Enemy or ActorType.Part && a.IsTargetable && !a.IsAlly && !a.IsDead))
+        foreach (var actor in ws.Actors.Where(a => a.IsTargetable && !a.IsAlly && !a.IsDead))
         {
             // fate mob in fate we are NOT a part of, skip entirely. it's okay to "attack" these (i.e., they won't be added as forbidden targets) because we can't even hit them
             // (though aggro'd mobs will continue attacking us after we unsync, but who really cares)
             if (actor.FateID > 0 && actor.FateID != allowedFateID)
                 continue;
-            
+
             // target is dying; skip it so that AI retargets, but ensure that it's not marked as a forbidden target
-            // skip this check on striking dummies as they die constantly
+            // skip this check on striking dummies (name ID 541) as they die constantly
             var predictedHP = ws.PendingEffects.PendingHPDifference(actor.InstanceID);
-            if (actor.HPMP.CurHP + predictedHP <= 0 && actor.OID != 0x23B)
+            if (actor.HPMP.CurHP + predictedHP <= 0 && actor.NameID != 541)
                 continue;
 
             var allowedAttack = actor.InCombat && ws.Party.FindSlot(actor.TargetID) >= 0;

--- a/BossMod/BossModule/AIHints.cs
+++ b/BossMod/BossModule/AIHints.cs
@@ -90,16 +90,24 @@ public sealed class AIHints
     {
         bool playerInFate = ws.Client.ActiveFate.ID != 0 && ws.Party.Player()?.Level <= Service.LuminaRow<Lumina.Excel.GeneratedSheets.Fate>(ws.Client.ActiveFate.ID)?.ClassJobLevelMax;
         var allowedFateID = playerInFate ? ws.Client.ActiveFate.ID : 0;
-        foreach (var actor in ws.Actors.Where(a => a.Type == ActorType.Enemy && a.IsTargetable && !a.IsAlly && !a.IsDead))
+        foreach (var actor in ws.Actors.Where(a => a.Type is ActorType.Enemy or ActorType.Part && a.IsTargetable && !a.IsAlly && !a.IsDead))
         {
             // fate mob in fate we are NOT a part of, skip entirely. it's okay to "attack" these (i.e., they won't be added as forbidden targets) because we can't even hit them
             // (though aggro'd mobs will continue attacking us after we unsync, but who really cares)
             if (actor.FateID > 0 && actor.FateID != allowedFateID)
                 continue;
+            
+            // target is dying; skip it so that AI retargets, but ensure that it's not marked as a forbidden target
+            // skip this check on striking dummies as they die constantly
+            var predictedHP = ws.PendingEffects.PendingHPDifference(actor.InstanceID);
+            if (actor.HPMP.CurHP + predictedHP <= 0 && actor.OID != 0x23B)
+                continue;
 
             var allowedAttack = actor.InCombat && ws.Party.FindSlot(actor.TargetID) >= 0;
             // enemies in our enmity list can also be attacked, regardless of who they are targeting (since they are keeping us in combat)
             allowedAttack |= actor.AggroPlayer;
+            // all fate mobs can be attacked if we are level synced (non synced mobs are skipped above)
+            allowedAttack |= actor.FateID > 0;
 
             PotentialTargets.Add(new(actor, playerIsDefaultTank)
             {


### PR DESCRIPTION
- add ActorType.Part, which is generally a part of a boss (tioman's wings, titan's heart, shinryu's tail)
- skip targets who are about to die (this is HUGE qol on casters or any class that has actions with very delayed damage application)
- set current-fate priority to 0 instead of -1