### PR TITLE
Antitower, Sohr Khai, Xelphatol

### DIFF
--- a/BossMod/Components/Gaze.cs
+++ b/BossMod/Components/Gaze.cs
@@ -48,11 +48,7 @@ public abstract class GenericGaze(BossModule module, ActionID aid = new(), bool 
         {
             bool danger = HitByEye(pc, eye) != Inverted;
             var eyeCenter = IndicatorScreenPos(eye.Position);
-            var dl = ImGui.GetWindowDrawList();
-            dl.PathArcTo(eyeCenter - new Vector2(0, _eyeOffsetV), _eyeOuterR, MathF.PI / 2 + _eyeHalfAngle, MathF.PI / 2 - _eyeHalfAngle);
-            dl.PathArcTo(eyeCenter + new Vector2(0, _eyeOffsetV), _eyeOuterR, -MathF.PI / 2 + _eyeHalfAngle, -MathF.PI / 2 - _eyeHalfAngle);
-            dl.PathFillConvex(danger ? ArenaColor.Enemy : ArenaColor.PC);
-            dl.AddCircleFilled(eyeCenter, _eyeInnerR, ArenaColor.Border);
+            DrawEye(eyeCenter, danger);
 
             if (pc.Position.InCircle(eye.Position, eye.Range))
             {
@@ -61,6 +57,15 @@ public abstract class GenericGaze(BossModule module, ActionID aid = new(), bool 
                 Arena.PathStroke(false, ArenaColor.Enemy);
             }
         }
+    }
+
+    public static void DrawEye(Vector2 eyeCenter, bool danger)
+    {
+        var dl = ImGui.GetWindowDrawList();
+        dl.PathArcTo(eyeCenter - new Vector2(0, _eyeOffsetV), _eyeOuterR, MathF.PI / 2 + _eyeHalfAngle, MathF.PI / 2 - _eyeHalfAngle);
+        dl.PathArcTo(eyeCenter + new Vector2(0, _eyeOffsetV), _eyeOuterR, -MathF.PI / 2 + _eyeHalfAngle, -MathF.PI / 2 - _eyeHalfAngle);
+        dl.PathFillConvex(danger ? ArenaColor.Enemy : ArenaColor.PC);
+        dl.AddCircleFilled(eyeCenter, _eyeInnerR, ArenaColor.Border);
     }
 
     private bool HitByEye(Actor actor, Eye eye) => (actor.Rotation + eye.Forward).ToDirection().Dot((eye.Position - actor.Position).Normalized()) >= 0.707107f; // 45-degree

--- a/BossMod/Modules/Heavensward/Dungeon/D11Antitower/D111ZuroRoggo.cs
+++ b/BossMod/Modules/Heavensward/Dungeon/D11Antitower/D111ZuroRoggo.cs
@@ -1,0 +1,109 @@
+﻿namespace BossMod.Heavensward.Dungeon.D11Antitower.D111ZuroRoggo;
+
+public enum OID : uint
+{
+    Boss = 0x14FC, // R3.000
+    Helper = 0x233C,
+    Chirp = 0x14FE, // R2.000, x0 (spawn during fight)
+    PoroggoChoirtoad = 0x14FD, // R2.100, x0 (spawn during fight)
+}
+
+public enum AID : uint
+{
+    WaterBomb1 = 5538, // Helper->location, 3.0s cast, range 6 circle
+    WaterBombVisual = 5537, // Boss->self, 3.0s cast, single-target
+    OdiousCroak = 5540, // Helper->self, no cast, range 11+R ?-degree cone
+    DiscordantHarmony = 5543, // Chirp->self, no cast, range 6 circle
+    FrogSong = 5541, // Helper->self, no cast, range 40 circle
+    WaterBomb2 = 5979, // Helper->location, 3.0s cast, range 6 circle
+    WaterBomb3 = 5977, // Helper->location, 3.0s cast, range 6 circle
+}
+
+class Choirtoad(BossModule module) : Components.Adds(module, (uint)OID.PoroggoChoirtoad)
+{
+    public override void AddAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints) => hints.PrioritizeTargetsByOID(OID.PoroggoChoirtoad, 1);
+}
+
+class Chirp(BossModule module) : Components.GenericAOEs(module)
+{
+    private readonly List<(Actor, DateTime)> Sources = [];
+
+    public override IEnumerable<AOEInstance> ActiveAOEs(int slot, Actor actor) => Sources.Select(src => new AOEInstance(new AOEShapeCircle(6), src.Item1.Position, src.Item1.Rotation, src.Item2));
+
+    public override void OnActorCreated(Actor actor)
+    {
+        if (actor.OID == (uint)OID.Chirp)
+            Sources.Add((actor, WorldState.FutureTime(8.95f)));
+    }
+
+    public override void OnEventCast(Actor caster, ActorCastEvent spell)
+    {
+        if (spell.Action.ID == (uint)AID.DiscordantHarmony)
+            Sources.RemoveAll(x => x.Item1 == caster);
+    }
+}
+class OdiousCroak(BossModule module) : Components.GenericAOEs(module)
+{
+    private record struct PersistentAOE(WPos Source, Angle Rotation, DateTime Activation, int NumCastsRemaining);
+
+    private PersistentAOE? AOE;
+
+    public override IEnumerable<AOEInstance> ActiveAOEs(int slot, Actor actor) => Utils.ZeroOrOne(AOE).Select(p => new AOEInstance(new AOEShapeCone(14, 60.Degrees()), p.Source, p.Rotation, p.Activation));
+
+    public override void OnEventCast(Actor caster, ActorCastEvent spell)
+    {
+        if (spell.Action.ID == (uint)AID.OdiousCroak)
+        {
+            if (AOE is PersistentAOE p)
+            {
+                AOE = p with
+                {
+                    Source = caster.Position,
+                    Rotation = caster.Rotation,
+                    NumCastsRemaining = p.NumCastsRemaining - 1
+                };
+                if (AOE?.NumCastsRemaining == 0)
+                    AOE = null;
+            }
+            else
+            {
+                AOE = new(caster.Position, caster.Rotation, default, 11);
+            }
+        }
+    }
+}
+
+class WaterBomb(BossModule module) : Components.GenericAOEs(module)
+{
+    private readonly List<(WPos, DateTime)> aoes = [];
+
+    public override IEnumerable<AOEInstance> ActiveAOEs(int slot, Actor actor) => aoes.Select(a => new AOEInstance(new AOEShapeCircle(6), a.Item1, default, a.Item2));
+
+    public override void OnCastStarted(Actor caster, ActorCastInfo spell)
+    {
+        if ((AID)spell.Action.ID is AID.WaterBomb1 or AID.WaterBomb2 or AID.WaterBomb3)
+            aoes.Add((spell.LocXZ, Module.CastFinishAt(spell)));
+    }
+
+    public override void OnCastFinished(Actor caster, ActorCastInfo spell)
+    {
+        if ((AID)spell.Action.ID is AID.WaterBomb1 or AID.WaterBomb2 or AID.WaterBomb3)
+            aoes.RemoveAll(a => a.Item1.AlmostEqual(spell.LocXZ, 1));
+    }
+}
+
+class ZuroRoggoStates : StateMachineBuilder
+{
+    public ZuroRoggoStates(BossModule module) : base(module)
+    {
+        TrivialPhase()
+            .ActivateOnEnter<Chirp>()
+            .ActivateOnEnter<WaterBomb>()
+            .ActivateOnEnter<OdiousCroak>()
+            .ActivateOnEnter<Choirtoad>();
+    }
+}
+
+[ModuleInfo(BossModuleInfo.Maturity.Contributed, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 141, NameID = 4805, Contributors = "xan")]
+public class ZuroRoggo(WorldState ws, Actor primary) : BossModule(ws, primary, new(-365, -250), new ArenaBoundsCircle(20));
+

