### PR TITLE
changelog display

### DIFF
--- a/BossMod/ActionTweaks/OutOfCombatActionsTweak.cs
+++ b/BossMod/ActionTweaks/OutOfCombatActionsTweak.cs
@@ -1,6 +1,6 @@
 ﻿namespace BossMod;
 
-[ConfigDisplay(Name = "Automatic out-of-combat utility actions", Parent = typeof(ActionTweaksConfig))]
+[ConfigDisplay(Name = "Automatic out-of-combat utility actions", Parent = typeof(ActionTweaksConfig), Since = "0.0.0.245")]
 class OutOfCombatActionsConfig : ConfigNode
 {
     [PropertyDisplay("Enable the feature")]

--- a/BossMod/ActionTweaks/SmartRotationTweak.cs
+++ b/BossMod/ActionTweaks/SmartRotationTweak.cs
@@ -1,6 +1,6 @@
 ﻿namespace BossMod;
 
-[ConfigDisplay(Name = "Smart character orientation", Parent = typeof(ActionTweaksConfig))]
+[ConfigDisplay(Name = "Smart character orientation", Parent = typeof(ActionTweaksConfig), Since = "0.0.0.229")]
 class SmartRotationConfig : ConfigNode
 {
     [PropertyDisplay("Enable the feature", tooltip: "Replace in-game 'auto face target' option with a smarter alternative.\nWhen using an action, changes direction only if target is not in frontal cone.\nDuring cast, keep character facing the target.")]

--- a/BossMod/Config/ChangelogDisplay.cs
+++ b/BossMod/Config/ChangelogDisplay.cs
@@ -80,7 +80,8 @@ public static class ChangelogDisplay
     private static Version GetPreviousPluginVersion(ChangelogProperties props)
     {
 #if DEBUG
-        return new(0, 0, 0, 0);
+        // change value to something sensible if you want to test the changelog stuff
+        return new(0, 0, 0, 999);
 #endif
         return props.BossModVersion;
     }

--- a/BossMod/Config/ChangelogDisplay.cs
+++ b/BossMod/Config/ChangelogDisplay.cs
@@ -74,7 +74,7 @@ public static class ChangelogDisplay
         // version is always 0.0.0.0 in debug, making it useless for testing
         return new(0, 0, 0, 999);
 #endif
-        return Assembly.GetExecutingAssembly().GetName().Version;
+        return Assembly.GetExecutingAssembly().GetName().Version!;
     }
 
     private static Version GetPreviousPluginVersion(ChangelogProperties props)

--- a/BossMod/Config/ChangelogDisplay.cs
+++ b/BossMod/Config/ChangelogDisplay.cs
@@ -1,0 +1,126 @@
+﻿using Dalamud.Interface.Utility.Raii;
+using ImGuiNET;
+using System.Reflection;
+
+namespace BossMod.Config;
+
+public sealed class ChangelogProperties : ConfigNode
+{
+    public Version BossModVersion { get; set; } = new(0, 0, 0, 0);
+}
+
+public class ChangelogWindow(Version old, List<VersionedField> fields) : UIWindow("VBM Changelog", false, new(400, 300))
+{
+    private readonly List<string> ProcessedFields = [];
+
+    private void SetOption(VersionedField field, bool value)
+    {
+        field.FieldInfo.SetValue(field.Node, value);
+        ProcessedFields.Add(field.FieldKey);
+        if (ProcessedFields.Count >= fields.Count)
+        {
+            IsOpen = false;
+            Service.Config.Modified.Fire();
+        }
+    }
+
+    public override void Draw()
+    {
+        ImGui.TextUnformatted($"The following config options have been added since version {old}:");
+
+        ImGui.Separator();
+
+        foreach (var group in fields.Where(f => !ProcessedFields.Contains(f.FieldKey)).GroupBy(f => f.Node.GetType()))
+        {
+            ImGui.TextUnformatted(group.Key.GetCustomAttribute<ConfigDisplayAttribute>()?.Name ?? "");
+            foreach (var f in group)
+            {
+                using var id = ImRaii.PushId($"changelog{f.FieldKey}");
+
+                var disp = f.FieldInfo.GetCustomAttribute<PropertyDisplayAttribute>();
+
+                ImGui.Bullet();
+                if (!string.IsNullOrEmpty(disp?.Tooltip))
+                    UIMisc.HelpMarker(disp!.Tooltip);
+                ImGui.SameLine();
+                ImGui.TextUnformatted(disp?.Label ?? "unknown");
+                ImGui.SameLine();
+                if (ImGui.Button("Enable"))
+                {
+                    SetOption(f, true);
+                    return;
+                }
+                ImGui.SameLine();
+                if (ImGui.Button("Disable"))
+                {
+                    SetOption(f, false);
+                    return;
+                }
+            }
+        }
+    }
+}
+
+public record VersionedField(ConfigNode Node, FieldInfo FieldInfo, Version AddedVersion)
+{
+    public string FieldKey => $"{Node}.{FieldInfo.Name}";
+}
+
+public static class ChangelogDisplay
+{
+    private static Version GetCurrentPluginVersion()
+    {
+#if DEBUG
+        // version is always 0.0.0.0 in debug, making it useless for testing
+        return new(0, 0, 0, 999);
+#endif
+        return Assembly.GetExecutingAssembly().GetName().Version;
+    }
+
+    private static Version GetPreviousPluginVersion(ChangelogProperties props)
+    {
+#if DEBUG
+        return new(0, 0, 0, 0);
+#endif
+        return props.BossModVersion;
+    }
+
+    private static IEnumerable<VersionedField> GetAllFields()
+    {
+        foreach (var n in Service.Config.Nodes)
+        {
+            var sinceNode = n.GetType().GetCustomAttribute<ConfigDisplayAttribute>()?.Since;
+
+            foreach (var f in n.GetType().GetFields())
+            {
+                // i don't feel like supporting non bool fields
+                if (f.FieldType != typeof(bool))
+                    continue;
+
+                if (sinceNode != null)
+                    yield return new(n, f, Version.Parse(sinceNode));
+
+                else if (f.GetCustomAttribute<PropertyDisplayAttribute>()?.Since is string sinceVersion)
+                    yield return new(n, f, Version.Parse(sinceVersion));
+            }
+        }
+    }
+
+    public static void UpdateAndNotifyUser()
+    {
+        var props = Service.Config.Get<ChangelogProperties>();
+        var previousVersion = GetPreviousPluginVersion(props);
+        var currentVersion = GetCurrentPluginVersion();
+
+        props.BossModVersion = currentVersion;
+
+        var fields = GetAllFields().Where(f => f.AddedVersion > previousVersion).ToList();
+        if (fields.Count > 0)
+        {
+            var win = new ChangelogWindow(previousVersion, fields)
+            {
+                IsOpen = true
+            };
+        }
+    }
+}

--- a/BossMod/Config/ConfigNode.cs
+++ b/BossMod/Config/ConfigNode.cs
@@ -10,16 +10,18 @@ public sealed class ConfigDisplayAttribute : Attribute
     public string? Name { get; set; }
     public int Order { get; set; }
     public Type? Parent { get; set; }
+    public string? Since { get; set; }
 }
 
 // attribute that specifies how config node field or enumeration value is shown in the UI
 [AttributeUsage(AttributeTargets.Field)]
