### PR TITLE
Custom Shape API for AOEs and ArenaBounds 

### DIFF
--- a/BossMod/BossMod.csproj
+++ b/BossMod/BossMod.csproj
@@ -31,9 +31,11 @@
   <ItemGroup>
     <Using Include="System" />
     <Using Include="System.Collections" />
+    <Using Include="System.Collections.Concurrent" />
     <Using Include="System.Collections.Generic" />
     <Using Include="System.Collections.Immutable" />
     <Using Include="System.Linq" />
+    <Using Include="System.Threading.Tasks;" />
     <Using Include="System.Numerics" />
   </ItemGroup>
 

--- a/BossMod/BossModule/AOEShapes.cs
+++ b/BossMod/BossModule/AOEShapes.cs
@@ -7,10 +7,7 @@ public abstract record class AOEShape
     public abstract void Outline(MiniArena arena, WPos origin, Angle rotation, uint color = 0);
     public abstract Func<WPos, float> Distance(WPos origin, Angle rotation);
 
-    public bool Check(WPos position, Actor? origin)
-    {
-        return origin != null && Check(position, origin.Position, origin.Rotation);
-    }
+    public bool Check(WPos position, Actor? origin) => origin != null && Check(position, origin.Position, origin.Rotation);
 
     public void Draw(MiniArena arena, Actor? origin, uint color = 0)
     {
@@ -25,27 +22,37 @@ public abstract record class AOEShape
     }
 }
 
-public sealed record class AOEShapeCone(float Radius, Angle HalfAngle, Angle DirectionOffset = default) : AOEShape
+public sealed record class AOEShapeCone(float Radius, Angle HalfAngle, Angle DirectionOffset = default, bool InvertForbiddenZone = false) : AOEShape
 {
-    public override string ToString() => $"Cone: r={Radius:f3}, angle={HalfAngle * 2}, off={DirectionOffset}";
+    public override string ToString() => $"Cone: r={Radius:f3}, angle={HalfAngle * 2}, off={DirectionOffset}, ifz={InvertForbiddenZone}";
     public override bool Check(WPos position, WPos origin, Angle rotation) => position.InCircleCone(origin, Radius, rotation + DirectionOffset, HalfAngle);
     public override void Draw(MiniArena arena, WPos origin, Angle rotation, uint color = 0) => arena.ZoneCone(origin, 0, Radius, rotation + DirectionOffset, HalfAngle, color);
     public override void Outline(MiniArena arena, WPos origin, Angle rotation, uint color = 0) => arena.AddCone(origin, Radius, rotation + DirectionOffset, HalfAngle, color);
-    public override Func<WPos, float> Distance(WPos origin, Angle rotation) => ShapeDistance.Cone(origin, Radius, rotation + DirectionOffset, HalfAngle);
+    public override Func<WPos, float> Distance(WPos origin, Angle rotation)
+    {
+        return !InvertForbiddenZone
+            ? ShapeDistance.Cone(origin, Radius, rotation + DirectionOffset, HalfAngle)
+            : ShapeDistance.InvertedCone(origin, Radius, rotation + DirectionOffset, HalfAngle);
+    }
 }
 
-public sealed record class AOEShapeCircle(float Radius) : AOEShape
+public sealed record class AOEShapeCircle(float Radius, bool InvertForbiddenZone = false) : AOEShape
 {
-    public override string ToString() => $"Circle: r={Radius:f3}";
+    public override string ToString() => $"Circle: r={Radius:f3}, ifz={InvertForbiddenZone}";
     public override bool Check(WPos position, WPos origin, Angle rotation = new()) => position.InCircle(origin, Radius);
     public override void Draw(MiniArena arena, WPos origin, Angle rotation = new(), uint color = 0) => arena.ZoneCircle(origin, Radius, color);
     public override void Outline(MiniArena arena, WPos origin, Angle rotation = new(), uint color = 0) => arena.AddCircle(origin, Radius, color);
-    public override Func<WPos, float> Distance(WPos origin, Angle rotation) => ShapeDistance.Circle(origin, Radius);
+    public override Func<WPos, float> Distance(WPos origin, Angle rotation)
+    {
+        return !InvertForbiddenZone
+            ? ShapeDistance.Circle(origin, Radius)
+            : ShapeDistance.InvertedCircle(origin, Radius);
+    }
 }
 
-public sealed record class AOEShapeDonut(float InnerRadius, float OuterRadius) : AOEShape
+public sealed record class AOEShapeDonut(float InnerRadius, float OuterRadius, bool InvertForbiddenZone = false) : AOEShape
 {
-    public override string ToString() => $"Donut: r={InnerRadius:f3}-{OuterRadius:f3}";
+    public override string ToString() => $"Donut: r={InnerRadius:f3}-{OuterRadius:f3}, ifz={InvertForbiddenZone}";
     public override bool Check(WPos position, WPos origin, Angle rotation = new()) => position.InDonut(origin, InnerRadius, OuterRadius);
     public override void Draw(MiniArena arena, WPos origin, Angle rotation = new(), uint color = 0) => arena.ZoneDonut(origin, InnerRadius, OuterRadius, color);
     public override void Outline(MiniArena arena, WPos origin, Angle rotation = new(), uint color = 0)
@@ -53,41 +60,53 @@ public sealed record class AOEShapeDonut(float InnerRadius, float OuterRadius) :
         arena.AddCircle(origin, InnerRadius, color);
         arena.AddCircle(origin, OuterRadius, color);
     }
-    public override Func<WPos, float> Distance(WPos origin, Angle rotation) => ShapeDistance.Donut(origin, InnerRadius, OuterRadius);
+    public override Func<WPos, float> Distance(WPos origin, Angle rotation)
+    {
+        return !InvertForbiddenZone
+            ? ShapeDistance.Donut(origin, InnerRadius, OuterRadius)
+            : ShapeDistance.InvertedDonut(origin, InnerRadius, OuterRadius);
+    }
 }
 
-public sealed record class AOEShapeDonutSector(float InnerRadius, float OuterRadius, Angle HalfAngle, Angle DirectionOffset = default) : AOEShape
+public sealed record class AOEShapeDonutSector(float InnerRadius, float OuterRadius, Angle HalfAngle, Angle DirectionOffset = default, bool InvertForbiddenZone = false) : AOEShape
 {
-    public override string ToString() => $"Donut sector: r={InnerRadius:f3}-{OuterRadius:f3}, angle={HalfAngle * 2}, off={DirectionOffset}";
+    public override string ToString() => $"Donut sector: r={InnerRadius:f3}-{OuterRadius:f3}, angle={HalfAngle * 2}, off={DirectionOffset}, ifz={InvertForbiddenZone}";
     public override bool Check(WPos position, WPos origin, Angle rotation) => position.InDonutCone(origin, InnerRadius, OuterRadius, rotation + DirectionOffset, HalfAngle);
     public override void Draw(MiniArena arena, WPos origin, Angle rotation, uint color = 0) => arena.ZoneCone(origin, InnerRadius, OuterRadius, rotation + DirectionOffset, HalfAngle, color);
     public override void Outline(MiniArena arena, WPos origin, Angle rotation, uint color = 0) => arena.AddDonutCone(origin, InnerRadius, OuterRadius, rotation + DirectionOffset, HalfAngle, color);
-    public override Func<WPos, float> Distance(WPos origin, Angle rotation) => ShapeDistance.DonutSector(origin, InnerRadius, OuterRadius, rotation + DirectionOffset, HalfAngle);
+    public override Func<WPos, float> Distance(WPos origin, Angle rotation)
+    {
+        return !InvertForbiddenZone
+            ? ShapeDistance.DonutSector(origin, InnerRadius, OuterRadius, rotation + DirectionOffset, HalfAngle)
+            : ShapeDistance.InvertedDonutSector(origin, InnerRadius, OuterRadius, rotation + DirectionOffset, HalfAngle);
+    }
 }
 