--- a/BossMod/Modules/Heavensward/Dungeon/D11Antitower/D112Ziggy.cs
+++ b/BossMod/Modules/Heavensward/Dungeon/D11Antitower/D112Ziggy.cs
@@ -1,0 +1,123 @@
+﻿namespace BossMod.Heavensward.Dungeon.D11Antitower.D112Ziggy;
+
+public enum OID : uint
+{
+    Boss = 0x3D82, // R2.700
+    Helper = 0x233C,
+    Stardust = 0x3D83, // R2.000, x0 (spawn during fight)
+}
+
+public enum AID : uint
+{
+    AutoAttack = 872, // Boss->player, no cast, single-target
+    GyratingGlare = 31835, // Boss->self, 5.0s cast, range 40 circle
+    ShinySummoning = 31831, // Boss->self, no cast, single-target
+    MysticLight = 31838, // Stardust->self, 6.0s cast, range 12 circle
+    JitteringGlare = 31832, // Boss->self, 3.0s cast, range 40 30-degree cone
+    JitteringJounceCast = 31833, // Boss->self, 6.0s cast, single-target
+    JitteringJounceCharge = 31840, // Boss->player/Stardust, no cast, width 6 rect charge
+    DeepFracture = 31839, // Stardust->self, 4.0s cast, range 11 circle
+    JitteringJab = 31837, // Boss->player, 5.0s cast, single-target
+}
+
+public enum IconID : uint
+{
+    JitteringJounce = 2, // player
+}
+
+public enum TetherID : uint
+{
+    JitteringJounce = 2, // Boss->player/Stardust
+}
+
+class JitteringGlare(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.JitteringGlare), new AOEShapeCone(40, 15.Degrees()));
+class JitteringJab(BossModule module) : Components.SingleTargetCast(module, ActionID.MakeSpell(AID.JitteringJab));
+
+class JitteringJounceAOE(BossModule module) : Components.GenericLineOfSightAOE(module, ActionID.MakeSpell(AID.JitteringJounceCharge), 100, false)
+{
+    public override void OnTethered(Actor source, ActorTetherInfo tether)
+    {
+        if (tether.ID == (uint)TetherID.JitteringJounce)
+        {
+            var slot = Raid.FindSlot(tether.Target);
+            if (slot >= 0)
+            {
+                Modify(Module.PrimaryActor.Position, Module.Enemies(OID.Stardust).Where(e => !e.IsDead).Select(s => (s.Position, 1f)), WorldState.FutureTime(6), BitMask.Build(slot));
+            }
+        }
+    }
+
+    public override void OnEventCast(Actor caster, ActorCastEvent spell)
+    {
+        if ((AID)spell.Action.ID == AID.JitteringJounceCharge)
+            Modify(null, []);
+    }
+}
+
+class JitteringJounceTether(BossModule module) : BossComponent(module)
+{
+    private Actor? Target;
+
+    public override void OnTethered(Actor source, ActorTetherInfo tether)
+    {
+        if (tether.ID == (uint)TetherID.JitteringJounce)
+            Target = WorldState.Actors.Find(tether.Target);
+    }
+
+    public override void OnUntethered(Actor source, ActorTetherInfo tether)
+    {
+        if (tether.ID == (uint)TetherID.JitteringJounce)
+            Target = null;
+    }
+
+    public override void DrawArenaBackground(int pcSlot, Actor pc)
+    {
+        if (Target == null)
+            return;
+
+        var src = Module.PrimaryActor.Position;
+        var dst = Target.Position;
+        var shape = new AOEShapeRect((dst - src).Length(), 3);
+        var angle = Angle.FromDirection(dst - src);
+        if (Target == pc)
+            shape.Outline(Module.Arena, src, angle, ArenaColor.Danger);
+        else
+            shape.Draw(Module.Arena, src, angle, ArenaColor.AOE);
+    }
+
+    public override void AddAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
+    {
+        if (Target == null || Target == actor)
+            return;
+
+        hints.AddForbiddenZone(ShapeDistance.Rect(Module.PrimaryActor.Position, Target.Position, 3), Module.CastFinishAt(Module.PrimaryActor.CastInfo, 0.5f));
+    }
+}
+
+class Stardust(BossModule module) : BossComponent(module)
+{
+    public override void DrawArenaForeground(int pcSlot, Actor pc) => Arena.Actors(Module.Enemies(OID.Stardust).Where(x => !x.IsDead), ArenaColor.Object, true);
+}
+class DeepFracture(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.DeepFracture), new AOEShapeCircle(11));
+class GyratingGlare(BossModule module) : Components.RaidwideCast(module, ActionID.MakeSpell(AID.GyratingGlare));
+class MysticLight(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.MysticLight), new AOEShapeCircle(12));
+
+class ZiggyStates : StateMachineBuilder
+{
+    public ZiggyStates(BossModule module) : base(module)
+    {
+        TrivialPhase()
+            .ActivateOnEnter<Stardust>()
+            .ActivateOnEnter<GyratingGlare>()
+            .ActivateOnEnter<MysticLight>()
+            .ActivateOnEnter<DeepFracture>()
+            .ActivateOnEnter<JitteringJounceAOE>()
+            .ActivateOnEnter<JitteringJounceTether>()
+            .ActivateOnEnter<JitteringJab>()
+            .ActivateOnEnter<JitteringGlare>();
+    }
+}
+
+[ModuleInfo(BossModuleInfo.Maturity.Contributed, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 141, NameID = 4808, Contributors = "xan")]
+public class Ziggy(WorldState ws, Actor primary) : BossModule(ws, primary, new(185.78f, 137.5f), new ArenaBoundsCircle(20));
+

