### PR TITLE
Fix Eliminator AOEs showing up after subroutine 3 ends if you kill adds too quickly

### DIFF
--- a/BossMod/Modules/Dawntrail/Dungeon/D06Alexandria/D063Eliminator.cs
+++ b/BossMod/Modules/Dawntrail/Dungeon/D06Alexandria/D063Eliminator.cs
@@ -140,12 +140,20 @@ class LightOfSalvation(BossModule module) : Components.BaitAwayCast(module, Acti
 
     public override void OnEventCast(Actor caster, ActorCastEvent spell)
     {
-        if ((AID)spell.Action.ID == AID.LightOfSalvationAOE)
+        if ((AID)spell.Action.ID is AID.LightOfSalvationAOE or AID.Subroutine3End or AID.LightOfDevotionAOE)
             CurrentBaits.Clear();
     }
 }
 
-class LightOfDevotion(BossModule module) : Components.SimpleLineStack(module, 3, 40, ActionID.MakeSpell(AID.LightOfDevotionTargetSelect), ActionID.MakeSpell(AID.LightOfDevotionAOE), 5.6f);
+class LightOfDevotion(BossModule module) : Components.SimpleLineStack(module, 3, 40, ActionID.MakeSpell(AID.LightOfDevotionTargetSelect), ActionID.MakeSpell(AID.LightOfDevotionAOE), 5.6f)
+{
+    public override void OnEventCast(Actor caster, ActorCastEvent spell)
+    {
+        if ((AID)spell.Action.ID is AID.Subroutine3End)
+            spell.Action = ActionID.MakeSpell(AID.LightOfDevotionAOE);
+        base.OnEventCast(caster, spell);
+    }
+}
 
 class EliminationExplosion(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.EliminationExplosion), new AOEShapeRect(25, 4, 25), 4);
 


### PR DESCRIPTION
This fixes two scenarios I encountered:
1. Subroutine 3 ends during light of salvation. Line baits appear for the remainder of the fight. In both replays I encountered this, LightOfDevotionAOE is cast to signify the end of the phase. Subroutine3End did not go off, but I left in the AID just in case.
2. Subroutine 3 ends during light of devotion. Line stack appears for the remainder of the fight. In the replay I encountered this, Subroutine3End is cast to signify the end of the phase and LightOfDevotionAOE is not cast.