-public sealed record class AOEShapeRect(float LengthFront, float HalfWidth, float LengthBack = 0, Angle DirectionOffset = default) : AOEShape
+public sealed record class AOEShapeRect(float LengthFront, float HalfWidth, float LengthBack = 0, Angle DirectionOffset = default, bool InvertForbiddenZone = false) : AOEShape
 {
-    public override string ToString() => $"Rect: l={LengthFront:f3}+{LengthBack:f3}, w={HalfWidth * 2}, off={DirectionOffset}";
+    public override string ToString() => $"Rect: l={LengthFront:f3}+{LengthBack:f3}, w={HalfWidth * 2}, off={DirectionOffset}, ifz={InvertForbiddenZone}";
     public override bool Check(WPos position, WPos origin, Angle rotation) => position.InRect(origin, rotation + DirectionOffset, LengthFront, LengthBack, HalfWidth);
     public override void Draw(MiniArena arena, WPos origin, Angle rotation, uint color = 0) => arena.ZoneRect(origin, rotation + DirectionOffset, LengthFront, LengthBack, HalfWidth, color);
     public override void Outline(MiniArena arena, WPos origin, Angle rotation, uint color = 0) => arena.AddRect(origin, (rotation + DirectionOffset).ToDirection(), LengthFront, LengthBack, HalfWidth, color);
-    public override Func<WPos, float> Distance(WPos origin, Angle rotation) => ShapeDistance.Rect(origin, rotation + DirectionOffset, LengthFront, LengthBack, HalfWidth);
+    public override Func<WPos, float> Distance(WPos origin, Angle rotation)
+    {
+        return !InvertForbiddenZone
+            ? ShapeDistance.Rect(origin, rotation + DirectionOffset, LengthFront, LengthBack, HalfWidth)
+            : ShapeDistance.InvertedRect(origin, rotation + DirectionOffset, LengthFront, LengthBack, HalfWidth);
+    }
 }
 
