### PR TITLE
Added animation lock simulated delay options

### DIFF
--- a/BossMod/ActionTweaks/ActionTweaksConfig.cs
+++ b/BossMod/ActionTweaks/ActionTweaksConfig.cs
@@ -9,6 +9,7 @@ public sealed class ActionTweaksConfig : ConfigNode
 
     [PropertyDisplay("Animation lock max delay (read tooltip!)", tooltip: "Configures the maximum simulated delay in milliseconds when using animation lock removal - this is required and cannot be reduced to zero. Setting this to 20ms will enable triple-weaving when using autorotation. The minimum setting to remove triple-weaving is 26ms. The minimum of 20ms has been accepted by FFLogs and should not cause issues with your logs.")]
     [PropertySlider(20, 50, Speed = 0.1f, Width = 100)]
+    [PropertySlider(20, 50, Speed = 0.1f)]
     public int AnimationLockDelayMax = 26;
 
     [PropertyDisplay("Remove extra framerate-induced cooldown delay", tooltip: "Dynamically adjusts cooldown and animation locks to ensure queued actions resolve immediately regardless of framerate limitations")]

--- a/BossMod/ActionTweaks/ActionTweaksConfig.cs
+++ b/BossMod/ActionTweaks/ActionTweaksConfig.cs
@@ -7,8 +7,7 @@ public sealed class ActionTweaksConfig : ConfigNode
     [PropertyDisplay("Remove extra lag-induced animation lock delay from instant casts (read tooltip!)", tooltip: "Do NOT use with XivAlexander or NoClippy - this should automatically disable itself if they are detected, but double check first!")]
     public bool RemoveAnimationLockDelay = false;
 
-    [PropertyDisplay("Animation lock max delay (read tooltip!)", tooltip: "Configures the maximum simulated delay in milliseconds when using animation lock removal - this is required and cannot be reduced to zero. Setting this to 20ms will enable triple-weaving when using autorotation. The minimum setting to remove triple-weaving is 26ms. The minimum of 20ms has been accepted by FFLogs and should not cause issues with your logs.")]
-    [PropertySlider(20, 50, Speed = 0.1f, Width = 100)]
+    [PropertyDisplay("Animation lock max. simulated delay (read tooltip!)", tooltip: "Configures the maximum simulated delay in milliseconds when using animation lock removal - this is required and cannot be reduced to zero. Setting this to 20ms will enable triple-weaving when using autorotation. The minimum setting to remove triple-weaving is 26ms. The minimum of 20ms has been accepted by FFLogs and should not cause issues with your logs.")]
     [PropertySlider(20, 50, Speed = 0.1f)]
     public int AnimationLockDelayMax = 26;
 

--- a/BossMod/ActionTweaks/ActionTweaksConfig.cs
+++ b/BossMod/ActionTweaks/ActionTweaksConfig.cs
@@ -7,6 +7,10 @@ public sealed class ActionTweaksConfig : ConfigNode
     [PropertyDisplay("Remove extra lag-induced animation lock delay from instant casts (read tooltip!)", tooltip: "Do NOT use with XivAlexander or NoClippy - this should automatically disable itself if they are detected, but double check first!")]
     public bool RemoveAnimationLockDelay = false;
 
+    [PropertyDisplay("Animation lock max delay (read tooltip!)", tooltip: "Configures the maximum simulated delay in milliseconds when using animation lock removal - this is required and cannot be reduced to zero. Setting this to 20ms will enable triple-weaving when using autorotation. The minimum setting to remove triple-weaving is 26ms. The minimum of 20ms has been accepted by FFLogs and should not cause issues with your logs.")]
+    [PropertySlider(20, 50, Speed = 0.1f, Width = 100)]
+    public int AnimationLockDelayMax = 26;
+
     [PropertyDisplay("Remove extra framerate-induced cooldown delay", tooltip: "Dynamically adjusts cooldown and animation locks to ensure queued actions resolve immediately regardless of framerate limitations")]
     public bool RemoveCooldownDelay = false;
 

--- a/BossMod/ActionTweaks/AnimationLockTweak.cs
+++ b/BossMod/ActionTweaks/AnimationLockTweak.cs
@@ -19,7 +19,7 @@ public sealed class AnimationLockTweak
     private float _lastReqInitialAnimLock;
     private int _lastReqSequence = -1;
 
-    public float DelayMax = 0.02f; // TODO: tweak
+    public float DelayMax => _config.AnimationLockDelayMax * .001f;
     public float DelaySmoothing = 0.8f; // TODO tweak
     public float DelayAverage { get; private set; } = 0.1f; // smoothed delay between client request and server response
     public float DelayEstimate => _config.RemoveAnimationLockDelay ? DelayMax : MathF.Min(DelayAverage * 1.5f, 0.1f); // this is a conservative estimate

--- a/BossMod/Config/ConfigNode.cs
+++ b/BossMod/Config/ConfigNode.cs
@@ -41,7 +41,6 @@ public sealed class PropertySliderAttribute(float min, float max) : Attribute
     public float Min { get; } = min;
     public float Max { get; } = max;
     public bool Logarithmic { get; set; }
-    public int Width { get; set; } // sets the width of the slider in pixels
 }
 
 // base class for configuration nodes

