### PR TITLE
Utility fixes, Enable CDPlanning for Criterion dungeon bosses

### DIFF
--- a/BossMod/Autorotation/Utility/ClassDRKUtility.cs
+++ b/BossMod/Autorotation/Utility/ClassDRKUtility.cs
@@ -74,7 +74,7 @@ public sealed class ClassDRKUtility(RotationModuleManager manager, Actor player)
 
         var dashStrategy = strategy.Option(Track.Shadowstride).As<DashStrategy>();
         if (ShouldUseDash(dashStrategy, primaryTarget))
-            Hints.ActionsToExecute.Push(ActionID.MakeSpell(DRK.AID.Shadowstride), Player, obl.Priority());
+            Hints.ActionsToExecute.Push(ActionID.MakeSpell(DRK.AID.Shadowstride), primaryTarget, obl.Priority());
     }
     private bool ShouldUseDash(DashStrategy strategy, Actor? primaryTarget) => strategy switch
     {

--- a/BossMod/Autorotation/Utility/ClassGNBUtility.cs
+++ b/BossMod/Autorotation/Utility/ClassGNBUtility.cs
@@ -73,7 +73,7 @@ public sealed class ClassGNBUtility(RotationModuleManager manager, Actor player)
 
         var dashStrategy = strategy.Option(Track.Trajectory).As<DashStrategy>();
         if (ShouldUseDash(dashStrategy, primaryTarget))
-            Hints.ActionsToExecute.Push(ActionID.MakeSpell(GNB.AID.Trajectory), Player, hoc.Priority());
+            Hints.ActionsToExecute.Push(ActionID.MakeSpell(GNB.AID.Trajectory), primaryTarget, hoc.Priority());
     }
     private bool ShouldUseDash(DashStrategy strategy, Actor? primaryTarget) => strategy switch
     {

--- a/BossMod/Autorotation/Utility/ClassSCHUtility.cs
+++ b/BossMod/Autorotation/Utility/ClassSCHUtility.cs
@@ -2,7 +2,7 @@
 
 public sealed class ClassSCHUtility(RotationModuleManager manager, Actor player) : RoleHealerUtility(manager, player)
 {
-    public enum Track { WhisperingDawn = SharedTrack.Count, Adloquium, Succor, FeyIllumination, Lustrate, SacredSoil, Indomitability, DeploymentTactics, EmergencyTactics, Dissipation, Excogitation, Aetherpact, Recitation, FeyBlessing, Consolation, Protraction, Expedient, Seraphism, Resurrection, Summons, PetActions }
+    public enum Track { WhisperingDawn = SharedTrack.Count, Adloquium, Succor, FeyIllumination, Lustrate, SacredSoil, Indomitability, DeploymentTactics, EmergencyTactics, Dissipation, Excogitation, Aetherpact, Recitation, FeyBlessing, Consolation, Protraction, Expedient, Seraphism, Resurrection, Summons }
     public enum SuccorOption { None, Succor, Concitation }
     public enum DeployOption { None, Use, UseEx }
     public enum AetherpactOption { None, Use, End }
@@ -81,7 +81,6 @@ public sealed class ClassSCHUtility(RotationModuleManager manager, Actor player)
         ExecuteSimple(strategy.Option(Track.EmergencyTactics), SCH.AID.EmergencyTactics, Player);
         ExecuteSimple(strategy.Option(Track.Dissipation), SCH.AID.Dissipation, Player);
         ExecuteSimple(strategy.Option(Track.Excogitation), SCH.AID.Excogitation, null);
-        ExecuteSimple(strategy.Option(Track.Aetherpact), SCH.AID.Aetherpact, null);
         ExecuteSimple(strategy.Option(Track.FeyBlessing), SCH.AID.FeyBlessing, Player);
         ExecuteSimple(strategy.Option(Track.Consolation), SCH.AID.Consolation, Player);
         ExecuteSimple(strategy.Option(Track.Protraction), SCH.AID.Protraction, null);
@@ -104,7 +103,7 @@ public sealed class ClassSCHUtility(RotationModuleManager manager, Actor player)
             Hints.ActionsToExecute.Push(ActionID.MakeSpell(SCH.AID.DeploymentTactics), Player, deploy.Priority(), deploy.Value.ExpireIn);
 
         var pact = strategy.Option(Track.Aetherpact);
-        var pactAction = succ.As<AetherpactOption>() switch
+        var pactAction = pact.As<AetherpactOption>() switch
         {
             AetherpactOption.Use => SCH.AID.Aetherpact,
             AetherpactOption.End => SCH.AID.DissolveUnion,
@@ -117,15 +116,15 @@ public sealed class ClassSCHUtility(RotationModuleManager manager, Actor player)
         if (recit.As<RecitationOption>() != RecitationOption.None)
             Hints.ActionsToExecute.Push(ActionID.MakeSpell(SCH.AID.Recitation), Player, recit.Priority(), recit.Value.ExpireIn);
 
-        var pet = strategy.Option(Track.PetActions);
-        var petAction = succ.As<PetOption>() switch
+        var pet = strategy.Option(Track.Summons);
+        var petSummons = pet.As<PetOption>() switch
         {
             PetOption.Eos => SCH.AID.SummonEos,
             PetOption.Seraph => SCH.AID.SummonSeraph,
             _ => default
         };
-        if (petAction != default)
-            Hints.ActionsToExecute.Push(ActionID.MakeSpell(petAction), Player, pet.Priority(), pet.Value.ExpireIn);
+        if (petSummons != default)
+            Hints.ActionsToExecute.Push(ActionID.MakeSpell(petSummons), Player, pet.Priority(), pet.Value.ExpireIn);
 
     }
 }

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C011Silkie/C011Silkie.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C011Silkie/C011Silkie.cs
@@ -35,8 +35,8 @@ public abstract class C011Silkie(WorldState ws, Actor primary) : BossModule(ws, 
     public static readonly AOEShapeCone ShapeYellow = new(60, 22.5f.Degrees());
 }
 
-[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.NBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 878, NameID = 11369, SortOrder = 5)]
+[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.NBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 878, NameID = 11369, SortOrder = 5, PlanLevel = 90)]
 public class C011NSilkie(WorldState ws, Actor primary) : C011Silkie(ws, primary);
 