-public sealed record class AOEShapeCross(float Length, float HalfWidth, Angle DirectionOffset = default) : AOEShape
+public sealed record class AOEShapeCross(float Length, float HalfWidth, Angle DirectionOffset = default, bool InvertForbiddenZone = false) : AOEShape
 {
-    public override string ToString() => $"Cross: l={Length:f3}, w={HalfWidth * 2}, off={DirectionOffset}";
+    public override string ToString() => $"Cross: l={Length:f3}, w={HalfWidth * 2}, off={DirectionOffset}, ifz={InvertForbiddenZone}";
     public override bool Check(WPos position, WPos origin, Angle rotation) => position.InRect(origin, rotation + DirectionOffset, Length, Length, HalfWidth) || position.InRect(origin, rotation + DirectionOffset, HalfWidth, HalfWidth, Length);
     public override void Draw(MiniArena arena, WPos origin, Angle rotation, uint color = 0) => arena.ZonePoly((GetType(), origin, rotation + DirectionOffset, Length, HalfWidth), ContourPoints(origin, rotation), color);
-
     public override void Outline(MiniArena arena, WPos origin, Angle rotation, uint color = 0)
     {
         foreach (var p in ContourPoints(origin, rotation))
             arena.PathLineTo(p);
         arena.PathStroke(true, color);
     }
-
-    public override Func<WPos, float> Distance(WPos origin, Angle rotation) => ShapeDistance.Cross(origin, rotation + DirectionOffset, Length, HalfWidth);
 
     private IEnumerable<WPos> ContourPoints(WPos origin, Angle rotation, float offset = 0)
     {
@@ -110,14 +129,164 @@ public sealed record class AOEShapeCross(float Length, float HalfWidth, Angle Di
         yield return origin + dx2 + dy2;
         yield return origin + dx1 + dy2;
     }
+
+    public override Func<WPos, float> Distance(WPos origin, Angle rotation)
+    {
+        return !InvertForbiddenZone
+            ? ShapeDistance.Cross(origin, rotation + DirectionOffset, Length, HalfWidth)
+            : ShapeDistance.InvertedCross(origin, rotation + DirectionOffset, Length, HalfWidth);
+    }
 }
 
-// note: it's very rare, not sure it needs to be a common utility - it's an isosceles triangle, a cone with flat base
-public sealed record class AOEShapeTriCone(float SideLength, Angle HalfAngle, Angle DirectionOffset = default) : AOEShape
+public sealed record class AOEShapeTriCone(float SideLength, Angle HalfAngle, Angle DirectionOffset = default, bool InvertForbiddenZone = false) : AOEShape
 {
-    public override string ToString() => $"TriCone: side={SideLength:f3}, angle={HalfAngle * 2}, off={DirectionOffset}";
-    public override bool Check(WPos position, WPos origin, Angle rotation) => position.InTri(origin, origin + SideLength * (rotation + HalfAngle).ToDirection(), origin + SideLength * (rotation - HalfAngle).ToDirection());
-    public override void Draw(MiniArena arena, WPos origin, Angle rotation, uint color = 0) => arena.ZoneTri(origin, origin + SideLength * (rotation + HalfAngle).ToDirection(), origin + SideLength * (rotation - HalfAngle).ToDirection(), color);
-    public override void Outline(MiniArena arena, WPos origin, Angle rotation, uint color = 0) => arena.AddTriangle(origin, origin + SideLength * (rotation + HalfAngle).ToDirection(), origin + SideLength * (rotation - HalfAngle).ToDirection(), color);
-    public override Func<WPos, float> Distance(WPos origin, Angle rotation) => ShapeDistance.Tri(origin, new(default, SideLength * (rotation + HalfAngle).ToDirection(), SideLength * (rotation - HalfAngle).ToDirection()));
+    public override string ToString() => $"TriCone: side={SideLength:f3}, angle={HalfAngle * 2}, off={DirectionOffset}, ifz={InvertForbiddenZone}";
+    public override bool Check(WPos position, WPos origin, Angle rotation) => position.InTri(origin, origin + SideLength * (rotation + DirectionOffset + HalfAngle).ToDirection(), origin + SideLength * (rotation + DirectionOffset - HalfAngle).ToDirection());
+    public override void Draw(MiniArena arena, WPos origin, Angle rotation, uint color = 0) => arena.ZoneTri(origin, origin + SideLength * (rotation + DirectionOffset + HalfAngle).ToDirection(), origin + SideLength * (rotation + DirectionOffset - HalfAngle).ToDirection(), color);
+    public override void Outline(MiniArena arena, WPos origin, Angle rotation, uint color = 0) => arena.AddTriangle(origin, origin + SideLength * (rotation + DirectionOffset + HalfAngle).ToDirection(), origin + SideLength * (rotation + DirectionOffset - HalfAngle).ToDirection(), color);
+
+    public override Func<WPos, float> Distance(WPos origin, Angle rotation)
+    {
+        var direction1 = SideLength * (rotation + DirectionOffset + HalfAngle).ToDirection();
+        var direction2 = SideLength * (rotation + DirectionOffset - HalfAngle).ToDirection();
+        var shape = new RelTriangle(default, direction1, direction2);
+        return !InvertForbiddenZone ? ShapeDistance.Tri(origin, shape) : ShapeDistance.InvertedTri(origin, shape);
+    }
+}
+
+public enum OperandType
+{
+    Union,
+    Xor,
+    Intersection,
+    Difference
+}
+
+// shapes1 for unions, shapes 2 for shapes for XOR/intersection with shapes1, differences for shapes that get subtracted after previous operations
+public sealed record class AOEShapeCustom(IEnumerable<Shape> Shapes1, IEnumerable<Shape>? DifferenceShapes = null, IEnumerable<Shape>? Shapes2 = null, bool InvertForbiddenZone = false, OperandType Operand = OperandType.Union) : AOEShape
+{
+    private static readonly Dictionary<int, RelSimplifiedComplexPolygon> _polygonCache = [];
+    private static readonly Queue<int> _polygonCacheQueue = new();
+    private readonly Dictionary<(int, WPos, WPos, Angle), bool> _checkCache = [];
+    private static readonly Dictionary<(int, WPos, Angle, bool), Func<WPos, float>> _distanceFuncCache = [];
+    private readonly int hashkey = CreateCacheKey(Shapes1, Shapes2 ?? [], DifferenceShapes ?? [], Operand);
+
+    public override string ToString() => $"Custom AOE shape: hashkey={hashkey}, ifz={InvertForbiddenZone}";
+
+    private RelSimplifiedComplexPolygon GetCombinedPolygon(WPos origin)
+    {
+        if (_polygonCache.TryGetValue(hashkey, out var cachedResult))
+            return cachedResult;
+
+        var shapes1 = CreateOperandFromShapes(Shapes1, origin);
+        var shapes2 = CreateOperandFromShapes(Shapes2, origin);
+        var differenceOperands = CreateOperandFromShapes(DifferenceShapes, origin);
+
+        var clipper = new PolygonClipper();
+        var combinedShapes = Operand switch
+        {
+            OperandType.Xor => clipper.Xor(shapes1, shapes2),
+            OperandType.Intersection => clipper.Intersect(shapes1, shapes2),
+            _ => null
+        };
+
+        var finalResult = combinedShapes != null
+            ? clipper.Difference(new PolygonClipper.Operand(combinedShapes), differenceOperands)
+            : clipper.Difference(shapes1, differenceOperands);
+
+        AddToPolygonCache(hashkey, finalResult);
+        return finalResult;
+    }
+
+    private static PolygonClipper.Operand CreateOperandFromShapes(IEnumerable<Shape>? shapes, WPos origin)
+    {
+        var operand = new PolygonClipper.Operand();
+        if (shapes != null)
+            foreach (var shape in shapes)
+                operand.AddPolygon(shape.ToPolygon(origin));
+        return operand;
+    }
+
+    public override bool Check(WPos position, WPos origin, Angle rotation)
+    {
+        var cacheKey = (hashkey, position, origin, rotation);
+        if (_checkCache.TryGetValue(cacheKey, out var cachedResult))
+            return cachedResult;
+
+        var combinedPolygon = GetCombinedPolygon(origin);
+        var relativePosition = position - origin;
+        var result = combinedPolygon.Contains(new(relativePosition.X, relativePosition.Z));
+        AddToCheckCache(cacheKey, result);
+        return result;
+    }
+
+    private static int CreateCacheKey(IEnumerable<Shape> shapes1, IEnumerable<Shape> shapes2, IEnumerable<Shape> differenceShapes, OperandType operand)
+    {
+        var hashCode = new HashCode();
+        foreach (var shape in shapes1.Concat(shapes2).Concat(differenceShapes))
+            hashCode.Add(shape.GetHashCode());
+        hashCode.Add(operand);
+        return hashCode.ToHashCode();
+    }
+
+    public override void Draw(MiniArena arena, WPos origin, Angle rotation, uint color = 0)
+    {
+        arena.ZoneRelPoly(hashkey, GetCombinedPolygon(origin), color);
+    }
+
+    public override void Outline(MiniArena arena, WPos origin, Angle rotation, uint color = 0)
+    {
+        var combinedPolygon = GetCombinedPolygon(origin);
+        foreach (var part in combinedPolygon.Parts)
+        {
+            var exteriorEdges = part.ExteriorEdges.ToList();
+            for (var i = 0; i < exteriorEdges.Count; i++)
+            {
+                var (start, end) = exteriorEdges[i];
+                arena.PathLineTo(origin + start);
+                if (i != exteriorEdges.Count - 1)
+                    arena.PathLineTo(origin + end);
+            }
+            arena.PathStroke(true, color);
+
+            foreach (var holeIndex in part.Holes)
+            {
+                var interiorEdges = part.InteriorEdges(holeIndex).ToList();
+                for (var i = 0; i < interiorEdges.Count; i++)
+                {
+                    var (start, end) = interiorEdges[i];
+                    arena.PathLineTo(origin + start);
+                    if (i != interiorEdges.Count - 1)
+                        arena.PathLineTo(origin + end);
+                }
+                arena.PathStroke(true, color);
+            }
+        }
+    }
+
+    public override Func<WPos, float> Distance(WPos origin, Angle rotation)
+    {
+        var cacheKey = (hashkey, origin, rotation, InvertForbiddenZone);
+        if (_distanceFuncCache.TryGetValue(cacheKey, out var cachedFunc))
+            return cachedFunc;
+
+        var result = InvertForbiddenZone ? RelPolygonWithHoles.InvertedPolygonWithHoles(origin, GetCombinedPolygon(origin)) : RelPolygonWithHoles.PolygonWithHoles(origin, GetCombinedPolygon(origin));
+        _distanceFuncCache[cacheKey] = result;
+        return result;
+    }
+
+    private static void AddToPolygonCache(int key, RelSimplifiedComplexPolygon polygon)
+    {
+        _polygonCache[key] = polygon;
+        _polygonCacheQueue.Enqueue(key);
+        if (_polygonCache.Count > 250)
+            _polygonCache.Remove(_polygonCacheQueue.Dequeue());
+    }
+
+    private void AddToCheckCache((int, WPos, WPos, Angle) key, bool result)
+    {
+        if (_checkCache.Count > 2500)
+            _checkCache.Clear();
+        _checkCache[key] = result;
+    }
 }

--- a/BossMod/BossModule/ArenaBounds.cs
+++ b/BossMod/BossModule/ArenaBounds.cs
@@ -275,7 +275,7 @@ public record class ArenaBoundsCustom(float Radius, RelSimplifiedComplexPolygon 
         // faster than using a shapedistance method, high accuracy due to 9 sample points per pixel
         var polygon = Offset != 0 ? Poly.Offset(Offset) : Poly;
 
-        var (halfWidth, halfHeight) = CalculatePolygonProperties(polygon);
+        var (halfWidth, halfHeight) = CalculatePolygonProperties(polygon); // calculate bounding box to ensure the smallest amount of pixels need to be checked
         var map = new Pathfinding.Map(MapResolution, default, halfWidth, halfHeight);
         var halfSample = MapResolution / 2 - 1e-5f; // tiny offset to account for floating point inaccuracies
         WDir[] sampleOffsets =
@@ -296,7 +296,7 @@ public record class ArenaBoundsCustom(float Radius, RelSimplifiedComplexPolygon 
             var (x, y, pos) = pixel;
             var relativeCenter = new WDir(pos.X, pos.Z);
             var allInside = true;
-            for (var i = 0; i < sampleOffsets.Length; i++)
+            for (var i = 0; i < 9; i++)
             {
                 var samplePoint = relativeCenter + sampleOffsets[i];
                 if (!Poly.Contains(samplePoint))
@@ -305,8 +305,7 @@ public record class ArenaBoundsCustom(float Radius, RelSimplifiedComplexPolygon 
                     break;
                 }
             }
-            var pixelIndex = map.GridToIndex(x, y);
-            map.PixelMaxG[pixelIndex] = allInside ? float.MaxValue : 0;
+            map.PixelMaxG[map.GridToIndex(x, y)] = allInside ? float.MaxValue : 0;
         });
 
         return map;

--- a/BossMod/BossModule/ArenaBounds.cs
+++ b/BossMod/BossModule/ArenaBounds.cs
@@ -1,5 +1,4 @@
 ﻿namespace BossMod;
-
 // radius is the largest horizontal/vertical dimension: radius for circle, max of width/height for rect
 // note: this class to represent *relative* arena bounds (relative to arena center) - the reason being that in some cases effective center moves every frame, and bounds caches a lot (clip poly & base map for pathfinding)
 // note: if arena bounds are changed, new instance is recreated; max approx error can change without recreating the instance
@@ -11,6 +10,8 @@ public abstract record class ArenaBounds(float Radius, float MapResolution)
     public RelSimplifiedComplexPolygon ShapeSimplified { get; private set; } = new();
     public List<RelTriangle> ShapeTriangulation { get; private set; } = [];
     private readonly PolygonClipper.Operand _clipOperand = new();
+    public static readonly Dictionary<object, object> StaticCache = [];
+    public readonly Dictionary<object, object> Cache = [];
 
     private float _screenHalfSize;
     public float ScreenHalfSize
@@ -46,8 +47,8 @@ public abstract record class ArenaBounds(float Radius, float MapResolution)
         if (innerRadius >= outerRadius || innerRadius < 0 || halfAngle.Rad <= 0)
             return [];
 
-        bool fullCircle = halfAngle.Rad >= MathF.PI;
-        bool donut = innerRadius > 0;
+        var fullCircle = halfAngle.Rad >= MathF.PI;
+        var donut = innerRadius > 0;
         var points = (donut, fullCircle) switch
         {
             (false, false) => CurveApprox.CircleSector(outerRadius, centerDirection - halfAngle, centerDirection + halfAngle, MaxApproxError),
@@ -96,6 +97,13 @@ public abstract record class ArenaBounds(float Radius, float MapResolution)
         var side = halfWidth * dir.OrthoR();
         return ClipAndTriangulate([startOffset + side, startOffset - side, endOffset - side, endOffset + side]);
     }
+
+    public void AddToInstanceCache(object key, object value)
+    {
+        if (Cache.Count > 2500)
+            Cache.Clear();
+        Cache[key] = value;
+    }
 }
 
 public record class ArenaBoundsCircle(float Radius, float MapResolution = 0.5f) : ArenaBounds(Radius, MapResolution)