--- a/BossMod/Modules/Heavensward/Dungeon/D11Antitower/D113Calcabrina.cs
+++ b/BossMod/Modules/Heavensward/Dungeon/D11Antitower/D113Calcabrina.cs
@@ -1,0 +1,106 @@
+﻿namespace BossMod.Heavensward.Dungeon.D11Antitower.D113Calcabrina;
+
+public enum OID : uint
+{
+    Boss = 0x1502, // R2.250, x1
+    Helper = 0x233C, // R0.500, x10, Helper type
+    Brina = 0x15E1, // R0.900, x0 (spawn during fight)
+    Calca = 0x15E0, // R0.900, x0 (spawn during fight)
+    Brina1 = 0x15E3, // R0.900, x0 (spawn during fight)
+    Calca1 = 0x15E2, // R0.900, x0 (spawn during fight)
+}
+
+public enum AID : uint
+{
+    TerrifyingGlance = 5559, // Boss->self, no cast, range 40+R ?-degree cone
+    Knockout = 5556, // Boss->player, 4.0s cast, single-target
+    Brace = 5557, // Boss->self, 3.0s cast, single-target
+    Breach = 5558, // Helper->player, no cast, single-target
+    Dollhouse = 5561, // Boss->self, 3.0s cast, ???
+    Slapstick = 5560, // Boss->self, no cast, range 40 circle
+    HeatGazeDonut = 5552, // 15E1/15E3->self, 3.0s cast, range 10 circle
+    HeatGazeCone = 5551, // 15E0/15E2->self, 3.0s cast, range 19+R 60-degree cone
+}
+
+public enum IconID : uint
+{
+    TerrifyingGlance = 73, // player
+}
+
+class HeatGazeDonut(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.HeatGazeDonut), new AOEShapeDonut(5, 10));
+class HeatGazeCone(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.HeatGazeCone), new AOEShapeCone(19.9f, 30.Degrees()));
+class Knockout(BossModule module) : Components.SingleTargetCast(module, ActionID.MakeSpell(AID.Knockout));
+class Brace(BossModule module) : Components.DirectionalParry(module, (uint)OID.Boss)
+{
+    public override void OnCastStarted(Actor caster, ActorCastInfo spell)
+    {
+        if ((AID)spell.Action.ID == AID.Brace)
+            PredictParrySide(caster.InstanceID, Side.All ^ Side.Front);
+    }
+}
+
+class TerrifyingGlance(BossModule module) : Components.BaitAwayIcon(module, new AOEShapeCone(40, 60.Degrees()), (uint)IconID.TerrifyingGlance, ActionID.MakeSpell(AID.TerrifyingGlance), 3.5f)
+{
+    private bool WillBeHit(Actor actor) => CurrentBaits.Any(b => b.Target == actor || IsClippedBy(actor, b));
+    private bool WillBeGazed(Actor actor) => WillBeHit(actor) && actor.Rotation.ToDirection().Dot((CurrentBaits[0].Source.Position - actor.Position).Normalized()) >= 0.707107f;
+
+    public override void AddAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
+    {
+        base.AddAIHints(slot, actor, assignment, hints);
+
+        if (WillBeHit(actor))
+            hints.ForbiddenDirections.Add((actor.AngleTo(CurrentBaits[0].Source), 45.Degrees(), CurrentBaits[0].Activation));
+    }
+
+    public override void AddHints(int slot, Actor actor, TextHints hints)
+    {
+        base.AddHints(slot, actor, hints);
+
+        if (WillBeGazed(actor))
+            hints.Add("Turn away from gaze!");
+    }
+
+    public override void DrawArenaForeground(int pcSlot, Actor pc)
+    {
+        base.DrawArenaForeground(pcSlot, pc);
+
+        if (CurrentBaits.Count > 0)
+        {
+            Components.GenericGaze.DrawEye(Module.Arena.WorldPositionToScreenPosition(CurrentBaits[0].Source.Position), WillBeGazed(pc));
+
+            if (WillBeHit(pc))
+            {
+                Arena.PathArcTo(pc.Position, 1, (pc.Rotation + 45.Degrees()).Rad, (pc.Rotation - 45.Degrees()).Rad);
+                Arena.PathStroke(false, ArenaColor.Enemy);
+            }
+        }
+    }
+}
+
+class CalcabrinaStates : StateMachineBuilder
+{
+    public CalcabrinaStates(BossModule module) : base(module)
+    {
+        TrivialPhase()
+            .ActivateOnEnter<Brace>()
+            .ActivateOnEnter<TerrifyingGlance>()
+            .ActivateOnEnter<Knockout>()
+            .ActivateOnEnter<HeatGazeDonut>()
+            .ActivateOnEnter<HeatGazeCone>();
+    }
+}
+
+[ModuleInfo(BossModuleInfo.Maturity.Contributed, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 141, NameID = 4813, Contributors = "xan")]
+public class Calcabrina(WorldState ws, Actor primary) : BossModule(ws, primary, new(232, -182), new ArenaBoundsCircle(20))
+{
+    protected override void DrawEnemies(int pcSlot, Actor pc) => Arena.Actors(WorldState.Actors.Where(x => !x.IsAlly), ArenaColor.Enemy);
+
+    protected override void CalculateModuleAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
+    {
+        foreach (var h in hints.PotentialTargets)
+            h.Priority = (OID)h.Actor.OID == OID.Boss ? 0 : 1;
+    }
+
+    protected override bool CheckPull() => PrimaryActor.InCombat;
+}
+