-[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.SBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 879, NameID = 11369, SortOrder = 5)]
+[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.SBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 879, NameID = 11369, SortOrder = 5, PlanLevel = 90)]
 public class C011SSilkie(WorldState ws, Actor primary) : C011Silkie(ws, primary);

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C012Gladiator/C012Gladiator.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C012Gladiator/C012Gladiator.cs
@@ -10,8 +10,8 @@ class SRushOfMightBack(BossModule module) : RushOfMightBack(module, AID.SRushOfM
 
 public abstract class C012Gladiator(WorldState ws, Actor primary) : BossModule(ws, primary, new(-35, -271), new ArenaBoundsSquare(20));
 
-[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.NBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 878, NameID = 11387, SortOrder = 8)]
+[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.NBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 878, NameID = 11387, SortOrder = 8, PlanLevel = 90)]
 public class C012NGladiator(WorldState ws, Actor primary) : C012Gladiator(ws, primary);
 
-[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.SBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 879, NameID = 11387, SortOrder = 8)]
+[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.SBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 879, NameID = 11387, SortOrder = 8, PlanLevel = 90)]
 public class C012SGladiator(WorldState ws, Actor primary) : C012Gladiator(ws, primary);

--- a/BossMod/Modules/Endwalker/Criterion/C01ASS/C013Shadowcaster/C013Shadowcaster.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C01ASS/C013Shadowcaster/C013Shadowcaster.cs
@@ -15,8 +15,8 @@ class SPureFire(BossModule module) : PureFire(module, AID.SPureFireAOE);
 
 public abstract class C013Shadowcaster(WorldState ws, Actor primary) : BossModule(ws, primary, new(289, -105), new ArenaBoundsRect(15, 20));
 
-[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.NBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 878, NameID = 11393, SortOrder = 9)]
+[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.NBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 878, NameID = 11393, SortOrder = 9, PlanLevel = 90)]
 public class C013NShadowcaster(WorldState ws, Actor primary) : C013Shadowcaster(ws, primary);
 
-[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.SBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 879, NameID = 11393, SortOrder = 9)]
+[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.SBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 879, NameID = 11393, SortOrder = 9, PlanLevel = 90)]
 public class C013SShadowcaster(WorldState ws, Actor primary) : C013Shadowcaster(ws, primary);

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C021Shishio/C021Shishio.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C021Shishio/C021Shishio.cs
@@ -10,8 +10,8 @@ class SThunderVortex(BossModule module) : ThunderVortex(module, AID.SThunderVort
 
 public abstract class C021Shishio(WorldState ws, Actor primary) : BossModule(ws, primary, new(0, -100), new ArenaBoundsSquare(20));
 
-[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.NBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 946, NameID = 12428, SortOrder = 4)]
+[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.NBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 946, NameID = 12428, SortOrder = 4, PlanLevel = 90)]
 public class C021NShishio(WorldState ws, Actor primary) : C021Shishio(ws, primary);
 
-[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.SBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 947, NameID = 12428, SortOrder = 4)]
+[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.SBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 947, NameID = 12428, SortOrder = 4, PlanLevel = 90)]
 public class C021SShishio(WorldState ws, Actor primary) : C021Shishio(ws, primary);

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C022Gorai/C022Gorai.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C022Gorai/C022Gorai.cs
@@ -6,8 +6,8 @@ class SUnenlightenment(BossModule module) : Unenlightenment(module, AID.SUnenlig
 
 public abstract class C022Gorai(WorldState ws, Actor primary) : BossModule(ws, primary, new(300, -120), new ArenaBoundsSquare(20));
 
-[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.NBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 946, NameID = 12373, SortOrder = 7)]
+[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.NBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 946, NameID = 12373, SortOrder = 7, PlanLevel = 90)]
 public class C022NGorai(WorldState ws, Actor primary) : C022Gorai(ws, primary);
 