@@ -117,34 +125,32 @@ public record class ArenaBoundsCircle(float Radius, float MapResolution = 0.5f) 
     private Pathfinding.Map BuildMap()
     {
         var map = new Pathfinding.Map(MapResolution, default, Radius, Radius);
-        map.BlockPixelsInside(ShapeDistance.InvertedCircle(default, Radius), 0, 0);
+        map.BlockPixelsInsideAccuracy(ShapeDistance.InvertedCircle(default, Radius), 0, 0);
         return map;
     }
 }
 
-public record class ArenaBoundsSquare(float Radius, float MapResolution = 0.5f) : ArenaBounds(Radius, MapResolution)
-{
-    public float HalfWidth => Radius;
-
-    protected override PolygonClipper.Operand BuildClipPoly() => new(CurveApprox.Rect(new(Radius, 0), new(0, Radius)));
-    public override void PathfindMap(Pathfinding.Map map, WPos center) => map.Init(MapResolution, center, Radius, Radius);
-    public override bool Contains(WDir offset) => offset.AlmostZero(Radius);
-    public override float IntersectRay(WDir originOffset, WDir dir) => Intersect.RayAABB(originOffset, dir, Radius, Radius);
-
-    public override WDir ClampToBounds(WDir offset)
-    {
-        if (Math.Abs(offset.X) > Radius)
-            offset *= Radius / Math.Abs(offset.X);
-        if (Math.Abs(offset.Z) > Radius)
-            offset *= Radius / Math.Abs(offset.Z);
-        return offset;
-    }
-}
-
 // if rotation is 0, half-width is along X and half-height is along Z
-public record class ArenaBoundsRect(float HalfWidth, float HalfHeight, Angle Rotation = default, float Radius = 0, float MapResolution = 0.5f) : ArenaBounds(Radius > 0 ? Radius : MathF.Max(HalfWidth, HalfHeight), MapResolution)
+public record class ArenaBoundsRect(float HalfWidth, float HalfHeight, Angle Rotation = default, float MapResolution = 0.5f) : ArenaBounds(CalculateRadius(HalfHeight, HalfWidth, Rotation), MapResolution)
 {
     public readonly WDir Orientation = Rotation.ToDirection();
+
+    private static float CalculateRadius(float HalfWidth, float HalfHeight, Angle Rotation)
+    {
+        if (StaticCache.TryGetValue((HalfWidth, HalfHeight, Rotation), out var cachedResult))
+            return (float)cachedResult;
+
+        var cos = MathF.Abs(MathF.Cos(Rotation.Rad));
+        var sin = MathF.Abs(MathF.Sin(Rotation.Rad));
+        var corner1 = new WDir(HalfWidth * cos - HalfHeight * sin, HalfWidth * sin + HalfHeight * cos);
+        var corner2 = new WDir(HalfWidth * cos + HalfHeight * sin, HalfWidth * sin - HalfHeight * cos);
+        var maxDistX = Math.Max(MathF.Abs(corner1.X), MathF.Abs(corner2.X));
+        var maxDistZ = Math.Max(MathF.Abs(corner1.Z), MathF.Abs(corner2.Z));
+        var radius = Math.Max(maxDistX, maxDistZ);
+
+        StaticCache[(HalfWidth, HalfHeight, Rotation)] = radius;
+        return radius;
+    }
 
     protected override PolygonClipper.Operand BuildClipPoly() => new(CurveApprox.Rect(Orientation, HalfWidth, HalfHeight));
     public override void PathfindMap(Pathfinding.Map map, WPos center) => map.Init(MapResolution, center, HalfWidth, HalfHeight, Rotation);
@@ -163,28 +169,239 @@ public record class ArenaBoundsRect(float HalfWidth, float HalfHeight, Angle Rot
     }
 }
 
