### PR TITLE
UX improvements

### DIFF
--- a/BossMod/BossModule/BossModuleConfig.cs
+++ b/BossMod/BossModule/BossModuleConfig.cs
@@ -4,16 +4,13 @@
 public class BossModuleConfig : ConfigNode
 {
     // boss module settings
-    [PropertyDisplay("Enable boss modules")]
-    public bool Enable = true;
-
     [PropertyDisplay("Minimal maturity for the module to be loaded", tooltip: "Some modules will have the \"WIP\" status and will not automatically load unless you change this")]
     public BossModuleInfo.Maturity MinMaturity = BossModuleInfo.Maturity.Contributed;
 
     [PropertyDisplay("Allow modules to automatically use actions", tooltip: "Example: modules can automatically use anti-knockback abilities before a knockback happens")]
     public bool AllowAutomaticActions = true;
 
-    [PropertyDisplay("Show testing radar and hint window", tooltip: "Useful for configuring your radar and hint windows without being inside of a boss encounter")]
+    [PropertyDisplay("Show testing radar and hint window", tooltip: "Useful for configuring your radar and hint windows without being inside of a boss encounter", separator: true)]
     public bool ShowDemo = false;
 
     // radar window settings
@@ -58,7 +55,7 @@ public class BossModuleConfig : ConfigNode
     [PropertyDisplay("Show waymarks on radar")]
     public bool ShowWaymarks = false;
 
-    [PropertyDisplay("Always show all alive party members")]
+    [PropertyDisplay("Always show all alive party members", separator: true)]
     public bool ShowIrrelevantPlayers = false;
 
     // hint window settings
@@ -71,7 +68,7 @@ public class BossModuleConfig : ConfigNode
     [PropertyDisplay("Show raidwide hints")]
     public bool ShowGlobalHints = true;
 
-    [PropertyDisplay("Show player hints and warnings")]
+    [PropertyDisplay("Show player hints and warnings", separator: true)]
     public bool ShowPlayerHints = true;
 
     // misc. settings

--- a/BossMod/BossModule/BossModuleConfig.cs
+++ b/BossMod/BossModule/BossModuleConfig.cs
@@ -17,6 +17,9 @@ public class BossModuleConfig : ConfigNode
     public bool ShowDemo = false;
 
     // radar window settings
+    [PropertyDisplay("Enable radar")]
+    public bool Enable = true;
+
     [PropertyDisplay("Lock radar and hint window movement and mouse interaction")]
     public bool Lock = false;
 

--- a/BossMod/Config/ConfigNode.cs
+++ b/BossMod/Config/ConfigNode.cs
@@ -14,11 +14,12 @@ public sealed class ConfigDisplayAttribute : Attribute
 
 // attribute that specifies how config node field or enumeration value is shown in the UI
 [AttributeUsage(AttributeTargets.Field)]
-public sealed class PropertyDisplayAttribute(string label, uint color = 0xffffffff, string tooltip = "") : Attribute
+public sealed class PropertyDisplayAttribute(string label, uint color = 0xffffffff, string tooltip = "", bool separator = false) : Attribute
 {
     public string Label { get; } = label;
     public uint Color { get; } = color;
     public string Tooltip { get; } = tooltip;
+    public bool Separator { get; } = separator;
 }
 
 // attribute that specifies combobox should be used for displaying int/bool property

--- a/BossMod/Config/ConfigUI.cs
+++ b/BossMod/Config/ConfigUI.cs
@@ -88,7 +88,7 @@ public sealed class ConfigUI : IDisposable
                 continue;
 
             var value = field.GetValue(node);
-            if (DrawProperty(props.Label, props.Tooltip, node, field, value, root, tree, ws))
+            if (DrawProperty(props.Label, props.Tooltip, props.Separator, node, field, value, root, tree, ws))
             {
                 node.Modified.Fire();
             }
@@ -134,19 +134,27 @@ public sealed class ConfigUI : IDisposable
         ImGui.SetCursorPosY(cursor);
     }
 
-    private static bool DrawProperty(string label, string tooltip, ConfigNode node, FieldInfo member, object? value, ConfigRoot root, UITree tree, WorldState ws) => value switch
+    private static void DrawSeparator(bool separator)
     {
-        bool v => DrawProperty(label, tooltip, node, member, v),
-        Enum v => DrawProperty(label, tooltip, node, member, v),
-        float v => DrawProperty(label, tooltip, node, member, v),
-        int v => DrawProperty(label, tooltip, node, member, v),
-        Color v => DrawProperty(label, tooltip, node, member, v),
-        Color[] v => DrawProperty(label, tooltip, node, member, v),
-        GroupAssignment v => DrawProperty(label, tooltip, node, member, v, root, tree, ws),
+        if (separator)
+        {
+            ImGui.Separator();
+        }
+    }
+
+    private static bool DrawProperty(string label, string tooltip, bool separator, ConfigNode node, FieldInfo member, object? value, ConfigRoot root, UITree tree, WorldState ws) => value switch
+    {
+        bool v => DrawProperty(label, tooltip, separator, node, member, v),
+        Enum v => DrawProperty(label, tooltip, separator, node, member, v),
+        float v => DrawProperty(label, tooltip, separator, node, member, v),
+        int v => DrawProperty(label, tooltip, separator, node, member, v),
+        Color v => DrawProperty(label, tooltip, separator, node, member, v),
+        Color[] v => DrawProperty(label, tooltip, separator, node, member, v),
+        GroupAssignment v => DrawProperty(label, tooltip, separator, node, member, v, root, tree, ws),
         _ => false
     };
 