-[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.SBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 947, NameID = 12373, SortOrder = 7)]
+[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.SBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 947, NameID = 12373, SortOrder = 7, PlanLevel = 90)]
 public class C022SGorai(WorldState ws, Actor primary) : C022Gorai(ws, primary);

--- a/BossMod/Modules/Endwalker/Criterion/C02AMR/C023Moko/C023Moko.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C02AMR/C023Moko/C023Moko.cs
@@ -6,8 +6,8 @@ class SLateralSlice(BossModule module) : LateralSlice(module, AID.SLateralSlice)
 
 public abstract class C023Moko(WorldState ws, Actor primary) : BossModule(ws, primary, new(-200, 0), new ArenaBoundsSquare(20));
 
-[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.NBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 946, NameID = 12357, SortOrder = 8)]
+[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.NBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 946, NameID = 12357, SortOrder = 8, PlanLevel = 90)]
 public class C023NMoko(WorldState ws, Actor primary) : C023Moko(ws, primary);
 
-[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.SBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 947, NameID = 12357, SortOrder = 8)]
+[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.SBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 947, NameID = 12357, SortOrder = 8, PlanLevel = 90)]
 public class C023SMoko(WorldState ws, Actor primary) : C023Moko(ws, primary);

--- a/BossMod/Modules/Endwalker/Criterion/C03AAI/C031Ketuduke/C031Ketuduke.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C03AAI/C031Ketuduke/C031Ketuduke.cs
@@ -16,8 +16,8 @@ class SHydrobomb(BossModule module) : Hydrobomb(module, AID.SHydrobombAOE);
 
 public abstract class C031Ketuduke(WorldState ws, Actor primary) : BossModule(ws, primary, new(0, 0), new ArenaBoundsSquare(20));
 
-[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.NBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 979, NameID = 12605, SortOrder = 5)]
+[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.NBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 979, NameID = 12605, SortOrder = 5, PlanLevel = 90)]
 public class C031NKetuduke(WorldState ws, Actor primary) : C031Ketuduke(ws, primary);
 
-[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.SBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 980, NameID = 12605, SortOrder = 5)]
+[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.SBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 980, NameID = 12605, SortOrder = 5, PlanLevel = 90)]
 public class C031SKetuduke(WorldState ws, Actor primary) : C031Ketuduke(ws, primary);

--- a/BossMod/Modules/Endwalker/Criterion/C03AAI/C032Lala/C032Lala.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C03AAI/C032Lala/C032Lala.cs
@@ -6,8 +6,8 @@ class SArcaneBlight(BossModule module) : ArcaneBlight(module, AID.SArcaneBlightA
 
 public abstract class C032Lala(WorldState ws, Actor primary) : BossModule(ws, primary, new(200, 0), new ArenaBoundsSquare(20));
 
-[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.NBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 979, NameID = 12639, SortOrder = 8)]
+[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.NBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 979, NameID = 12639, SortOrder = 8, PlanLevel = 90)]
 public class C032NLala(WorldState ws, Actor primary) : C032Lala(ws, primary);
 
-[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.SBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 980, NameID = 12639, SortOrder = 8)]
+[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.SBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 980, NameID = 12639, SortOrder = 8, PlanLevel = 90)]
 public class C032SLala(WorldState ws, Actor primary) : C032Lala(ws, primary);

--- a/BossMod/Modules/Endwalker/Criterion/C03AAI/C033Statice/C033Statice.cs
+++ b/BossMod/Modules/Endwalker/Criterion/C03AAI/C033Statice/C033Statice.cs
@@ -12,8 +12,8 @@ class SFaerieRing(BossModule module) : FaerieRing(module, AID.SFaerieRing);
 
 public abstract class C033Statice(WorldState ws, Actor primary) : BossModule(ws, primary, new(-200, 0), new ArenaBoundsCircle(20));
 
-[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.NBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 979, NameID = 12506, SortOrder = 9)]
+[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.NBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 979, NameID = 12506, SortOrder = 9, PlanLevel = 90)]
 public class C033NStatice(WorldState ws, Actor primary) : C033Statice(ws, primary);
 
-[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.SBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 980, NameID = 12506, SortOrder = 9)]
+[ModuleInfo(BossModuleInfo.Maturity.Verified, PrimaryActorOID = (uint)OID.SBoss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 980, NameID = 12506, SortOrder = 9, PlanLevel = 90)]
 public class C033SStatice(WorldState ws, Actor primary) : C033Statice(ws, primary);


### PR DESCRIPTION
- [x] ASS
- [x] ASS (Savage)
- [x] AMR
- [x] AMR (Savage)
- [x] AAI
- [x] AAI (Savage)
- [x] Fix issue with **ClassSCHUtility.cs** breaking from _Aetherpact_
- [x] Fix issue with **ClassGNBUtility.cs** not calling _Trajectory_
- [x] Fix issue with **ClassDRKUtility.cs** not calling _Shadowstride_