### PR TITLE
ops for pet state, duty action charges, blue mage spells

### DIFF
--- a/BossMod/ActionQueue/ActionDefinition.cs
+++ b/BossMod/ActionQueue/ActionDefinition.cs
@@ -83,11 +83,19 @@ public sealed record class ActionDefinition(ActionID ID)
     public bool IsGCD => MainCooldownGroup == ActionDefinitions.GCDGroup || ExtraCooldownGroup == ActionDefinitions.GCDGroup;
 
     // for duty actions, the action definition always stores cooldown group 80, but in reality a different one might be used
-    public int ActualMainCooldownGroup(ReadOnlySpan<ActionID> dutyActions)
+    public int ActualMainCooldownGroup(ReadOnlySpan<ClientState.DutyAction> dutyActions)
     {
         if (MainCooldownGroup < ActionDefinitions.DutyAction0CDGroup)
             return MainCooldownGroup;
-        var index = dutyActions.IndexOf(ID);
+        var index = -1;
+        for (var i = 0; i < dutyActions.Length; i++)
+        {
+            if (dutyActions[i].Action == ID)
+            {
+                index = i;
+                break;
+            }
+        }
         if (index < 0)
             return MainCooldownGroup; // TODO: reconsider...
         return MainCooldownGroup + index;
@@ -95,7 +103,7 @@ public sealed record class ActionDefinition(ActionID ID)
 
     // for multi-charge abilities, action is ready when elapsed >= single-charge cd; assume that if any multi-charge actions share cooldown group, they have same cooldown - otherwise dunno how it should work
     // TODO: use adjusted cooldown
-    public float MainReadyIn(ReadOnlySpan<Cooldown> cooldowns, ReadOnlySpan<ActionID> dutyActions)
+    public float MainReadyIn(ReadOnlySpan<Cooldown> cooldowns, ReadOnlySpan<ClientState.DutyAction> dutyActions)
     {
         if (MainCooldownGroup < 0)
             return 0;
@@ -104,10 +112,10 @@ public sealed record class ActionDefinition(ActionID ID)
     }
 
     public float ExtraReadyIn(ReadOnlySpan<Cooldown> cooldowns) => ExtraCooldownGroup >= 0 ? cooldowns[ExtraCooldownGroup].Remaining : 0;
-    public float ReadyIn(ReadOnlySpan<Cooldown> cooldowns, ReadOnlySpan<ActionID> dutyActions) => Math.Max(MainReadyIn(cooldowns, dutyActions), ExtraReadyIn(cooldowns));
+    public float ReadyIn(ReadOnlySpan<Cooldown> cooldowns, ReadOnlySpan<ClientState.DutyAction> dutyActions) => Math.Max(MainReadyIn(cooldowns, dutyActions), ExtraReadyIn(cooldowns));
 
     // return time until charges are capped (for multi-charge abilities; for single-charge this is equivalent to remaining cooldown)
-    public float ChargeCapIn(ReadOnlySpan<Cooldown> cooldowns, ReadOnlySpan<ActionID> dutyActions, int level)
+    public float ChargeCapIn(ReadOnlySpan<Cooldown> cooldowns, ReadOnlySpan<ClientState.DutyAction> dutyActions, int level)
     {
         if (MainCooldownGroup < 0)
             return 0;

--- a/BossMod/Autorotation/Legacy/CommonState.cs
+++ b/BossMod/Autorotation/Legacy/CommonState.cs
@@ -29,12 +29,12 @@ public abstract class CommonState(RotationModule module)
     public float SpellGCDTime;
 
     // find a slot containing specified duty action; returns -1 if not found
-    public int FindDutyActionSlot(ActionID action) => Array.IndexOf(Module.World.Client.DutyActions, action);
+    public int FindDutyActionSlot(ActionID action) => Array.FindIndex(Module.World.Client.DutyActions, d => d.Action == action);
     // find a slot containing specified duty action, if other duty action is the specified one; returns -1 if not found, or other action is different
     public int FindDutyActionSlot(ActionID action, ActionID other)
     {
         var slot = FindDutyActionSlot(action);
-        return slot >= 0 && Module.World.Client.DutyActions[1 - slot] == other ? slot : -1;
+        return slot >= 0 && Module.World.Client.DutyActions[1 - slot].Action == other ? slot : -1;
     }
 
     public float GCD => Module.World.Client.Cooldowns[ActionDefinitions.GCDGroup].Remaining; // 2.5 max (decreased by SkS), 0 if not on gcd

--- a/BossMod/Autorotation/RotationModule.cs
+++ b/BossMod/Autorotation/RotationModule.cs
@@ -147,12 +147,12 @@ public abstract class RotationModule(RotationModuleManager manager, Actor player
     protected float PotionCD => World.Client.Cooldowns[ActionDefinitions.PotionCDGroup].Remaining; // variable max
 
     // find a slot containing specified duty action; returns -1 if not found
-    public int FindDutyActionSlot(ActionID action) => Array.IndexOf(World.Client.DutyActions, action);
+    public int FindDutyActionSlot(ActionID action) => Array.FindIndex(World.Client.DutyActions, d => d.Action == action);
     // find a slot containing specified duty action, if other duty action is the specified one; returns -1 if not found, or other action is different
     public int FindDutyActionSlot(ActionID action, ActionID other)
     {
         var slot = FindDutyActionSlot(action);
-        return slot >= 0 && World.Client.DutyActions[1 - slot] == other ? slot : -1;
+        return slot >= 0 && World.Client.DutyActions[1 - slot].Action == other ? slot : -1;
     }
 
     public float DutyActionCD(int slot) => slot is >= 0 and < 2 ? World.Client.Cooldowns[ActionDefinitions.DutyAction0CDGroup + slot].Remaining : float.MaxValue;

--- a/BossMod/Data/ClientState.cs
+++ b/BossMod/Data/ClientState.cs
@@ -1,6 +1,4 @@
-﻿using System.Windows.Markup;
-
-namespace BossMod;
+﻿namespace BossMod;
 
 public record struct ClientActionRequest
 (
@@ -39,6 +37,8 @@ public sealed class ClientState
     public record struct Gauge(ulong Low, ulong High);
     public record struct Stats(int SkillSpeed, int SpellSpeed, int Haste);
 
+    public record struct Pet(uint InstanceID, byte Order, byte Stance);
+
     public const int NumCooldownGroups = 82;
     public const int NumClassLevels = 32; // see ClassJob.ExpArrayIndex
 
@@ -50,14 +50,26 @@ public sealed class ClientState
     public Stats PlayerStats;
     public readonly Cooldown[] Cooldowns = new Cooldown[NumCooldownGroups];
     public readonly ActionID[] DutyActions = new ActionID[2];
+    public readonly byte[] DutyActionCharges = new byte[2];
     public readonly byte[] BozjaHolster = new byte[(int)BozjaHolsterID.Count]; // number of copies in holster per item
+    public readonly uint[] BlueMageSpells = new uint[24];
     public readonly short[] ClassJobLevels = new short[NumClassLevels];
     public Fate ActiveFate;
+    public Pet ActivePet;
 
     public int ClassJobLevel(Class c)
     {
         var index = Service.LuminaRow<Lumina.Excel.GeneratedSheets.ClassJob>((uint)c)?.ExpArrayIndex ?? -1;
         return index >= 0 && index < ClassJobLevels.Length ? ClassJobLevels[index] : -1;
+    }
+
+    public unsafe T GetGauge<T>() where T : unmanaged
+    {
+        T res = default;
+        ((ulong*)&res)[1] = GaugePayload.Low;
+        if (sizeof(T) > 16)
+            ((ulong*)&res)[2] = GaugePayload.High;
+        return res;
     }
 
     public IEnumerable<WorldState.Operation> CompareToInitial()
@@ -80,6 +92,8 @@ public sealed class ClientState
 
         if (DutyActions.Any(a => a))
             yield return new OpDutyActionsChange(DutyActions[0], DutyActions[1]);
+        if (DutyActionCharges.Any(a => a > 0))
+            yield return new OpDutyActionChargesChange(DutyActionCharges[0], DutyActionCharges[1]);
 
         var bozjaHolster = BozjaHolster.Select((v, i) => ((BozjaHolsterID)i, v)).Where(iv => iv.v > 0).ToList();
         if (BozjaHolster.Any(count => count != 0))
@@ -87,6 +101,12 @@ public sealed class ClientState
 
         if (ClassJobLevels.Any(a => a != 0))
             yield return new OpClassJobLevelsChange(ClassJobLevels);
+
+        if (BlueMageSpells.Any(a => a != 0))
+            yield return new OpBlueMageSpellsChange(BlueMageSpells);
+
+        if (ActivePet.InstanceID != 0)
+            yield return new OpActivePetChange(ActivePet);
     }
 
     public void Tick(float dt)
@@ -222,6 +242,18 @@ public sealed class ClientState
         public override void Write(ReplayRecorder.Output output) => output.EmitFourCC("CLDA"u8).Emit(Slot0).Emit(Slot1);
     }
 
+    public Event<OpDutyActionChargesChange> DutyActionChargesChanged = new();
+    public sealed record class OpDutyActionChargesChange(byte Slot0, byte Slot1) : WorldState.Operation
+    {
+        protected override void Exec(WorldState ws)
+        {
+            ws.Client.DutyActionCharges[0] = Slot0;
+            ws.Client.DutyActionCharges[1] = Slot1;
+            ws.Client.DutyActionChargesChanged.Fire(this);
+        }
+        public override void Write(ReplayRecorder.Output output) => output.EmitFourCC("CLDC"u8).Emit(Slot0).Emit(Slot1);
+    }
+
     public Event<OpBozjaHolsterChange> BozjaHolsterChanged = new();
     public sealed record class OpBozjaHolsterChange(List<(BozjaHolsterID entry, byte count)> Contents) : WorldState.Operation
     {
@@ -270,6 +302,43 @@ public sealed class ClientState
             output.Emit((byte)Values.Length);
             foreach (var e in Values)
                 output.Emit(e);
+        }
+    }
+
+    public Event<OpBlueMageSpellsChange> BlueMageSpellsChanged = new();
+    public sealed record class OpBlueMageSpellsChange(uint[] Values) : WorldState.Operation
+    {
+        public readonly uint[] Values = Values;
+
+        protected override void Exec(WorldState ws)
+        {
+            Array.Fill(ws.Client.BlueMageSpells, (ushort)0);
+            for (var i = 0; i < Values.Length; i++)
+                ws.Client.BlueMageSpells[i] = Values[i];
+            ws.Client.BlueMageSpellsChanged.Fire(this);
+        }
+
+        public override void Write(ReplayRecorder.Output output)
+        {
+            output.EmitFourCC("BLUS"u8);
+            output.Emit((byte)Values.Length);
+            foreach (var e in Values)
+                output.Emit(e);
+        }
+    }
+
+    public Event<OpActivePetChange> ActivePetChanged = new();
+    public sealed record class OpActivePetChange(Pet Value) : WorldState.Operation
+    {
+        protected override void Exec(WorldState ws)
+        {
+            ws.Client.ActivePet = Value;
+            ws.Client.ActivePetChanged.Fire(this);
+        }
+
+        public override void Write(ReplayRecorder.Output output)
+        {
+            output.EmitFourCC("PETS"u8).Emit(Value.InstanceID).Emit(Value.Order).Emit(Value.Stance);
         }
     }
 }