--- a/BossMod/Modules/Heavensward/Dungeon/D13SohrKhai/D131ChieftainMoglin.cs
+++ b/BossMod/Modules/Heavensward/Dungeon/D13SohrKhai/D131ChieftainMoglin.cs
@@ -1,0 +1,160 @@
+﻿namespace BossMod.Heavensward.Dungeon.D13SohrKhai.D131ChieftainMoglin;
+
+public enum OID : uint
+{
+    Boss = 0x15FB, // R1.800, x1
+    Helper = 0x1B2, // R0.500, x23
+    PomguardPompincher = 0x1602, // R0.900, x0 (spawn during fight)
+    PomguardPomchopper = 0x15FD, // R0.900, x0 (spawn during fight)
+    CaptainMogsun = 0x15FC, // R0.900, x0 (spawn during fight)
+    PomguardPomcrier = 0x1601, // R0.900, x1
+    PomguardPomfluffer = 0x15FE, // R0.900, x1
+    PomguardPomfryer = 0x1600, // R0.900, x1
+    PomguardPompiercer = 0x15FF, // R0.900, x1
+    DemoniacalMogcane = 0x1603, // R5.000, x0 (spawn during fight)
+}
+
+public enum AID : uint
+{
+    ThousandKuponzeCharge = 6019, // Boss->self, no cast, range 8+R ?-degree cone
+    PoisonNeedle = 4432, // 1602->player, no cast, single-target
+    PomHoly = 6020, // Boss->location, 3.0s cast, range 50 circle
+    PomPraise = 6016, // 1B2->self, 13.0s cast, range 4 circle
+    PomPraiseVisual = 6015, // Boss->self, 13.0s cast, single-target
+    HundredKuponzeSwipe = 4429, // 15FD->self, 3.0s cast, range 20+R 90-degree cone
+    DemoniacalMogcane = 6017, // Boss->self, 2.0s cast, single-target
+    MoogleEyeShot = 4427, // 15FF->player, no cast, single-target
+    PomBomVisual = 6018, // 1603->self, no cast, single-target
+    PomBom = 6212, // ChieftainMoglin->self, no cast, range 40+R width 4 rect
+    SpinningMogshield = 4425, // CaptainMogsun->self, 3.0s cast, range 6+R circle
+    MarchOfTheMoogles = 4431, // PomguardPomcrier->self, 5.0s cast, range 10 circle, damage buff to allies
+    PomCure = 4426, // PomguardPomfluffer->Boss, 3.0s cast, single-target
+    PomFlare = 4428, // PomguardPomfryer->self, 6.0s cast, range 21+R circle
+}
+
+public enum SID : uint
+{
+    Invincibility = 325, // none->Boss, extra=0x0
+    OffBalance = 1064, // none->CaptainMogsun/PomguardPomchopper/PomguardPompincher, extra=0x0
+    Poison = 18, // PomguardPompincher->player, extra=0x0
+}
+
+class Mogshield(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.SpinningMogshield), new AOEShapeCircle(6.9f));
+class ThousandKuponzeCharge(BossModule module) : Components.GenericBaitAway(module)
+{
+    public override void OnEventCast(Actor caster, ActorCastEvent spell)
+    {
+        if ((AID)spell.Action.ID == AID.DemoniacalMogcane)
+            CurrentBaits.Add(new(caster, WorldState.Actors.Find(caster.TargetID)!, new AOEShapeCone(9.8f, 60.Degrees()), WorldState.FutureTime(4.2f)));
+
+        if ((AID)spell.Action.ID == AID.ThousandKuponzeCharge)
+            CurrentBaits.Clear();
+    }
+
+    public override void Update()
+    {
+        base.Update();
+
+        // sanity check: clear baits if cleave is delayed enough (haven't seen this happen in any replays)
+        CurrentBaits.RemoveAll(b => (WorldState.CurrentTime - b.Activation).TotalSeconds > 6);
+    }
+}
+class PomFlare(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.PomFlare), new AOEShapeCircle(21.9f));
+class PomHoly(BossModule module) : Components.RaidwideCast(module, ActionID.MakeSpell(AID.PomHoly));
+class Swipe(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.HundredKuponzeSwipe), new AOEShapeCone(20.9f, 45.Degrees()));
+// pombom 6.4f
+class PomBom(BossModule module) : Components.GenericAOEs(module)
+{
+    private record struct CaneObj(Actor Cane, DateTime Activation);
+    private CaneObj? Cane;
+
+    public override IEnumerable<AOEInstance> ActiveAOEs(int slot, Actor actor) => Utils.ZeroOrOne(Cane).Select(c => new AOEInstance(new AOEShapeCross(20.25f, 2), c.Cane.Position, c.Cane.Rotation, c.Activation));
+
+    public override void OnActorCreated(Actor actor)
+    {
+        if ((OID)actor.OID == OID.DemoniacalMogcane)
+        {
+            Cane = new(actor, WorldState.FutureTime(6.4f));
+        }
+    }
+
+    public override void OnEventCast(Actor caster, ActorCastEvent spell)
+    {
+        if ((AID)spell.Action.ID == AID.PomBom)
+            Cane = null;
+    }
+}
+class PomPraise(BossModule module) : BossComponent(module)
+{
+    private readonly List<Actor> Casters = [];
+
+    private IEnumerable<Actor> RaisedMoogles => Casters.Count == 0 ? [] : WorldState.Actors.Where(e => e.FindStatus(SID.OffBalance) != null && WillRaise(e));
+
+    private bool WillRaise(Actor moogle) => Casters.Any(c => moogle.Position.InCircle(c.Position, 4));
+
+    public override void OnCastStarted(Actor caster, ActorCastInfo spell)
+    {
+        if ((AID)spell.Action.ID == AID.PomPraise)
+            Casters.Add(caster);
+    }
+
+    public override void OnCastFinished(Actor caster, ActorCastInfo spell)
+    {
+        if ((AID)spell.Action.ID == AID.PomPraise)
+            Casters.Remove(caster);
+    }
+
+    public override void DrawArenaForeground(int pcSlot, Actor pc)
+    {
+        foreach (var e in WorldState.Actors.Exclude(Module.PrimaryActor).Where(x => !x.IsAlly && x.IsTargetable))
+            Arena.Actor(e, e.FindStatus(SID.OffBalance) == null ? ArenaColor.Enemy : WillRaise(e) ? ArenaColor.Object : ArenaColor.PlayerGeneric);
+    }
+
+    public override void DrawArenaBackground(int pcSlot, Actor pc)
+    {
+        foreach (var c in Casters)
+            Arena.ZoneCircle(c.Position, 4, ArenaColor.AOE);
+    }
+
+    public override void AddAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
+    {
+        if (Casters.Count == 0)
+            return;
+
+        foreach (var r in hints.PotentialTargets)
+            if (r.Actor.FindStatus(SID.OffBalance) != null && WillRaise(r.Actor))
+                r.Priority = 5;
+    }
+
+    public override void AddHints(int slot, Actor actor, TextHints hints)
+    {
+        if (RaisedMoogles.Any())
+            hints.Add("Knock moogles out of raise!");
+    }
+}
+
+class ChieftainMoglinStates : StateMachineBuilder
+{
+    public ChieftainMoglinStates(BossModule module) : base(module)
+    {
+        TrivialPhase()
+            .ActivateOnEnter<PomHoly>()
+            .ActivateOnEnter<Swipe>()
+            .ActivateOnEnter<PomPraise>()
+            .ActivateOnEnter<PomFlare>()
+            .ActivateOnEnter<PomBom>()
+            .ActivateOnEnter<ThousandKuponzeCharge>()
+            .ActivateOnEnter<Mogshield>();
+    }
+}
+
+[ModuleInfo(BossModuleInfo.Maturity.Contributed, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 171, NameID = 4943, Contributors = "xan")]
+public class ChieftainMoglin(WorldState ws, Actor primary) : BossModule(ws, primary, new(-400, -158), new ArenaBoundsCircle(20))
+{
+    protected override void CalculateModuleAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
+    {
+        foreach (var h in hints.PotentialTargets)
+            h.Priority = h.Actor.FindStatus(SID.Invincibility) == null ? 1 : 0;
+    }
+}
+

