### PR TITLE
ensure existence of default preset

### DIFF
--- a/BossMod/Autorotation/AutorotationConfig.cs
+++ b/BossMod/Autorotation/AutorotationConfig.cs
@@ -19,6 +19,9 @@ public sealed class AutorotationConfig : ConfigNode
     [PropertyDisplay("Show autorotation preset in the server info bar")]
     public DtrStatus ShowDTR = DtrStatus.None;
 
+    [PropertyDisplay("Hide VBM Default preset", tooltip: "If you've created your own presets and no longer need the included default, this option will prevent it from being shown in the Autorotation and Preset Editor windows.", since: "0.0.0.253")]
+    public bool HideDefaultPreset = false;
+
     [PropertyDisplay("Show positional hints in world", tooltip: "Show tips for positional abilities, indicating to move to the flank or rear of your target")]
     public bool ShowPositionals = false;
 

--- a/BossMod/Autorotation/PresetDatabase.cs
+++ b/BossMod/Autorotation/PresetDatabase.cs
@@ -6,31 +6,43 @@ namespace BossMod.Autorotation;
 // note: presets in the database are immutable (otherwise eg. manager won't see the changes in active preset)
 public sealed class PresetDatabase
 {
+    public const string DefaultPresetName = "VBM Default";
+
+    private readonly AutorotationConfig _cfg = Service.Config.Get<AutorotationConfig>();
+
     public readonly List<Preset> Presets = [];
     public Event<Preset?, Preset?> PresetModified = new(); // (old, new); old == null if preset is added, new == null if preset is removed
 
     private readonly FileInfo _dbPath;
 
-    public PresetDatabase(string rootPath, FileInfo? defaultPresets)
+    public PresetDatabase(string rootPath, FileInfo defaultPresets)
     {
         _dbPath = new(rootPath + ".db.json");
-        if (!_dbPath.Exists && (defaultPresets?.Exists ?? false))
-            defaultPresets.CopyTo(_dbPath.FullName);
+
+        if (defaultPresets.Exists)
+            Presets.AddRange(LoadPresetsFromFile(defaultPresets.FullName));
+        else
+            Service.Log($"Failed to load default presets from '{defaultPresets}': file is missing");
 
         if (_dbPath.Exists)
         {
             try
             {
-                using var json = Serialization.ReadJson(_dbPath.FullName);
-                var version = json.RootElement.GetProperty("version").GetInt32();
-                var payload = json.RootElement.GetProperty("payload");
-                Presets = payload.Deserialize<List<Preset>>(Serialization.BuildSerializationOptions()) ?? [];
+                Presets.AddRange(LoadPresetsFromFile(_dbPath.FullName));
             }
             catch (Exception ex)
             {
                 Service.Log($"Failed to parse preset database '{_dbPath}': {ex}");
             }
         }
+    }
+
+    private List<Preset> LoadPresetsFromFile(string path)
+    {
+        using var json = Serialization.ReadJson(path);
+        var version = json.RootElement.GetProperty("version").GetInt32();
+        var payload = json.RootElement.GetProperty("payload");
+        return payload.Deserialize<List<Preset>>(Serialization.BuildSerializationOptions()) ?? [];
     }
 
     // if index >= 0: replace or delete
@@ -61,7 +73,7 @@ public sealed class PresetDatabase
             jwriter.WriteStartObject();
             jwriter.WriteNumber("version", 0);
             jwriter.WritePropertyName("payload");
-            JsonSerializer.Serialize(jwriter, Presets, Serialization.BuildSerializationOptions());
+            JsonSerializer.Serialize(jwriter, Presets.Where(p => p.Name != DefaultPresetName), Serialization.BuildSerializationOptions());
             jwriter.WriteEndObject();
             Service.Log($"Database saved successfully to '{_dbPath.FullName}'");
         }
@@ -71,5 +83,5 @@ public sealed class PresetDatabase
         }
     }
 
-    public IEnumerable<Preset> PresetsForClass(Class c) => Presets.Where(p => p.Modules.Any(m => RotationModuleRegistry.Modules[m.Key].Definition.Classes[(int)c]));
+    public IEnumerable<Preset> PresetsForClass(Class c) => Presets.Where(p => (p.Name != DefaultPresetName || !_cfg.HideDefaultPreset) && p.Modules.Any(m => RotationModuleRegistry.Modules[m.Key].Definition.Classes[(int)c]));
 }

--- a/BossMod/Autorotation/RotationDatabase.cs
+++ b/BossMod/Autorotation/RotationDatabase.cs
@@ -7,7 +7,7 @@ public sealed class RotationDatabase
     public readonly PresetDatabase Presets;
     public readonly PlanDatabase Plans;
 
