### PR TITLE
change PCT motif default behavior

### DIFF
--- a/BossMod/Autorotation/xan/Casters/PCT.cs
+++ b/BossMod/Autorotation/xan/Casters/PCT.cs
@@ -6,7 +6,7 @@ namespace BossMod.Autorotation.xan;
 public sealed class PCT(RotationModuleManager manager, Actor player) : Castxan<AID, TraitID>(manager, player)
 {
     public enum Track { Motif = SharedTrack.Count, Holy, Hammer }
-    public enum MotifStrategy { Instant, Downtime, Combat }
+    public enum MotifStrategy { Combat, Downtime, Instant }
 
     public static RotationModuleDefinition Definition()
     {
@@ -15,9 +15,9 @@ public sealed class PCT(RotationModuleManager manager, Actor player) : Castxan<A
         def.DefineShared().AddAssociatedActions(AID.StarryMuse);
 
         def.Define(Track.Motif).As<MotifStrategy>("Motifs")
-            .AddOption(MotifStrategy.Instant, "Instant", "Only cast motifs when they are instant (out of combat)")
+            .AddOption(MotifStrategy.Combat, "Combat", "Cast motifs in combat, outside of burst window")
             .AddOption(MotifStrategy.Downtime, "Downtime", "Cast motifs in combat if there are no targets nearby")
-            .AddOption(MotifStrategy.Combat, "Combat", "Cast motifs in combat, outside of burst window");
+            .AddOption(MotifStrategy.Instant, "Instant", "Only cast motifs when they are instant (out of combat)");
 
         def.DefineSimple(Track.Holy, "Holy").AddAssociatedActions(AID.HolyInWhite);
         def.DefineSimple(Track.Hammer, "Hammer").AddAssociatedActions(AID.HammerStamp);


### PR DESCRIPTION
changed default from "Instant" (out of combat only) -> "Combat" (out of burst window only)

this won't change existing presets since the names are the same, just makes the default more sane