--- a/BossMod/Modules/Heavensward/Dungeon/D13SohrKhai/D132Poqhiraj.cs
+++ b/BossMod/Modules/Heavensward/Dungeon/D13SohrKhai/D132Poqhiraj.cs
@@ -1,0 +1,116 @@
+﻿namespace BossMod.Heavensward.Dungeon.D13SohrKhai.D132Poqhiraj;
+
+public enum OID : uint
+{
+    Boss = 0x155C, // R2.500, x?
+    PrayerWall = 0x155E, // R5.000, x?
+    Poqhiraj = 0x1B2, // R0.500, x?
+    DarkCloud = 0x155D, // R1.000, x?
+}
+
+public enum AID : uint
+{
+    RearHoof = 6013, // 155C->player, no cast, single-target
+    BurningBright = 6011, // 155C->self/players, 3.0s cast, range 26+R width 6 rect
+    TouchdownVisual = 6240, // 1B2->self, 3.0s cast, range 40+R circle
+    Touchdown = 6012, // 155C->self, no cast, range 40+R circle
+    GallopVisual = 5777, // 155C->location, 4.5s cast, width 10 rect charge
+    GallopLine = 5778, // 1B2->self, 4.9s cast, range 40+R width 2 rect
+    GallopKnockback = 5823, // 1B2->self, 4.9s cast, range 4+R width 40 rect
+    CloudCall = 6009, // 155C->self, 4.0s cast, single-target
+    LightningBolt = 6010, // 155D->self, 3.0s cast, range 8 circle
+}
+
+public enum IconID : uint
+{
+    CloudCall = 24, // player
+}
+
+class Touchdown(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.TouchdownVisual), new AOEShapeCircle(20));
+class GallopLine(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.GallopLine), new AOEShapeRect(40, 1));
+class GallopKnockback(BossModule module) : Components.KnockbackFromCastTarget(module, ActionID.MakeSpell(AID.GallopKnockback), 10, shape: new AOEShapeRect(6.5f, 20), kind: Kind.DirForward, stopAtWall: true)
+{
+    public override bool DestinationUnsafe(int slot, Actor actor, WPos pos) => pos.X is > 405 or < 395;
+
+    public override void AddAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
+    {
+        base.AddAIHints(slot, actor, assignment, hints);
+
+        if (Casters.Count == 0)
+            return;
+
+        List<WPos> leftBlockers = [];
+        List<WPos> rightBlockers = [];
+
+        foreach (var wall in Module.Enemies(OID.PrayerWall).Where(x => !x.IsDeadOrDestroyed))
+        {
+            if (wall.Position.X > 400)
+                rightBlockers.Add(wall.Position);
+            else
+                leftBlockers.Add(wall.Position);
+        }
+
+        if (rightBlockers.Count + leftBlockers.Count == 0)
+            return;
+
+        hints.AddForbiddenZone(p =>
+        {
+            var blockers = p.X > 400 ? rightBlockers : leftBlockers;
+            return blockers.Any(b => Utils.AlmostEqual(p.Z, b.Z, 5.1f)) ? 0 : -1;
+        }, Module.CastFinishAt(Casters[0].CastInfo));
+    }
+}
+class BurningBright(BossModule module) : Components.BaitAwayCast(module, ActionID.MakeSpell(AID.BurningBright), new AOEShapeRect(26, 3), endsOnCastEvent: false);
+class CloudCall(BossModule module) : Components.BaitAwayIcon(module, new AOEShapeCircle(8), (uint)IconID.CloudCall, ActionID.MakeSpell(AID.CloudCall), 4.1f, true);
+class LightningBolt(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.LightningBolt), new AOEShapeCircle(8));
+
+class Walls(BossModule module) : BossComponent(module)
+{
+    public ArenaBoundsCustom BuildBounds()
+    {
+        RelSimplifiedComplexPolygon def = new(CurveApprox.Rect(new(8.4f, 0), new(0, 20)));
+        foreach (var wall in Module.Enemies(OID.PrayerWall).Where(x => !x.IsDeadOrDestroyed))
+        {
+            var blocked = CurveApprox.Rect(wall.Position, wall.Rotation.ToDirection() * 6.5f, new(0, 5.1f));
+            def = Arena.Bounds.Clipper.Difference(new(def), new(blocked.Select(p => p - Arena.Center)));
+        }
+        return new(20, def);
+    }
+
+    public override void OnActorDestroyed(Actor actor)
+    {
+        if ((OID)actor.OID == OID.PrayerWall)
+            Arena.Bounds = BuildBounds();
+    }
+
+    public override void DrawArenaBackground(int pcSlot, Actor pc)
+    {
+        Arena.ZoneRect(Arena.Center + new WDir(5, 0), Arena.Center + new WDir(8.5f, 0), 20, ArenaColor.AOE);
+        Arena.ZoneRect(Arena.Center - new WDir(5, 0), Arena.Center - new WDir(8.5f, 0), 20, ArenaColor.AOE);
+    }
+
+    public override void AddHints(int slot, Actor actor, TextHints hints)
+    {
+        if (actor.Position.X is > 405 or < 395)
+            hints.Add("GTFO from lightning!");
+    }
+}
+
+class PoqhirajStates : StateMachineBuilder
+{
+    public PoqhirajStates(BossModule module) : base(module)
+    {
+        TrivialPhase()
+            .ActivateOnEnter<GallopLine>()
+            .ActivateOnEnter<BurningBright>()
+            .ActivateOnEnter<CloudCall>()
+            .ActivateOnEnter<Walls>()
+            .ActivateOnEnter<GallopKnockback>()
+            .ActivateOnEnter<Touchdown>()
+            .ActivateOnEnter<LightningBolt>();
+    }
+}
+
+[ModuleInfo(BossModuleInfo.Maturity.Contributed, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 171, NameID = 4952, Contributors = "xan")]
+public class Poqhiraj(WorldState ws, Actor primary) : BossModule(ws, primary, new(400, 104.15f), new ArenaBoundsRect(4.5f, 20));
+