--- a/BossMod/Framework/ActionManagerEx.cs
+++ b/BossMod/Framework/ActionManagerEx.cs
@@ -167,7 +167,7 @@ public sealed unsafe class ActionManagerEx : IDisposable
         return gcd->Total - gcd->Elapsed;
     }
 
-    public (ActionID Action, byte Charges) GetDutyAction(ushort slot)
+    public ClientState.DutyAction GetDutyAction(ushort slot)
     {
         var id = ActionManager.GetDutyActionId(slot);
         if (id == 0)
@@ -178,7 +178,7 @@ public sealed unsafe class ActionManagerEx : IDisposable
 
         return new(action, dir == null ? default : *((byte*)dir + 1484 + slot));
     }
-    public ((ActionID, byte), (ActionID, byte)) GetDutyActions() => (GetDutyAction(0), GetDutyAction(1));
+    public (ClientState.DutyAction, ClientState.DutyAction) GetDutyActions() => (GetDutyAction(0), GetDutyAction(1));
 
     public uint GetAdjustedActionID(uint actionID) => _inst->GetAdjustedActionId(actionID);
 

--- a/BossMod/Framework/ActionManagerEx.cs
+++ b/BossMod/Framework/ActionManagerEx.cs
@@ -1,12 +1,12 @@
 ﻿using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.Game.Control;
