### PR TITLE
MCH and BRD improvements

### DIFF
--- a/BossMod/Autorotation/Utility/ClassBRDUtility.cs
+++ b/BossMod/Autorotation/Utility/ClassBRDUtility.cs
@@ -6,6 +6,8 @@ public sealed class ClassBRDUtility(RotationModuleManager manager, Actor player)
 
     public static readonly ActionID IDLimitBreak3 = ActionID.MakeSpell(BRD.AID.SagittariusArrow);
 
+    public enum TroubOption { Use87, Use88, DontUse }
+
     public static RotationModuleDefinition Definition()
     {
         var res = new RotationModuleDefinition("Utility: BRD", "Planner support for utility actions", "veyn", RotationModuleQuality.WIP, BitMask.Build((int)Class.BRD), 100);
@@ -13,7 +15,13 @@ public sealed class ClassBRDUtility(RotationModuleManager manager, Actor player)
 
         // TODO: repelling shot (not sure how it can be planned really...)
         DefineSimpleConfig(res, Track.WardensPaean, "WardensPaean", "Dispel", -10, BRD.AID.WardensPaean, 30);
-        DefineSimpleConfig(res, Track.Troubadour, "Troubadour", "Troub", 500, BRD.AID.Troubadour, 15);
+
+        res.Define(Track.Troubadour).As<TroubOption>("Troubadour", "Troub", 500)
+            .AddOption(TroubOption.Use87, "Use", "Use Troubadour", 120, 15, ActionTargets.Self, 62, 87)
+            .AddOption(TroubOption.Use88, "Use", "Use Troubadour", 90, 15, ActionTargets.Self, 88)
+            .AddOption(TroubOption.DontUse, "None", "Do not use automatically")
+            .AddAssociatedActions(BRD.AID.Troubadour);
+
         DefineSimpleConfig(res, Track.NaturesMinne, "NaturesMinne", "Minne", 400, BRD.AID.NaturesMinne, 15);
 
         return res;

--- a/BossMod/Autorotation/Utility/ClassMCHUtility.cs
+++ b/BossMod/Autorotation/Utility/ClassMCHUtility.cs
@@ -9,13 +9,19 @@ public sealed class ClassMCHUtility(RotationModuleManager manager, Actor player)
     // Add Machinist LB3
     public static readonly ActionID IDLimitBreak3 = ActionID.MakeSpell(MCH.AID.SatelliteBeam);
 
+    public enum TactOption { Use87, Use88, DontUse }
+
     public static RotationModuleDefinition Definition()
     {
         var res = new RotationModuleDefinition("Utility: MCH", "Planner support for utility actions", "Aimsucks", RotationModuleQuality.Ok, BitMask.Build((int)Class.MCH), 100);
         DefineShared(res, IDLimitBreak3);
 
         // Add track for Tactician: 15s long, 15% player damage received reduction
-        DefineSimpleConfig(res, Track.Tactician, "Tactician", "Tact", 400, MCH.AID.Tactician, 15);
+        res.Define(Track.Tactician).As<TactOption>("Tactician", "Tact", 400)
+            .AddOption(TactOption.Use87, "Use", "Use Tactician", 90, 15, ActionTargets.Self, 56, 87)
+            .AddOption(TactOption.Use88, "Use", "Use Tactician", 90, 15, ActionTargets.Self, 88)
+            .AddOption(TactOption.DontUse, "None", "Do not use automatically")
+            .AddAssociatedActions(MCH.AID.Tactician);
 
         // Add track for Dismantle: 10s long, 10% target damage reduction
         DefineSimpleConfig(res, Track.Dismantle, "Dismantle", "Dism", 500, MCH.AID.Dismantle, 10);

--- a/BossMod/Autorotation/Utility/ClassMCHUtility.cs
+++ b/BossMod/Autorotation/Utility/ClassMCHUtility.cs
@@ -11,14 +11,14 @@ public sealed class ClassMCHUtility(RotationModuleManager manager, Actor player)
 
     public static RotationModuleDefinition Definition()
     {
-        var res = new RotationModuleDefinition("Utility: MCH", "Planner support for utility actions", "Aimsucks", RotationModuleQuality.WIP, BitMask.Build((int)Class.MCH), 100);
+        var res = new RotationModuleDefinition("Utility: MCH", "Planner support for utility actions", "Aimsucks", RotationModuleQuality.Ok, BitMask.Build((int)Class.MCH), 100);
         DefineShared(res, IDLimitBreak3);
 
         // Add track for Tactician: 15s long, 15% player damage received reduction
-        DefineSimpleConfig(res, Track.Tactician, "Tactician", "Tactician", 400, MCH.AID.Tactician);
+        DefineSimpleConfig(res, Track.Tactician, "Tactician", "Tact", 400, MCH.AID.Tactician, 15);
 
         // Add track for Dismantle: 10s long, 10% target damage reduction
-        DefineSimpleConfig(res, Track.Dismantle, "Dismantle", "Dismantle", 500, MCH.AID.Dismantle);
+        DefineSimpleConfig(res, Track.Dismantle, "Dismantle", "Dism", 500, MCH.AID.Dismantle, 10);
 
         return res;
     }

--- a/BossMod/Autorotation/Utility/ClassMCHUtility.cs
+++ b/BossMod/Autorotation/Utility/ClassMCHUtility.cs
@@ -18,7 +18,7 @@ public sealed class ClassMCHUtility(RotationModuleManager manager, Actor player)
 
         // Add track for Tactician: 15s long, 15% player damage received reduction
         res.Define(Track.Tactician).As<TactOption>("Tactician", "Tact", 400)
-            .AddOption(TactOption.Use87, "Use", "Use Tactician", 90, 15, ActionTargets.Self, 56, 87)
+            .AddOption(TactOption.Use87, "Use", "Use Tactician", 120, 15, ActionTargets.Self, 56, 87)
             .AddOption(TactOption.Use88, "Use", "Use Tactician", 90, 15, ActionTargets.Self, 88)
             .AddOption(TactOption.DontUse, "None", "Do not use automatically")
             .AddAssociatedActions(MCH.AID.Tactician);

--- a/BossMod/Autorotation/xan/Ranged/MCH.cs
+++ b/BossMod/Autorotation/xan/Ranged/MCH.cs
@@ -20,7 +20,7 @@ public sealed class MCH(RotationModuleManager manager, Actor player) : Attackxan
 
         def.DefineShared().AddAssociatedActions(AID.BarrelStabilizer, AID.Wildfire);
 
-        def.Define(Track.Queen).As<QueenStrategy>("Queen", "Automaton Queen")
+        def.Define(Track.Queen).As<QueenStrategy>("Queen", "Queen")
             .AddOption(QueenStrategy.MinGauge, "Min", "Summon at 50+ gauge")
             .AddOption(QueenStrategy.FullGauge, "Full", "Summon at 100 gauge")
             .AddOption(QueenStrategy.RaidBuffsOnly, "Buffed", "Delay summon until raid buffs, regardless of gauge")


### PR DESCRIPTION
- Updated Tactician to be a 90 second cooldown at level 88 and higher
- Updated Troubadour to be a 90 second cooldown at level 88 and higher
- Added effect durations