--- a/BossMod/Modules/Heavensward/Dungeon/D13SohrKhai/D133Hraesvelgr.cs
+++ b/BossMod/Modules/Heavensward/Dungeon/D13SohrKhai/D133Hraesvelgr.cs
@@ -1,0 +1,122 @@
+﻿namespace BossMod.Heavensward.Dungeon.D13SohrKhai.D133Hraesvelgr;
+
+public enum OID : uint
+{
+    Boss = 0x3D17,
+    Helper = 0x233C,
+}
+
+public enum AID : uint
+{
+    Wyrmclaw = 32141, // Boss->player, 5.0s cast, single-target
+    HallowedWingsLeft = 32136, // Boss->self, 6.0s cast, range 50 width 22 rect, regular aoe (with offset)
+    HallowedWingsRight = 32137, // Boss->self, 6.0s cast, range 50 width 22 rect, regular aoe (with offset)
+    HolyStorm = 32127, // Boss->self, 5.0s cast, range 40 circle, raidwide
+    HallowedDive = 32131, // Boss->self, 6.0s cast, range 40 width 20 rect, regular aoe
+    HolyOrb = 32129, // Helper->self, 5.0s cast, range 6 circle, exaflares
+    HolyOrbRepeat = 32130, // Helper->self, no cast, range 6 circle
+    AkhMorn = 32132, // Boss->players, 5.0s cast, range 6 circle, stack 1
+    AkhMornRepeat = 32133, // Boss->players, no cast, range 6 circle, stack 2
+    HolyBreathVisual = 32138, // Boss->self, 5.0+1.0s cast, single-target
+    HolyBreath = 32139, // Helper->player, 6.0s cast, range 6 circle, spread
+    DiamondStorm = 32128, // Boss->self, 5.0s cast, range 40 circle, raidwide + ice
+    FrigidDive = 32134, // Boss->self, 6.0s cast, range 40 width 20 rect, regular aoe
+    FrostedOrb = 32135, // Helper->self, 5.0s cast, range 6 circle, regular aoe
+}
+
+class HolyStorm(BossModule module) : Components.RaidwideCast(module, ActionID.MakeSpell(AID.HolyStorm));
+class DiamondStorm(BossModule module) : Components.RaidwideCast(module, ActionID.MakeSpell(AID.DiamondStorm));
+class FrigidDive(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.FrigidDive), new AOEShapeRect(40, 10));
+class HallowedDive(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.HallowedDive), new AOEShapeRect(40, 10));
+class Wyrmclaw(BossModule module) : Components.SingleTargetCast(module, ActionID.MakeSpell(AID.Wyrmclaw));
+class FrostedOrb(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.FrostedOrb), new AOEShapeCircle(6));
+class HolyBreath(BossModule module) : Components.SpreadFromIcon(module, 311, ActionID.MakeSpell(AID.HolyBreath), 6, 6);
+class HallowedWings(BossModule module) : Components.GenericAOEs(module)
+{
+    private readonly List<Actor> Casters = [];
+
+    public override IEnumerable<AOEInstance> ActiveAOEs(int slot, Actor actor) => Casters.Select(c => new AOEInstance(new AOEShapeRect(50, 11), c.CastInfo!.LocXZ, c.CastInfo!.Rotation, Module.CastFinishAt(c.CastInfo)));
+
+    public override void OnCastStarted(Actor caster, ActorCastInfo spell)
+    {
+        if ((AID)spell.Action.ID is AID.HallowedWingsLeft or AID.HallowedWingsRight)
+            Casters.Add(caster);
+    }
+
+    public override void OnCastFinished(Actor caster, ActorCastInfo spell)
+    {
+        if ((AID)spell.Action.ID is AID.HallowedWingsLeft or AID.HallowedWingsRight)
+            Casters.Remove(caster);
+    }
+}
+class AkhMorn(BossModule module) : Components.UniformStackSpread(module, 6, 0)
+{
+    private int Counter;
+    public override void OnCastStarted(Actor caster, ActorCastInfo spell)
+    {
+        if ((AID)spell.Action.ID == AID.AkhMorn)
+            AddStack(WorldState.Actors.Find(spell.TargetID)!, Module.CastFinishAt(spell));
+    }
+
+    public override void OnEventCast(Actor caster, ActorCastEvent spell)
+    {
+        if ((AID)spell.Action.ID is AID.AkhMorn or AID.AkhMornRepeat)
+            if (++Counter >= 6)
+                Stacks.Clear();
+    }
+}
+class HolyOrb(BossModule module) : Components.Exaflare(module, new AOEShapeCircle(6))
+{
+    public override void OnCastStarted(Actor caster, ActorCastInfo spell)
+    {
+        if ((AID)spell.Action.ID == AID.HolyOrb)
+            Lines.Add(new Line()
+            {
+                Next = caster.Position,
+                Advance = caster.Rotation.ToDirection() * 6.8f,
+                NextExplosion = Module.CastFinishAt(spell),
+                TimeToMove = 0.95f,
+                ExplosionsLeft = 5,
+                MaxShownExplosions = 3
+            });
+    }
+
+    public override void OnEventCast(Actor caster, ActorCastEvent spell)
+    {
+        if ((AID)spell.Action.ID is AID.HolyOrb or AID.HolyOrbRepeat)
+        {
+            int index = Lines.FindIndex(item => item.Next.AlmostEqual(caster.Position, 1));
+            if (index == -1)
+            {
+                ReportError($"Failed to find entry for {caster.InstanceID:X}");
+                return;
+            }
+
+            AdvanceLine(Lines[index], caster.Position);
+            if (Lines[index].ExplosionsLeft == 0)
+                Lines.RemoveAt(index);
+        }
+    }
+}
+
+class HraesvelgrStates : StateMachineBuilder
+{
+    public HraesvelgrStates(BossModule module) : base(module)
+    {
+        TrivialPhase()
+            .ActivateOnEnter<Wyrmclaw>()
+            .ActivateOnEnter<HallowedWings>()
+            .ActivateOnEnter<FrigidDive>()
+            .ActivateOnEnter<HallowedDive>()
+            .ActivateOnEnter<HolyStorm>()
+            .ActivateOnEnter<DiamondStorm>()
+            .ActivateOnEnter<AkhMorn>()
+            .ActivateOnEnter<FrostedOrb>()
+            .ActivateOnEnter<HolyBreath>()
+            .ActivateOnEnter<HolyOrb>();
+    }
+}
+
+[ModuleInfo(BossModuleInfo.Maturity.Contributed, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 171, NameID = 4954, Contributors = "xan")]
+public class Hraesvelgr(WorldState ws, Actor primary) : BossModule(ws, primary, new(400, -400), new ArenaBoundsCircle(20));
+