+using FFXIVClientStructs.FFXIV.Client.Game.Event;
 using FFXIVClientStructs.FFXIV.Client.Game.InstanceContent;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
-using FFXIVClientStructs.FFXIV.Common.Configuration;
 using System.Runtime.InteropServices;
 using CSActionType = FFXIVClientStructs.FFXIV.Client.Game.ActionType;
 
@@ -167,12 +167,18 @@ public sealed unsafe class ActionManagerEx : IDisposable
         return gcd->Total - gcd->Elapsed;
     }
 
-    public ActionID GetDutyAction(ushort slot)
+    public (ActionID Action, byte Charges) GetDutyAction(ushort slot)
     {
         var id = ActionManager.GetDutyActionId(slot);
-        return id != 0 ? new(ActionType.Spell, id) : default;
+        if (id == 0)
+            return default;
+
+        var action = new ActionID(ActionType.Spell, id);
+        var dir = EventFramework.Instance()->GetContentDirector();
+
+        return new(action, dir == null ? default : *((byte*)dir + 1484 + slot));
     }
-    public (ActionID, ActionID) GetDutyActions() => (GetDutyAction(0), GetDutyAction(1));
+    public ((ActionID, byte), (ActionID, byte)) GetDutyActions() => (GetDutyAction(0), GetDutyAction(1));
 
     public uint GetAdjustedActionID(uint actionID) => _inst->GetAdjustedActionId(actionID);
 