+public record class ArenaBoundsSquare(float Radius, Angle Rotation = default, float MapResolution = 0.5f) : ArenaBoundsRect(Radius, Radius, Rotation, MapResolution) { }
+
 // custom complex polygon bounds
-public record class ArenaBoundsCustom(float Radius, RelSimplifiedComplexPolygon Poly, float MapResolution = 0.5f) : ArenaBounds(Radius, MapResolution)
+public record class ArenaBoundsCustom(float Radius, RelSimplifiedComplexPolygon Poly, float MapResolution = 0.5f, float Offset = 0) : ArenaBounds(Radius, MapResolution)
 {
     private Pathfinding.Map? _cachedMap;
 
     protected override PolygonClipper.Operand BuildClipPoly() => new(Poly);
     public override void PathfindMap(Pathfinding.Map map, WPos center) => map.Init(_cachedMap ??= BuildMap(), center);
-    public override bool Contains(WDir offset) => Poly.Contains(offset);
-    public override float IntersectRay(WDir originOffset, WDir dir) => Intersect.RayPolygon(originOffset, dir, Poly);
+
+    public override bool Contains(WDir offset)
+    {
+        var cacheKey = (Poly, offset, Radius);
+        if (Cache.TryGetValue(cacheKey, out var cachedResult)) // caching contains seems to lower drawtime by ~33%
+            return (bool)cachedResult;
+        var result = Poly.Contains(offset);
+        AddToInstanceCache(cacheKey, result);
+        return result;
+    }
+
+    public override float IntersectRay(WDir originOffset, WDir dir)
+    {
+        var cacheKey = (Poly, originOffset, dir);
+        if (Cache.TryGetValue(cacheKey, out var cachedResult)) // caching intersections seems to lower drawtime by ~12.5% while in use
+            return (float)cachedResult;
+        var result = Intersect.RayPolygon(originOffset, dir, Poly);
+        AddToInstanceCache(cacheKey, result);
+        return result;
+    }
+
     public override WDir ClampToBounds(WDir offset)
     {
-        var l = offset.Length();
-        var dir = offset / l;
-        var t = Intersect.RayPolygon(default, dir, Poly);
-        return dir * Math.Min(t, l);
+        var cacheKey = (Poly, offset);
+        if (Cache.TryGetValue(cacheKey, out var cachedResult)) // caching ClampToBounds seems to lower drawtime by about 50%
+            return (WDir)cachedResult;
+        if (Contains(offset) || offset.AlmostEqual(default, 0.1f)) // if actor is almost in the center of the arena, do nothing (eg donut arena)
+        {
+            Cache[(Poly, offset)] = offset;
+            return offset;
+        }
+        var minDistance = float.MaxValue;
+        var nearestPoint = offset;
+
+        foreach (var part in Poly.Parts)
+        {
+            foreach (var edge in part.ExteriorEdges.Concat(part.Holes.SelectMany(part.InteriorEdges)))
+            {
+                var edgeStart = edge.Item1;
+                var edgeEnd = edge.Item2;
+                var nearest = NearestPointOnSegment(offset, edgeStart, edgeEnd);
+                var distance = (nearest - offset).LengthSq();
+
+                if (distance < minDistance)
+                {
+                    minDistance = distance;
+                    nearestPoint = nearest;
+                }
+            }
+        }
+        AddToInstanceCache(cacheKey, nearestPoint);
+        return nearestPoint;
+    }
+
+    private static WDir NearestPointOnSegment(WDir point, WDir segmentStart, WDir segmentEnd)
+    {
+        var segmentVector = segmentEnd - segmentStart;
+        var segmentLengthSq = segmentVector.LengthSq();
+        if (segmentLengthSq == 0)
+            return segmentStart;
+
+        var t = Math.Max(0, Math.Min(1, (point - segmentStart).Dot(segmentVector) / segmentLengthSq));
+        return segmentStart + t * segmentVector;
+    }
+
+    private static (float halfWidth, float halfHeight) CalculatePolygonProperties(RelSimplifiedComplexPolygon Poly)
+    {
+        if (StaticCache.TryGetValue(Poly, out var cachedResult))
+            return ((float, float))cachedResult;
+
+        float minX = float.MaxValue, maxX = float.MinValue, minZ = float.MaxValue, maxZ = float.MinValue;
+
+        foreach (var part in Poly.Parts)
+        {
+            foreach (var vertex in part.Exterior)
+            {
+                if (vertex.X < minX)
+                    minX = vertex.X;
+                if (vertex.X > maxX)
+                    maxX = vertex.X;
+                if (vertex.Z < minZ)
+                    minZ = vertex.Z;
+                if (vertex.Z > maxZ)
+                    maxZ = vertex.Z;
+            }
+        }
+
+        var result = ((maxX - minX) / 2, (maxZ - minZ) / 2);
+        StaticCache[Poly] = result;
+        return result;
     }
 
     private Pathfinding.Map BuildMap()
     {
-        var map = new Pathfinding.Map(MapResolution, default, Radius, Radius);
-        var tri = ShapeDistance.TriList(default, Poly.Triangulate());
-        map.BlockPixelsInside(p => -tri(p), 0, 0);
+        // faster than using a shapedistance method, high accuracy due to 9 sample points per pixel
+        var polygon = Offset != 0 ? Poly.Offset(Offset) : Poly;
+
+        var (halfWidth, halfHeight) = CalculatePolygonProperties(polygon);
+        var map = new Pathfinding.Map(MapResolution, default, halfWidth, halfHeight);
+        var halfSample = MapResolution / 2 - 1e-5f; // tiny offset to account for floating point inaccuracies
+        WDir[] sampleOffsets =
+        [
+        new(-halfSample, -halfSample),
+        new(-halfSample,  0),
+        new(-halfSample,  halfSample),
+        new(0, -halfSample),
+        new(0, 0),
+        new(0, halfSample),
+        new(halfSample, -halfSample),
+        new(halfSample, 0),
+        new(halfSample, halfSample)
+        ];
+
+        Parallel.ForEach(map.EnumeratePixels(), pixel =>
+        {
+            var (x, y, pos) = pixel;
+            var relativeCenter = new WDir(pos.X, pos.Z);
+            var allInside = true;
+            for (var i = 0; i < sampleOffsets.Length; i++)
+            {
+                var samplePoint = relativeCenter + sampleOffsets[i];
+                if (!Poly.Contains(samplePoint))
+                {
+                    allInside = false;
+                    break;
+                }
+            }
+            var pixelIndex = map.GridToIndex(x, y);
+            map.PixelMaxG[pixelIndex] = allInside ? float.MaxValue : 0;
+        });
+
         return map;
     }
+}
+
+// for creating complex bounds by using two IEnumerable of shapes
+// first IEnumerable contains platforms that will be united, second optional IEnumberale contains shapes that will be subtracted
+// for convenience third list will optionally perform additional unions at the end
+public record class ArenaBoundsComplex : ArenaBoundsCustom
+{
+    public WPos Center;
+
+    public ArenaBoundsComplex(IEnumerable<Shape> UnionShapes, IEnumerable<Shape>? DifferenceShapes = null, IEnumerable<Shape>? AdditionalShapes = null, float MapResolution = 0.5f, float Offset = 0)
+        : base(BuildBounds(UnionShapes, DifferenceShapes, AdditionalShapes, MapResolution, Offset, out var center))
+    {
+        Center = center;
+    }
+
+    private static ArenaBoundsCustom BuildBounds(IEnumerable<Shape> unionShapes, IEnumerable<Shape>? differenceShapes, IEnumerable<Shape>? additionalShapes, float mapResolution, float offset, out WPos center)
+    {
+        var cacheKey = CreateCacheKey(unionShapes, differenceShapes ?? [], additionalShapes ?? []);
+        var properties = CalculatePolygonProperties(cacheKey, unionShapes, differenceShapes ?? [], additionalShapes ?? []);
+        center = properties.Center;
+        return new ArenaBoundsCustom(properties.Radius, properties.Poly, mapResolution, offset);
+    }
+
+    private static (WPos Center, float Radius, RelSimplifiedComplexPolygon Poly) CalculatePolygonProperties(int cacheKey, IEnumerable<Shape> unionShapes, IEnumerable<Shape> differenceShapes, IEnumerable<Shape> additionalShapes)
+    {
+        if (StaticCache.TryGetValue(cacheKey, out var cachedResult))
+            return ((WPos, float, RelSimplifiedComplexPolygon))cachedResult;
+
+        var unionPolygons = ParseShapes(unionShapes);
+        var differencePolygons = ParseShapes(differenceShapes);
+        var additionalPolygons = ParseShapes(additionalShapes);
+
+        var combinedPoly = CombinePolygons(unionPolygons, differencePolygons, additionalPolygons);
+
+        float minX = float.MaxValue, maxX = float.MinValue, minZ = float.MaxValue, maxZ = float.MinValue;
+        foreach (var part in combinedPoly.Parts)
+        {
+            foreach (var vertex in part.Exterior)
+            {
+                if (vertex.X < minX)
+                    minX = vertex.X;
+                if (vertex.X > maxX)
+                    maxX = vertex.X;
+                if (vertex.Z < minZ)
+                    minZ = vertex.Z;
+                if (vertex.Z > maxZ)
+                    maxZ = vertex.Z;
+            }
+        }
+
+        var center = new WPos((minX + maxX) / 2, (minZ + maxZ) / 2);
+        var maxDistX = Math.Max(MathF.Abs(maxX - center.X), MathF.Abs(minX - center.X));
+        var maxDistZ = Math.Max(MathF.Abs(maxZ - center.Z), MathF.Abs(minZ - center.Z));
+        var radius = Math.Max(maxDistX, maxDistZ);
+
+        var combinedPolyCentered = CombinePolygons(ParseShapes(unionShapes, center), ParseShapes(differenceShapes, center), ParseShapes(additionalShapes, center));
+        var result = (center, radius, combinedPolyCentered);
+        StaticCache[cacheKey] = result;
+        return result;
+    }
+
+    private static int CreateCacheKey(IEnumerable<Shape> unionShapes, IEnumerable<Shape> differenceShapes, IEnumerable<Shape> additionalShapes)
+    {
+        var hashCode = new HashCode();
+        foreach (var shape in unionShapes.Concat(differenceShapes).Concat(additionalShapes))
+            hashCode.Add(shape.GetHashCode());
+        return hashCode.ToHashCode();
+    }
+
+    private static RelSimplifiedComplexPolygon CombinePolygons(List<RelSimplifiedComplexPolygon> unionPolygons, List<RelSimplifiedComplexPolygon> differencePolygons, List<RelSimplifiedComplexPolygon> secondUnionPolygons)
+    {
+        var clipper = new PolygonClipper();
+        var operandUnion = new PolygonClipper.Operand();
+        var operandDifference = new PolygonClipper.Operand();
+        var operandSecondUnion = new PolygonClipper.Operand();
+
+        foreach (var polygon in unionPolygons)
+            operandUnion.AddPolygon(polygon);
+        foreach (var polygon in differencePolygons)
+            operandDifference.AddPolygon(polygon);
+        foreach (var polygon in secondUnionPolygons)
+            operandSecondUnion.AddPolygon(polygon);
+
+        var combinedShape = clipper.Union(operandUnion, new PolygonClipper.Operand());
+        if (differencePolygons.Count != 0)
+            combinedShape = clipper.Difference(new PolygonClipper.Operand(combinedShape), operandDifference);
+        if (secondUnionPolygons.Count != 0)
+            combinedShape = clipper.Union(new PolygonClipper.Operand(combinedShape), operandSecondUnion);
+
+        return combinedShape;
+    }
+
+    private static List<RelSimplifiedComplexPolygon> ParseShapes(IEnumerable<Shape> shapes, WPos center = default) => shapes.Select(shape => shape.ToPolygon(center)).ToList();
 }