--- a/BossMod/Modules/Heavensward/Dungeon/D15Xelphatol/D151NuzalHueloc.cs
+++ b/BossMod/Modules/Heavensward/Dungeon/D15Xelphatol/D151NuzalHueloc.cs
@@ -1,0 +1,99 @@
+﻿namespace BossMod.Heavensward.Dungeon.D15Xelphatol.D151NuzalHueloc;
+
+public enum OID : uint
+{
+    Boss = 0x179B, // R1.500, x1
+    FallenRock = 0xD25, // R0.500, x1
+    IxaliStitcher = 0x179C, // R1.080, x0 (spawn during fight)
+    FloatingTurret = 0x179E, // R1.000, x0 (spawn during fight)
+    Airstone = 0x179D, // R1.500, x0 (spawn during fight)
+}
+
+public enum AID : uint
+{
+    ShortBurst = 6598, // Boss->player, no cast, single-target
+    WindBlast = 6599, // Boss->self, 3.0s cast, range 60+R width 8 rect
+    Lift = 6601, // Boss->self, 3.0s cast, single-target
+    AirRaid = 6602, // Boss->location, no cast, range 50 circle
+    HotBlast = 6604, // 179E->self, 6.0s cast, range 25 circle
+    LongBurst = 6600, // Boss->player, 3.0s cast, single-target
+    ShortBurstAdds = 6603, // 179E->player, 3.0s cast, single-target
+}
+
+public enum SID : uint
+{
+    Hover = 412, // Boss->Boss, extra=0x0
+    Invincibility = 775, // none->Boss/FloatingTurret, extra=0x0
+    DamageUp = 443, // none->Boss, extra=0x1/0x2
+    Windburn = 269, // Boss/FloatingTurret->player, extra=0x0
+}
+
+class WindBlast(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.WindBlast), new AOEShapeRect(60, 4));
+class HotBlast(BossModule module) : Components.CastCounter(module, ActionID.MakeSpell(AID.HotBlast))
+{
+    private readonly List<Actor> Casters = [];
+
+    public override void OnCastStarted(Actor caster, ActorCastInfo spell)
+    {
+        if (spell.Action == WatchedAction)
+            Casters.Add(caster);
+    }
+
+    public override void OnCastFinished(Actor caster, ActorCastInfo spell)
+    {
+        if (spell.Action == WatchedAction)
+            Casters.Remove(caster);
+    }
+
+    public override void DrawArenaBackground(int pcSlot, Actor pc)
+    {
+        if (Casters.Count == 0)
+            return;
+
+        Arena.ZoneCircle(Module.PrimaryActor.Position, 4, ArenaColor.SafeFromAOE);
+    }
+
+    public override void AddHints(int slot, Actor actor, TextHints hints)
+    {
+        if (Casters.Count == 0)
+            return;
+
+        hints.Add("Stand under boss!", !actor.Position.InCircle(Module.PrimaryActor.Position, 4));
+    }
+
+    public override void AddAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
+    {
+        if (Casters.Count == 0)
+            return;
+
+        hints.AddForbiddenZone(new AOEShapeDonut(4, 40), Module.PrimaryActor.Position, activation: Module.CastFinishAt(Casters[0].CastInfo));
+        hints.PredictedDamage.Add((Raid.WithSlot().Mask(), Module.CastFinishAt(Casters[0].CastInfo)));
+    }
+}
+
+class NuzalHuelocStates : StateMachineBuilder
+{
+    public NuzalHuelocStates(BossModule module) : base(module)
+    {
+        TrivialPhase()
+            .ActivateOnEnter<WindBlast>()
+            .ActivateOnEnter<HotBlast>();
+    }
+}
+
+[ModuleInfo(BossModuleInfo.Maturity.Contributed, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 182, NameID = 5265, Contributors = "xan")]
+public class NuzalHueloc(WorldState ws, Actor primary) : BossModule(ws, primary, new(-74.5f, -70.25f), new ArenaBoundsCircle(20))
+{
+    protected override void CalculateModuleAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
+    {
+        foreach (var h in hints.PotentialTargets)
+            h.Priority = h.Actor.FindStatus(SID.Invincibility) == null ? 1 : 0;
+    }
+
+    protected override void DrawEnemies(int pcSlot, Actor pc)
+    {
+        foreach (var actor in WorldState.Actors.Where(x => !x.IsAlly))
+            Arena.Actor(actor, (OID)actor.OID == OID.FloatingTurret && actor.HPMP.CurHP == 1 ? ArenaColor.PlayerGeneric : ArenaColor.Enemy);
+    }
+}
+

--- a/BossMod/Modules/Heavensward/Dungeon/D15Xelphatol/D152DotoliCiloc.cs
+++ b/BossMod/Modules/Heavensward/Dungeon/D15Xelphatol/D152DotoliCiloc.cs
@@ -1,0 +1,130 @@
+﻿namespace BossMod.Heavensward.Dungeon.D15Xelphatol.D151DotoliCiloc;
+
+public enum OID : uint
+{
+    Boss = 0x179F, // R1.980, x?
+    Whirlwind = 0x17A0, // R1.000, x?
+}
+
+public enum AID : uint
+{
+    OnLow = 6606, // Boss->self, 4.0s cast, range 9+R 120-degree cone
+    OnHigh = 6607, // Boss->self, 3.0s cast, range 50+R circle
+    DarkWings = 32556, // Boss->player, no cast, range 6 circle
+    Swiftfeather = 6609, // Boss->self, 3.0s cast, single-target
+    Stormcoming = 32557, // Boss->location, 4.0s cast, range 6 circle
+    TerribleFlurry = 6610, // _Gen_Whirlwind->self, no cast, range 6 circle
+}
+
+class Stormcoming(BossModule module) : Components.PersistentVoidzoneAtCastTarget(module, 6, ActionID.MakeSpell(AID.Stormcoming), m => m.Enemies(OID.Whirlwind).Where(w => w.EventState != 7), 0);
+class Swiftfeather(BossModule module) : Components.GenericBaitAway(module, ActionID.MakeSpell(AID.Swiftfeather))
+{
+    // 2.3f delay
+    public override void OnCastStarted(Actor caster, ActorCastInfo spell)
+    {
+        if (spell.Action == WatchedAction)
+            CurrentBaits.Add(new(caster, WorldState.Actors.Find(caster.TargetID)!, new AOEShapeCone(11, 60.Degrees()), Module.CastFinishAt(spell, 2.3f)));
+
+        if ((AID)spell.Action.ID == AID.OnLow)
+            CurrentBaits.Clear();
+    }
+}
+class OnLow(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.OnLow), new AOEShapeCone(11, 60.Degrees()));
+class OnHigh(BossModule module) : Components.Knockback(module, ActionID.MakeSpell(AID.OnHigh))
+{
+    private readonly List<Actor> Casters = [];
+    private static readonly Angle[] Walls = [default, 90.Degrees(), 180.Degrees(), 270.Degrees()];
+    private BitMask BlockedWalls;
+    private IEnumerable<Angle> UnblockedWalls => Walls.Where((_, i) => !BlockedWalls[i]);
+    private const float WallHalfAngle = MathF.PI / 16;
+
+    public override IEnumerable<Source> Sources(int slot, Actor actor) => Casters.Select(c => new Source(c.Position, CheckWall(actor.Position) ? 19 - (c.Position - actor.Position).Length() : 30, Module.CastFinishAt(c.CastInfo)));
+
+    public override void OnCastStarted(Actor caster, ActorCastInfo spell)
+    {
+        if (spell.Action == WatchedAction)
+            Casters.Add(caster);
+    }
+
+    public override void OnCastFinished(Actor caster, ActorCastInfo spell)
+    {
+        if (spell.Action == WatchedAction)
+            Casters.Remove(caster);
+    }
+
+    public override void OnActorCreated(Actor actor)
+    {
+        if ((OID)actor.OID == OID.Whirlwind)
+        {
+            for (var i = 0; i < Walls.Length; i++)
+            {
+                if (Module.PrimaryActor.AngleTo(actor).AlmostEqual(Walls[i], WallHalfAngle))
+                {
+                    BlockedWalls.Set(i);
+                    break;
+                }
+            }
+        }
+    }
+
+    public override void OnActorDestroyed(Actor actor)
+    {
+        if ((OID)actor.OID == OID.Whirlwind)
+            BlockedWalls.Reset();
+    }
+
+    public override bool DestinationUnsafe(int slot, Actor actor, WPos pos) => base.DestinationUnsafe(slot, actor, pos) || !UnblockedWalls.Any(w => Module.PrimaryActor.AngleTo(actor).AlmostEqual(w, WallHalfAngle));
+
+    public override void AddAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
+    {
+        if (Casters.Count == 0)
+            return;
+
+        var zones = UnblockedWalls.Select(w => ShapeDistance.InvertedCone(Arena.Center, 30, w, WallHalfAngle.Radians())).ToList();
+        hints.AddForbiddenZone(ShapeDistance.Intersection(zones), Module.CastFinishAt(Casters[0].CastInfo));
+    }
+
+    private bool CheckWall(WPos pos) => Walls.Any(w => Angle.FromDirection(pos - Arena.Center).AlmostEqual(w, WallHalfAngle));
+}
+class Walls(BossModule module) : Components.GenericAOEs(module)
+{
+    public override IEnumerable<AOEInstance> ActiveAOEs(int slot, Actor actor) => [new AOEInstance(new AOEShapeDonut(20, 30), Arena.Center)];
+
+    public override void DrawArenaForeground(int pcSlot, Actor pc)
+    {
+        base.DrawArenaForeground(pcSlot, pc);
+
+        DrawWall(default);
+        DrawWall(90.Degrees());
+        DrawWall(180.Degrees());
+        DrawWall(270.Degrees());
+    }
+
+    private void DrawWall(Angle angle)
+    {
+        var delta = MathF.PI / 16;
+        Arena.PathArcTo(Arena.Center, 20, angle.Rad + delta, angle.Rad - delta);
+        Arena.PathStroke(false, ArenaColor.Border);
+    }
+}
+
+class DotoliCilocStates : StateMachineBuilder
+{
+    public DotoliCilocStates(BossModule module) : base(module)
+    {
+        TrivialPhase()
+            .ActivateOnEnter<OnLow>()
+            .ActivateOnEnter<OnHigh>()
+            .ActivateOnEnter<Walls>()
+            .ActivateOnEnter<Swiftfeather>()
+            .ActivateOnEnter<Stormcoming>();
+    }
+}
+
+[ModuleInfo(BossModuleInfo.Maturity.Contributed, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 182, NameID = 5269, Contributors = "xan")]
+public class DotoliCiloc(WorldState ws, Actor primary) : BossModule(ws, primary, DefaultCenter, new ArenaBoundsCircle(25))
+{
+    // position of boss casting On High (knockback from arena center)
+    public static readonly WPos DefaultCenter = new(245.289f, 13.626f);
+}
+