--- a/BossMod/Framework/WorldStateGameSync.cs
+++ b/BossMod/Framework/WorldStateGameSync.cs
@@ -564,11 +564,9 @@ sealed class WorldStateGameSync : IDisposable
                 _ws.Execute(new ClientState.OpCooldown(false, CalcCooldownDifference(cooldowns, _ws.Client.Cooldowns.AsSpan())));
         }
 
-        var ((dutyAction0, dutyCharge0), (dutyAction1, dutyCharge1)) = _amex.GetDutyActions();
+        var (dutyAction0, dutyAction1) = _amex.GetDutyActions();
         if (_ws.Client.DutyActions[0] != dutyAction0 || _ws.Client.DutyActions[1] != dutyAction1)
             _ws.Execute(new ClientState.OpDutyActionsChange(dutyAction0, dutyAction1));
-        if (_ws.Client.DutyActionCharges[0] != dutyCharge0 || _ws.Client.DutyActionCharges[1] != dutyCharge1)
-            _ws.Execute(new ClientState.OpDutyActionChargesChange(dutyCharge0, dutyCharge1));
 
         Span<byte> bozjaHolster = stackalloc byte[_ws.Client.BozjaHolster.Length];
         bozjaHolster.Clear();

--- a/BossMod/Replay/ReplayParserLog.cs
+++ b/BossMod/Replay/ReplayParserLog.cs
@@ -334,10 +334,13 @@ public sealed class ReplayParserLog : IDisposable
             [new("CLCB"u8)] = ParseClientCombo,
             [new("CLST"u8)] = ParseClientPlayerStats,
             [new("CLCD"u8)] = ParseClientCooldown,
+            [new("CLDC"u8)] = ParseClientDutyActionCharges,
             [new("CLDA"u8)] = ParseClientDutyActions,
             [new("CLBH"u8)] = ParseClientBozjaHolster,
             [new("CLAF"u8)] = ParseClientActiveFate,
             [new("CLVL"u8)] = ParseClientClassJobLevels,