--- a/BossMod/Config/ConfigNode.cs
+++ b/BossMod/Config/ConfigNode.cs
@@ -41,6 +41,7 @@ public sealed class PropertySliderAttribute(float min, float max) : Attribute
     public float Min { get; } = min;
     public float Max { get; } = max;
     public bool Logarithmic { get; set; }
+    public int Width { get; set; } // sets the width of the slider in pixels
 }
 
 // base class for configuration nodes

--- a/BossMod/Config/ConfigUI.cs
+++ b/BossMod/Config/ConfigUI.cs
@@ -194,10 +194,7 @@ public sealed class ConfigUI : IDisposable
             var flags = ImGuiSliderFlags.None;
             if (slider.Logarithmic)
                 flags |= ImGuiSliderFlags.Logarithmic;
-            if (slider.Width != 0)
-            {
-                ImGui.SetNextItemWidth(slider.Width);
-            }
+            ImGui.SetNextItemWidth(ImGui.GetWindowWidth() * 0.30f);
             if (ImGui.DragFloat(label, ref v, slider.Speed, slider.Min, slider.Max, "%.3f", flags))
             {
                 member.SetValue(node, v);
@@ -224,10 +221,7 @@ public sealed class ConfigUI : IDisposable
             var flags = ImGuiSliderFlags.None;
             if (slider.Logarithmic)
                 flags |= ImGuiSliderFlags.Logarithmic;
-            if (slider.Width != 0)
-            {
-                ImGui.SetNextItemWidth(slider.Width);
-            }
+            ImGui.SetNextItemWidth(ImGui.GetWindowWidth() * 0.30f);
             if (ImGui.DragInt(label, ref v, slider.Speed, (int)slider.Min, (int)slider.Max, "%d", flags))
             {
                 member.SetValue(node, v);

--- a/BossMod/Config/ConfigUI.cs
+++ b/BossMod/Config/ConfigUI.cs
@@ -194,6 +194,10 @@ public sealed class ConfigUI : IDisposable
             var flags = ImGuiSliderFlags.None;
             if (slider.Logarithmic)
                 flags |= ImGuiSliderFlags.Logarithmic;
+            if (slider.Width != 0)
+            {
+                ImGui.SetNextItemWidth(slider.Width);
+            }
             if (ImGui.DragFloat(label, ref v, slider.Speed, slider.Min, slider.Max, "%.3f", flags))
             {
                 member.SetValue(node, v);
@@ -220,6 +224,10 @@ public sealed class ConfigUI : IDisposable
             var flags = ImGuiSliderFlags.None;
             if (slider.Logarithmic)
                 flags |= ImGuiSliderFlags.Logarithmic;
+            if (slider.Width != 0)
+            {
+                ImGui.SetNextItemWidth(slider.Width);
+            }
             if (ImGui.DragInt(label, ref v, slider.Speed, (int)slider.Min, (int)slider.Max, "%d", flags))
             {
                 member.SetValue(node, v);

--- a/BossMod/Config/ConfigUI.cs
+++ b/BossMod/Config/ConfigUI.cs
@@ -1,6 +1,7 @@
 ﻿using BossMod.Autorotation;
 using Dalamud.Interface.Utility.Raii;
 using ImGuiNET;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 
@@ -194,7 +195,7 @@ public sealed class ConfigUI : IDisposable
             var flags = ImGuiSliderFlags.None;
             if (slider.Logarithmic)
                 flags |= ImGuiSliderFlags.Logarithmic;
-            ImGui.SetNextItemWidth(ImGui.GetWindowWidth() * 0.30f);
+            ImGui.SetNextItemWidth(MathF.Min(ImGui.GetWindowWidth() * 0.30f, 175));
             if (ImGui.DragFloat(label, ref v, slider.Speed, slider.Min, slider.Max, "%.3f", flags))
             {
                 member.SetValue(node, v);
@@ -221,7 +222,7 @@ public sealed class ConfigUI : IDisposable
             var flags = ImGuiSliderFlags.None;
             if (slider.Logarithmic)
                 flags |= ImGuiSliderFlags.Logarithmic;
-            ImGui.SetNextItemWidth(ImGui.GetWindowWidth() * 0.30f);
+            ImGui.SetNextItemWidth(MathF.Min(ImGui.GetWindowWidth() * 0.30f, 175));
             if (ImGui.DragInt(label, ref v, slider.Speed, (int)slider.Min, (int)slider.Max, "%d", flags))
             {
                 member.SetValue(node, v);


### PR DESCRIPTION
- Added an option under Action Tweaks config to change the simulated animation lock delay from 20ms (what it was set before) to anything from 20ms to 50ms
- Tooltip explains that 26ms is the minimum to prevent triple-weaving
- Set the default for this config parameter to 26ms to prevent people using the tweak and "accidentally" triple-weaving
- Slider was really wide so I added a parameter in `PropertySlider` for the width of the slider in pixels

Tooltip reads as follows:
> Configures the maximum simulated delay in milliseconds when using animation lock removal - this is required and cannot be reduced to zero. Setting this to 20ms will enable triple-weaving when using autorotation. The minimum setting to remove triple-weaving is 26ms. The minimum of 20ms has been accepted by FFLogs and should not cause issues with your logs.

Screenshots of changes:
![image](https://github.com/user-attachments/assets/97c772b7-9e4d-46cf-8d78-3b16237f36f4) 
![image](https://github.com/user-attachments/assets/baa002fb-6b08-4d02-985a-72019bacc323)