--- a/BossMod/Modules/Heavensward/Dungeon/D15Xelphatol/D153TozolHuatotl.cs
+++ b/BossMod/Modules/Heavensward/Dungeon/D15Xelphatol/D153TozolHuatotl.cs
@@ -1,0 +1,64 @@
+﻿namespace BossMod.Heavensward.Dungeon.D15Xelphatol.D153TozolHuatotl;
+
+public enum OID : uint
+{
+    Garuda = 0x17A4, // R2.890, x1
+    AbalathianHornbill1 = 0x17A3, // R1.080, x4
+    AbalathianHornbill2 = 0xD25, // R0.500, x2
+    Boss = 0x17A2, // R3.000, x1
+}
+
+public enum AID : uint
+{
+    IxaliAero = 6611, // Boss->player, no cast, single-target
+    IxaliAeroII = 6612, // Boss->self, 3.0s cast, range 40+R width 6 rect
+    IxaliAeroIII = 6613, // Boss->self, 3.0s cast, range 50+R circle
+    Hawk = 6614, // Boss->self, 5.0s cast, single-target
+    Bill = 6618, // _Gen_AbalathianHornbill->player, 5.0s cast, range 5 circle
+    IngurgitateCast = 6616, // _Gen_AbalathianHornbill->player, 5.0s cast, single-target
+    IngurgitateDamage = 6617, // _Gen_AbalathianHornbill1->self, no cast, range 5 circle
+    SummonGaruda = 6615, // Boss->location, 4.0s cast, single-target
+    EyeOfTheStorm = 6619, // _Gen_AbalathianHornbill1->self, 6.0s cast, range 20 circle
+    MistralSong = 6620, // _Gen_Garuda->self, 5.0s cast, range 30+R 120-degree cone
+    WickedWheel = 6621, // _Gen_Garuda->self, 6.0s cast, range 7 circle
+    AerialBlast = 6622, // _Gen_Garuda->self, 4.0s cast, range 50+R circle
+}
+
+public enum IconID : uint
+{
+    Bill = 70, // player
+    Ingurgitate = 62, // player
+}
+
+class IxaliAeroII(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.IxaliAeroII), new AOEShapeRect(40, 3));
+class IxaliAeroIII(BossModule module) : Components.RaidwideCast(module, ActionID.MakeSpell(AID.IxaliAeroIII));
+class MistralSong(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.MistralSong), new AOEShapeCone(30, 60.Degrees()));
+class WickedWheel(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.WickedWheel), new AOEShapeCircle(7));
+class AerialBlast(BossModule module) : Components.RaidwideCast(module, ActionID.MakeSpell(AID.AerialBlast));
+class EyeOfTheStorm(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.EyeOfTheStorm), new AOEShapeDonut(10, 20));
+class Bill(BossModule module) : Components.SpreadFromCastTargets(module, ActionID.MakeSpell(AID.Bill), 5);
+class Ingurgitate(BossModule module) : Components.StackWithIcon(module, (uint)IconID.Ingurgitate, ActionID.MakeSpell(AID.IngurgitateCast), 5, 5.4f);
+
+class TozolHuatotlStates : StateMachineBuilder
+{
+    public TozolHuatotlStates(BossModule module) : base(module)
+    {
+        TrivialPhase()
+            .ActivateOnEnter<EyeOfTheStorm>()
+            .ActivateOnEnter<MistralSong>()
+            .ActivateOnEnter<WickedWheel>()
+            .ActivateOnEnter<AerialBlast>()
+            .ActivateOnEnter<Bill>()
+            .ActivateOnEnter<IxaliAeroIII>()
+            .ActivateOnEnter<IxaliAeroII>()
+            .ActivateOnEnter<Ingurgitate>();
+    }
+}
+
+[ModuleInfo(BossModuleInfo.Maturity.Contributed, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 182, NameID = 5272, Contributors = "xan")]
+public class TozolHuatotl(WorldState ws, Actor primary) : BossModule(ws, primary, DefaultCenter, new ArenaBoundsCircle(20))
+{
+    // position of Garuda casting Eye of the Storm
+    public static readonly WPos DefaultCenter = new(317.948f, -416.172f);
+}
+


### PR DESCRIPTION
notable framework changes:

1. i made the eye drawing logic a public static method of GenericGaze. this is because Calcabrina (Antitower B3) has a gaze attack with an associated shape, namely a cone. i figured it would be less risky to roll my own "conditional" gaze component than it would be to refactor the existing gaze component to support a shape, but i'm open to making that change instead if you think it would be better
2. added AffectedPlayers property to LOS component, so i could use it for Antitower B2's tether mechanic where one player needs to hide behind a meteor.

also we should consider using castinfo location instead of caster location for self targeted AOEs. encounters where I noticed castinfo location differing drastically from caster location are Sohr Khai B3, Hashmal (from the ivalice questline and one of the zadnor CEs), double dragons in DSR, and Lunar Odin in Death Unto Dawn