+            [new("BLUS"u8)] = ParseBlueSpells,
+            [new("PETS"u8)] = ParsePet,
             [new("IPCI"u8)] = ParseNetworkIDScramble,
             [new("IPCS"u8)] = ParseNetworkServerIPC,
         };
@@ -638,6 +641,8 @@ public sealed class ReplayParserLog : IDisposable
 
     private ClientState.OpDutyActionsChange ParseClientDutyActions() => new(_input.ReadAction(), _input.ReadAction());
 
+    private ClientState.OpDutyActionChargesChange ParseClientDutyActionCharges() => new(_input.ReadByte(false), _input.ReadByte(false));
+
     private ClientState.OpBozjaHolsterChange ParseClientBozjaHolster()
     {
         List<(BozjaHolsterID, byte)> contents = [];
@@ -656,6 +661,16 @@ public sealed class ReplayParserLog : IDisposable
             contents[i] = _input.ReadShort();
         return new(contents);
     }
+
+    private ClientState.OpBlueMageSpellsChange ParseBlueSpells()
+    {
+        var contents = new uint[_input.ReadByte(false)];
+        for (int i = 0; i < contents.Length; i++)
+            contents[i] = _input.ReadUInt(false);
+        return new(contents);
+    }
+
+    private ClientState.OpActivePetChange ParsePet() => new(new(_input.ReadUInt(false), _input.ReadByte(false), _input.ReadByte(false)));
 
     private NetworkState.OpIDScramble ParseNetworkIDScramble() => new(_input.ReadUInt(false));
     private NetworkState.OpServerIPC ParseNetworkServerIPC() => new(new((Network.ServerIPC.PacketID)_input.ReadInt(), _input.ReadUShort(false), _input.ReadUInt(false), _input.ReadUInt(true), new(_input.ReadLong()), _input.ReadBytes()));

--- a/BossMod/Replay/ReplayParserLog.cs
+++ b/BossMod/Replay/ReplayParserLog.cs
@@ -334,7 +334,6 @@ public sealed class ReplayParserLog : IDisposable
             [new("CLCB"u8)] = ParseClientCombo,
             [new("CLST"u8)] = ParseClientPlayerStats,
             [new("CLCD"u8)] = ParseClientCooldown,
-            [new("CLDC"u8)] = ParseClientDutyActionCharges,
             [new("CLDA"u8)] = ParseClientDutyActions,
             [new("CLBH"u8)] = ParseClientBozjaHolster,
             [new("CLAF"u8)] = ParseClientActiveFate,
@@ -639,9 +638,7 @@ public sealed class ReplayParserLog : IDisposable
         return new(reset, cooldowns);
     }
 
-    private ClientState.OpDutyActionsChange ParseClientDutyActions() => new(_input.ReadAction(), _input.ReadAction());
-
-    private ClientState.OpDutyActionChargesChange ParseClientDutyActionCharges() => new(_input.ReadByte(false), _input.ReadByte(false));
+    private ClientState.OpDutyActionsChange ParseClientDutyActions() => new(new(_input.ReadAction(), _input.ReadByte(false)), new(_input.ReadAction(), _input.ReadByte(false)));
 
     private ClientState.OpBozjaHolsterChange ParseClientBozjaHolster()
     {

--- a/BossMod/Replay/ReplayRecorder.cs
+++ b/BossMod/Replay/ReplayRecorder.cs
@@ -163,7 +163,7 @@ public sealed class ReplayRecorder : IDisposable
     private readonly Output _logger;
     private readonly EventSubscription _subscription;
 
-    public const int Version = 19;
+    public const int Version = 20;
 
     public ReplayRecorder(WorldState ws, ReplayLogFormat format, bool logInitialState, DirectoryInfo targetDirectory, string logPrefix)
     {


### PR DESCRIPTION
- pet state needed for scholar, used to check whether a Place order is currently active so we don't spam it trying to place Eos at fight start
- duty action charges are dynamically updated during some duties, specifically in this case the thancred vs ran'jit fight. the duty action should always be used ASAP if it has a charge, but if it doesn't have a charge, then pushing it onto the queue just locks up the rotation.
- BLU spells for obvious reasons