--- a/BossMod/BossModule/MiniArena.cs
+++ b/BossMod/BossModule/MiniArena.cs
@@ -247,6 +247,8 @@ public sealed class MiniArena(BossModuleConfig config, WPos center, ArenaBounds 
         => Zone(_triCache[(10, key)] ??= Bounds.ClipAndTriangulate(contour.Select(p => p - Center)), color);
     public void ZoneRelPoly(object key, IEnumerable<WDir> relContour, uint color)
         => Zone(_triCache[(11, key)] ??= Bounds.ClipAndTriangulate(relContour), color);
+    public void ZoneRelPoly(int key, RelSimplifiedComplexPolygon poly, uint color)
+        => Zone(_triCache[(12, key)] ??= Bounds.ClipAndTriangulate(poly), color);
 
     public void TextScreen(Vector2 center, string text, uint color, float fontSize = 17)
     {
@@ -266,14 +268,26 @@ public sealed class MiniArena(BossModuleConfig config, WPos center, ArenaBounds 
         var dl = ImGui.GetWindowDrawList();
         foreach (var p in Bounds.ShapeSimplified.Parts)
         {
+            Vector2? lastPoint = null;
             foreach (var off in p.Exterior)
-                dl.PathLineTo(ScreenCenter + WorldOffsetToScreenOffset(off));
+            {
+                var currentPoint = ScreenCenter + WorldOffsetToScreenOffset(off);
+                if (lastPoint != currentPoint)
+                    dl.PathLineTo(currentPoint);
+                lastPoint = currentPoint;
+            }
             dl.PathStroke(color, ImDrawFlags.Closed, 2);
 
             foreach (var i in p.Holes)
             {
+                lastPoint = null;
                 foreach (var off in p.Interior(i))
-                    dl.PathLineTo(ScreenCenter + WorldOffsetToScreenOffset(off));
+                {
+                    var currentPoint = ScreenCenter + WorldOffsetToScreenOffset(off);
+                    if (lastPoint != currentPoint)
+                        dl.PathLineTo(currentPoint);
+                    lastPoint = currentPoint;
+                }
                 dl.PathStroke(color, ImDrawFlags.Closed, 2);
             }
         }

--- a/BossMod/BossModule/Shapes.cs
+++ b/BossMod/BossModule/Shapes.cs
@@ -1,0 +1,144 @@
+namespace BossMod;
+
+public abstract record class Shape
+{
+    public const float MaxApproxError = 0.01f;
+
+    public abstract List<WDir> Contour(WPos center);
+
+    public RelSimplifiedComplexPolygon ToPolygon(WPos center) => new((List<RelPolygonWithHoles>)[new(Contour(center))]);
+}
+
+public record class Circle(WPos Center, float Radius) : Shape
+{
+    public override List<WDir> Contour(WPos center) => CurveApprox.Circle(Radius, MaxApproxError).Select(p => p + (Center - center)).ToList();
+    public override string ToString() => $"{nameof(Circle)}:{Center.X},{Center.Z},{Radius}";
+}
+
+// for custom polygons, automatically checking if convex or concave
+public record class PolygonCustom(IEnumerable<WPos> Vertices) : Shape
+{
+    public override List<WDir> Contour(WPos center) => Vertices.Select(v => v - center).ToList();
+    public override string ToString() => $"{nameof(PolygonCustom)}:{string.Join(",", Vertices.Select(v => $"{v.X},{v.Z}"))}";
+}
+
+public record class Donut(WPos Center, float InnerRadius, float OuterRadius) : Shape
+{
+    public override List<WDir> Contour(WPos center) => CurveApprox.Donut(InnerRadius, OuterRadius, MaxApproxError).Select(p => p + (Center - center)).ToList();
+    public override string ToString() => $"{nameof(Donut)}:{Center.X},{Center.Z},{InnerRadius},{OuterRadius}";
+}
+
+// for rectangles defined by a center, halfwidth, halfheight and optionally rotation
+public record class Rectangle(WPos Center, float HalfWidth, float HalfHeight, Angle Rotation = default) : Shape
+{
+    public override List<WDir> Contour(WPos center)
+    {
+        var cos = MathF.Cos(Rotation.Rad);
+        var sin = MathF.Sin(Rotation.Rad);
+        return
+        [
+            new WDir(HalfWidth * cos - HalfHeight * sin, HalfWidth * sin + HalfHeight * cos) + (Center - center),
+            new WDir(HalfWidth * cos + HalfHeight * sin, HalfWidth * sin - HalfHeight * cos) + (Center - center),
+            new WDir(-HalfWidth * cos + HalfHeight * sin, -HalfWidth * sin - HalfHeight * cos) + (Center - center),
+            new WDir(-HalfWidth * cos - HalfHeight * sin, -HalfWidth * sin + HalfHeight * cos) + (Center - center)
+        ];
+    }
+    public override string ToString() => $"{nameof(Rectangle)}:{Center.X},{Center.Z},{HalfWidth},{HalfHeight},{Rotation}";
+}
+
+// for rectangles defined by a start point, end point and halfwidth
+public record class RectangleSE(WPos Start, WPos End, float HalfWidth) : Rectangle(
+    Center: new WPos((Start.X + End.X) / 2, (Start.Z + End.Z) / 2),
+    HalfWidth: HalfWidth,
+    HalfHeight: (End - Start).Length() / 2,
+    Rotation: new Angle(MathF.Atan2(End.Z - Start.Z, End.X - Start.X)) + 90.Degrees()
+);
+
+public record class Square(WPos Center, float HalfSize, Angle Rotation = default) : Rectangle(Center, HalfSize, HalfSize, Rotation);
+
+public record class Cross(WPos Center, float Length, float HalfWidth, Angle Rotation = default) : Shape
+{
+    public override List<WDir> Contour(WPos center)
+    {
+        var dx = Rotation.ToDirection();
+        var dy = dx.OrthoL();
+        var dx1 = dx * Length;
+        var dx2 = dx * HalfWidth;
+        var dy1 = dy * Length;
+        var dy2 = dy * HalfWidth;
+        return
+        [
+            Center + dx1 + dy2 - center,
+            Center + dx2 + dy2 - center,
+            Center + dx2 + dy1 - center,
+            Center - dx2 + dy1 - center,
+            Center - dx2 + dy2 - center,
+            Center - dx1 + dy2 - center,
+            Center - dx1 - dy2 - center,
+            Center - dx2 - dy2 - center,
+            Center - dx2 - dy1 - center,
+            Center + dx2 - dy1 - center,
+            Center + dx2 - dy2 - center,
+            Center + dx1 - dy2 - center
+        ];
+    }
+    public override string ToString() => $"{nameof(Cross)}:{Center.X},{Center.Z},{Length},{HalfWidth},{Rotation}";
+}
+
+// Equilateral triangle defined by center, sidelength and rotation
+public record class TriangleE(WPos Center, float SideLength, Angle Rotation = default) : Shape
+{
+    private static readonly float heightFactor = MathF.Sqrt(3) / 2;
+    public override List<WDir> Contour(WPos center)
+    {
+        var height = SideLength * heightFactor;
+        List<WDir> vertices = [new(SideLength / 2, height / 2), new(-SideLength / 2, height / 2), new(0, -height / 2)];
+        var cos = MathF.Cos(Rotation.Rad);
+        var sin = MathF.Sin(Rotation.Rad);
+        vertices = vertices.Select(v => new WDir(v.X * cos - v.Z * sin, v.X * sin + v.Z * cos)).ToList();
+        return vertices.Select(v => v + (Center - center)).ToList();
+    }
+    public override string ToString() => $"{nameof(TriangleE)}:{Center.X},{Center.Z},{SideLength},{Rotation}";
+}
+
+// for polygons defined by a radius and n amount of vertices
+public record class Polygon(WPos Center, float Radius, int Vertices, Angle Rotation = default) : Shape
+{
+    public override List<WDir> Contour(WPos center)
+    {
+        var angleIncrement = 2 * MathF.PI / Vertices;
+        var initialRotation = Rotation.Rad;
+        var vertices = new List<WDir>();
+        for (var i = 0; i < Vertices; i++)
+        {
+            var angle = i * angleIncrement + initialRotation;
+            var x = Center.X + Radius * MathF.Cos(angle);
+            var z = Center.Z + Radius * MathF.Sin(angle);
+            vertices.Add(new WDir(x - center.X, z - center.Z));
+        }
+        vertices.Reverse();
+        return vertices;
+    }
+    public override string ToString() => $"{nameof(Polygon)}:{Center.X},{Center.Z},{Radius},{Vertices},{Rotation}";
+}
+
+// for cones defined by radius, start angle and end angle
+public record class Cone(WPos Center, float Radius, Angle StartAngle, Angle EndAngle) : Shape
+{
+    public override List<WDir> Contour(WPos center) => CurveApprox.CircleSector(Center, Radius, StartAngle, EndAngle, MaxApproxError).Select(p => p - center).ToList();
+    public override string ToString() => $"{nameof(Cone)}:{Center.X},{Center.Z},{Radius},{StartAngle},{EndAngle}";
+}
+
+// for cones defined by radius, direction and half angle
+public record class ConeHA(WPos Center, float Radius, Angle CenterDir, Angle HalfAngle) : Cone(Center, Radius, CenterDir - HalfAngle, CenterDir + HalfAngle);
+
+// for donut segments defined by inner and outer radius, direction, start angle and end angle
+public record class DonutSegment(WPos Center, float InnerRadius, float OuterRadius, Angle StartAngle, Angle EndAngle) : Shape
+{
+    public override List<WDir> Contour(WPos center) => CurveApprox.DonutSector(InnerRadius, OuterRadius, StartAngle, EndAngle, MaxApproxError).Select(p => p + (Center - center)).ToList();
+    public override string ToString() => $"{nameof(DonutSegment)}:{Center.X},{Center.Z},{InnerRadius},{OuterRadius},{StartAngle},{EndAngle}";
+}
+
+// for donut segments defined by inner and outer radius, direction and half angle
+public record class DonutSegmentHA(WPos Center, float InnerRadius, float OuterRadius, Angle CenterDir, Angle HalfAngle) : DonutSegment(Center, InnerRadius, OuterRadius,
+CenterDir - HalfAngle, CenterDir + HalfAngle);

--- a/BossMod/ThirdParty/Earcut.cs
+++ b/BossMod/ThirdParty/Earcut.cs
@@ -6,10 +6,10 @@ namespace EarcutNet;
 
 public class Earcut
 {
-    public static List<int> Tessellate(IList<double> data, IList<int> holeIndices)
+    public static List<int> Tessellate(ReadOnlySpan<double> data, IList<int> holeIndices)
     {
         var hasHoles = holeIndices.Count > 0;
-        var outerLen = hasHoles ? holeIndices[0] * 2 : data.Count;
+        var outerLen = hasHoles ? holeIndices[0] * 2 : data.Length;
         var outerNode = LinkedList(data, 0, outerLen, true);
         var triangles = new List<int>();
 
@@ -30,7 +30,7 @@ public class Earcut
         }
 
         // if the shape is not too simple, we'll use z-order curve hash later; calculate polygon bbox
-        if (data.Count > 80 * 2)
+        if (data.Length > 80 * 2)
         {
             for (int i = 0; i < outerLen; i += 2)
             {
@@ -69,7 +69,7 @@ public class Earcut
     }
 
     // Creates a circular doubly linked list from polygon points in the specified winding order.
-    static Node LinkedList(IList<double> data, int start, int end, bool clockwise)
+    static Node LinkedList(ReadOnlySpan<double> data, int start, int end, bool clockwise)
     {
         var last = default(Node);
 
@@ -370,7 +370,7 @@ public class Earcut
     }
 
     // link every hole into the outer loop, producing a single-ring polygon without holes
-    static Node EliminateHoles(IList<double> data, IList<int> holeIndices, Node outerNode)
+    static Node EliminateHoles(ReadOnlySpan<double> data, IList<int> holeIndices, Node outerNode)
     {
         var queue = new List<Node>();
 
@@ -379,7 +379,7 @@ public class Earcut
         for (var i = 0; i < len; i++)
         {
             var start = holeIndices[i] * 2;
-            var end = i < len - 1 ? holeIndices[i + 1] * 2 : data.Count;
+            var end = i < len - 1 ? holeIndices[i + 1] * 2 : data.Length;
             var list = LinkedList(data, start, end, false);
             if (list == list.next)
             {
@@ -822,7 +822,7 @@ public class Earcut
         }
     }
 
-    static double SignedArea(IList<double> data, int start, int end)
+    static double SignedArea(ReadOnlySpan<double> data, int start, int end)
     {
         var sum = default(double);
 
@@ -837,26 +837,26 @@ public class Earcut
 
     // return a percentage difference between the polygon area and its triangulation area;
     // used to verify correctness of triangulation
-    public static double Deviation(IList<double> data, IList<int> holeIndices, IList<int> triangles)
+    public static double Deviation(ReadOnlySpan<double> data, ReadOnlySpan<int> holeIndices, ReadOnlySpan<int> triangles)
     {
-        var hasHoles = holeIndices.Count > 0;
-        var outerLen = hasHoles ? holeIndices[0] * 2 : data.Count;
+        var hasHoles = holeIndices.Length > 0;
+        var outerLen = hasHoles ? holeIndices[0] * 2 : data.Length;
 
         var polygonArea = Math.Abs(SignedArea(data, 0, outerLen));
         if (hasHoles)
         {
-            var len = holeIndices.Count;
+            var len = holeIndices.Length;
 
             for (var i = 0; i < len; i++)
             {
                 var start = holeIndices[i] * 2;
-                var end = i < len - 1 ? holeIndices[i + 1] * 2 : data.Count;
+                var end = i < len - 1 ? holeIndices[i + 1] * 2 : data.Length;
                 polygonArea -= Math.Abs(SignedArea(data, start, end));
             }
         }
 
         var trianglesArea = default(double);
-        for (var i = 0; i < triangles.Count; i += 3)
+        for (var i = 0; i < triangles.Length; i += 3)
         {
             var a = triangles[i] * 2;
             var b = triangles[i + 1] * 2;


### PR DESCRIPTION
Key changes:

- added Shapes.cs for easy access to various shapes, winding order ensured to be correct for clipper operations like union and differences
- added AOEShapeCustom to generate any AOE shape you like, including multiple holes and disjointed shapes. PolygonWithHoles distance method added that I optimised to the best of my ability for accuracy and performance.
- added ability to invert forbidden zones of aoe shapes for easy creation of safespots, maybe the GenericAOEs components needs to be adjusted to automatically generate an appropriate safespot hint if an inverted shape is used.
- merged ArenaBoundsSquare and Rect, automatically calculates the radius to ensure that the cardinal directions do not appear inside the arena bounds if the arena is rotated.
- changed ClampToBounds of ArenaBoundsCustom to work correctly for more complex shapes
- replaced the forbidden zone triangulation of ArenaBoundsCustom to something that performs better and higher accuracy, incorrectly blocked pixels due to rounding errors (incorrect: https://cdn.discordapp.com/attachments/1209273216267321405/1286831812273770576/image.png?ex=66f5ee84&is=66f49d04&hm=eee960646223b1bf1ca32e86ed45d8264b48cda290b371eae7c891fa3345fa43& correct: https://cdn.discordapp.com/attachments/1209273216267321405/1286832181926301757/image.png?ex=66f5eedc&is=66f49d5c&hm=3add699db7c7a19f68d6306fb2192fe03c513191090c6577a9b911fe79bed9ec&) are a thing of the past now
- added ArenaBoundsComplex which inherits from ArenaBoundsCustom to easily make arbitrary arena bound shapes by combining shapes from Shapes.cs, automatically calculates the center and radius for convenience
- added method to offset (deflate/inflate) polygons, for example to the ease the pathfinding
- added some multi threading (parallel for/foreach) where it is free performance due to no risk of race conditions