-public sealed class PropertyDisplayAttribute(string label, uint color = 0xffffffff, string tooltip = "", bool separator = false) : Attribute
+public sealed class PropertyDisplayAttribute(string label, uint color = 0xffffffff, string tooltip = "", bool separator = false, string? since = null) : Attribute
 {
     public string Label { get; } = label;
     public uint Color { get; } = color;
     public string Tooltip { get; } = tooltip;
     public bool Separator { get; } = separator;
+    public string? Since { get; } = since;
 }
 
 // attribute that specifies combobox should be used for displaying int/bool property

--- a/BossMod/Framework/Plugin.cs
+++ b/BossMod/Framework/Plugin.cs
@@ -1,4 +1,5 @@
 ﻿using BossMod.Autorotation;
+using BossMod.Config;
 using Dalamud.Common;
 using Dalamud.Game;
 using Dalamud.Game.ClientState.Conditions;
@@ -97,6 +98,8 @@ public sealed class Plugin : IDalamudPlugin
         dalamud.UiBuilder.DisableAutomaticUiHide = true;
         dalamud.UiBuilder.Draw += DrawUI;
         dalamud.UiBuilder.OpenConfigUi += () => OpenConfigUI();
+
+        ChangelogDisplay.UpdateAndNotifyUser();
     }
 
     public void Dispose()


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b58c5376-0363-40ff-bf0b-e4d93d797e13)

it is not pretty but it should work. only applies to config options that have bool values, other ones are assumed to have sensible defaults.

each option disappears once you click "Enable" or "Disable". the window itself disappears once all the options have been acknowledged by the user. we track which options to display in this window by storing the current and previous plugin assembly versions in config and only displaying the config options that are newer than previous

i tested this by hardcoding the previous plugin version in ChangelogDisplay to 0.0.0.0 and then to 0.0.0.245, seems to work