-    private static bool DrawProperty(string label, string tooltip, ConfigNode node, FieldInfo member, bool v)
+    private static bool DrawProperty(string label, string tooltip, bool separator, ConfigNode node, FieldInfo member, bool v)
     {
         DrawHelp(tooltip);
         var combo = member.GetCustomAttribute<PropertyComboAttribute>();
@@ -166,10 +174,11 @@ public sealed class ConfigUI : IDisposable
                 return true;
             }
         }
+        DrawSeparator(separator);
         return false;
     }
 
-    private static bool DrawProperty(string label, string tooltip, ConfigNode node, FieldInfo member, Enum v)
+    private static bool DrawProperty(string label, string tooltip, bool separator, ConfigNode node, FieldInfo member, Enum v)
     {
         DrawHelp(tooltip);
         if (UICombo.Enum(label, ref v))
@@ -177,10 +186,11 @@ public sealed class ConfigUI : IDisposable
             member.SetValue(node, v);
             return true;
         }
+        DrawSeparator(separator);
         return false;
     }
 
-    private static bool DrawProperty(string label, string tooltip, ConfigNode node, FieldInfo member, float v)
+    private static bool DrawProperty(string label, string tooltip, bool separator, ConfigNode node, FieldInfo member, float v)
     {
         DrawHelp(tooltip);
         var slider = member.GetCustomAttribute<PropertySliderAttribute>();
@@ -203,10 +213,11 @@ public sealed class ConfigUI : IDisposable
                 return true;
             }
         }
+        DrawSeparator(separator);
         return false;
     }
 
-    private static bool DrawProperty(string label, string tooltip, ConfigNode node, FieldInfo member, int v)
+    private static bool DrawProperty(string label, string tooltip, bool separator, ConfigNode node, FieldInfo member, int v)
     {
         DrawHelp(tooltip);
         var slider = member.GetCustomAttribute<PropertySliderAttribute>();
@@ -229,10 +240,11 @@ public sealed class ConfigUI : IDisposable
                 return true;
             }
         }
+        DrawSeparator(separator);
         return false;
     }
 
-    private static bool DrawProperty(string label, string tooltip, ConfigNode node, FieldInfo member, Color v)
+    private static bool DrawProperty(string label, string tooltip, bool separator, ConfigNode node, FieldInfo member, Color v)
     {
         DrawHelp(tooltip);
         var col = v.ToFloat4();
@@ -241,10 +253,11 @@ public sealed class ConfigUI : IDisposable
             member.SetValue(node, Color.FromFloat4(col));
             return true;
         }
+        DrawSeparator(separator);
         return false;
     }
 
-    private static bool DrawProperty(string label, string tooltip, ConfigNode node, FieldInfo member, Color[] v)
+    private static bool DrawProperty(string label, string tooltip, bool separator, ConfigNode node, FieldInfo member, Color[] v)
     {
         var modified = false;
         for (int i = 0; i < v.Length; ++i)
@@ -258,10 +271,11 @@ public sealed class ConfigUI : IDisposable
                 modified = true;
             }
         }
+        DrawSeparator(separator);
         return modified;
     }
 
-    private static bool DrawProperty(string label, string tooltip, ConfigNode node, FieldInfo member, GroupAssignment v, ConfigRoot root, UITree tree, WorldState ws)
+    private static bool DrawProperty(string label, string tooltip, bool separator, ConfigNode node, FieldInfo member, GroupAssignment v, ConfigRoot root, UITree tree, WorldState ws)
     {
         var group = member.GetCustomAttribute<GroupDetailsAttribute>();
         if (group == null)
@@ -308,6 +322,7 @@ public sealed class ConfigUI : IDisposable
                 ImGui.TextUnformatted(name);
             }
         }
+        DrawSeparator(separator);
         return modified;
     }
 


### PR DESCRIPTION
- Changed the wording for `Enable boss modules` to `Enable radar` since everything works when the boolean is false, just radar isn't shown, see [this Discord conversation](https://discord.com/channels/1001823907193552978/1191076246860349450/1281019776331939955) for details
- Added separators to the config UI, which can be drawn below a `PropertyDisplay` item by providing the `separator: true` value inside of the attribute
- Placed separators in the `Boss Modules and Radar` settings area to separate out general, radar, hint, and misc. settings from each other

This is what it looks like:
![image](https://github.com/user-attachments/assets/497275ef-a75f-475d-806f-87cbfe9736ce)
