### PR TITLE
ihuykatumu boss 1: widen persistent cone aoe

### DIFF
--- a/BossMod/Modules/Dawntrail/Dungeon/D01Ihuykatumu/D011PrimePunutiy.cs
+++ b/BossMod/Modules/Dawntrail/Dungeon/D01Ihuykatumu/D011PrimePunutiy.cs
@@ -60,7 +60,7 @@ class Resurface(BossModule module) : Components.GenericAOEs(module)
     private Actor? _source;
     private DateTime _activation;
 
-    private static readonly AOEShapeCone _shape = new(100, 30.Degrees());
+    private static readonly AOEShapeCone _shape = new(100, 32.Degrees());
 
     public override IEnumerable<AOEInstance> ActiveAOEs(int slot, Actor actor)
     {


### PR DESCRIPTION
i had this set as 64 degrees in my local copy because i kept getting clipped by 60 degrees, even though that's the width of the visual. i think this might be slightly too wide but if it keeps people from getting hit then it's fine