-    public RotationDatabase(DirectoryInfo rootPath, FileInfo? defaultPresets)
+    public RotationDatabase(DirectoryInfo rootPath, FileInfo defaultPresets)
     {
         if (!rootPath.Exists)
             rootPath.Create();

--- a/BossMod/Autorotation/UIPresetDatabaseEditor.cs
+++ b/BossMod/Autorotation/UIPresetDatabaseEditor.cs
@@ -12,7 +12,10 @@ public sealed class UIPresetDatabaseEditor(PresetDatabase db)
     private Type? _selectedModuleType; // we want module selection to be persistent when changing presets
     private UIPresetEditor? _selectedPreset;
 
+    private readonly AutorotationConfig _cfg = Service.Config.Get<AutorotationConfig>();
+
     private bool HaveUnsavedModifications => _selectedPreset?.Modified ?? false;
+    private bool DefaultSelected => _selectedPreset?.IsDefaultPreset ?? false;
 
     public void Draw()
     {
@@ -95,6 +98,9 @@ public sealed class UIPresetDatabaseEditor(PresetDatabase db)
                 for (int i = 0; i < db.Presets.Count; ++i)
                 {
                     var preset = db.Presets[i];
+                    if (preset.Name == PresetDatabase.DefaultPresetName && _cfg.HideDefaultPreset)
+                        continue;
+
                     if (ImGui.Selectable(preset.Name, _selectedPresetIndex == i))
                     {
                         _pendingSelectPresetIndex = i;
@@ -134,7 +140,7 @@ public sealed class UIPresetDatabaseEditor(PresetDatabase db)
         if (UIMisc.Button("Copy", 0, (HaveUnsavedModifications, "Current preset is modified, save or discard changes"), (_selectedPresetIndex < 0, "No preset is selected")))
             CreateNewPreset(_selectedPresetIndex);
         ImGui.SameLine();
-        if (UIMisc.Button("Delete", 0, (!ImGui.GetIO().KeyShift, "Hold shift to delete"), (_selectedPresetIndex < 0, "No preset is selected")))
+        if (UIMisc.Button("Delete", 0, DefaultSelected ? (true, "The default preset can't be deleted. If you would like to hide it, you can do so in Settings -> Autorotation.") : (!ImGui.GetIO().KeyShift, "Hold shift to delete"), (_selectedPresetIndex < 0, "No preset is selected")))
             DeleteCurrentPreset();
         ImGui.SameLine();
         if (UIMisc.Button("Export", _selectedPreset == null, "No preset is selected"))

--- a/BossMod/Autorotation/UIPresetEditor.cs
+++ b/BossMod/Autorotation/UIPresetEditor.cs
@@ -15,6 +15,8 @@ public sealed class UIPresetEditor
     private readonly List<int> _orderedTrackList = []; // for current module, by UI order
     private readonly List<int> _settingGuids = []; // a hack to keep track of held item during drag-n-drop
 
+    public bool IsDefaultPreset => Preset.Name == PresetDatabase.DefaultPresetName;
+
     public UIPresetEditor(PresetDatabase db, int index, Type? initiallySelectedModuleType)
     {
         _db = db;
@@ -116,6 +118,9 @@ public sealed class UIPresetEditor
                 }
             }
         }
+
+        using var d = ImRaii.Disabled(IsDefaultPreset);
+
         if (ImGui.Button("Add##module", width))
             ImGui.OpenPopup("add_module");
 
@@ -167,6 +172,8 @@ public sealed class UIPresetEditor
             ImGui.TextUnformatted("Add or select rotation module to configure its strategies");
             return;
         }
+
+        using var d = ImRaii.Disabled(IsDefaultPreset);
 
         var width = new Vector2(ImGui.GetContentRegionAvail().X, 0);
         var md = RotationModuleRegistry.Modules[SelectedModuleType].Definition;

--- a/BossMod/DefaultRotationPresets.json
+++ b/BossMod/DefaultRotationPresets.json
@@ -2,7 +2,7 @@
   "version": 0,
   "payload": [
     {
-      "Name": "Default",
+      "Name": "VBM Default",
       "Modules": {
         "BossMod.Autorotation.xan.DNC": [
           {


### PR DESCRIPTION
based on a discussion in discord, it seems like there can be a few factors that prevent people from even knowing that vbm includes a sane-ish default preset - one being the `Exists` bug, but also plenty of people who have been using the plugin for a long time have gotten grandfathered in to the older, shittier system where we had two separate default presets, or no default at all. and since PresetDatabase would only seed the default if the preset file was missing entirely (which, for any existing users, it wouldn't be), the vast majority of those users never found out that these defaults existed.

in this PR, i ensure that we always load the default presets, which i renamed to `VBM Default` to clarify what it is and because i already have my own `Default` that i'm using. i also added an option to hide it from the UI, since power users probably won't want it.

here's how it looks if you try to edit the default:

![image](https://github.com/user-attachments/assets/f92af4b7-cfee-49ec-88ff-b1a4ebde6081)

tooltip for the delete button: 
![image](https://github.com/user-attachments/assets/fa4697b9-fe73-4642-8d16-fbcfc8c7e1e0)
