### PR TITLE
Operations for system log and treasure open

### DIFF
--- a/BossMod/Data/ActorState.cs
+++ b/BossMod/Data/ActorState.cs
@@ -409,4 +409,14 @@ public sealed class ActorState : IEnumerable<Actor>
         protected override void ExecActor(WorldState ws, Actor actor) => ws.Actors.EventNpcYell.Fire(actor, Message);
         public override void Write(ReplayRecorder.Output output) => output.EmitFourCC("NYEL"u8).EmitActor(InstanceID).Emit(Message);
     }
+
+    public Event<Actor> EventOpenTreasure = new();
+    public sealed record class OpEventOpenTreasure(ulong InstanceID) : Operation(InstanceID)
+    {
+        protected override void ExecActor(WorldState ws, Actor actor) => ws.Actors.EventOpenTreasure.Fire(actor);
+        public override void Write(ReplayRecorder.Output output)
+        {
+            output.EmitFourCC("OPNT"u8).EmitActor(InstanceID);
+        }
+    }
 }

--- a/BossMod/Data/WorldState.cs
+++ b/BossMod/Data/WorldState.cs
@@ -143,4 +143,17 @@ public sealed class WorldState
         protected override void Exec(WorldState ws) => ws.EnvControl.Fire(this);
         public override void Write(ReplayRecorder.Output output) => output.EmitFourCC("ENVC"u8).Emit(Index, "X2").Emit(State, "X8");
     }
+
+    public Event<OpSystemLogMessage> SystemLogMessage = new();
+    public sealed record class OpSystemLogMessage(uint MessageId, int[] Args) : Operation
+    {
+        protected override void Exec(WorldState ws) => ws.SystemLogMessage.Fire(this);
+        public override void Write(ReplayRecorder.Output output)
+        {
+            output.EmitFourCC("SLOG"u8).Emit(MessageId);
+            output.Emit(Args.Length);
+            foreach (var arg in Args)
+                output.Emit(arg);
+        }
+    }
 }

--- a/BossMod/Data/WorldState.cs
+++ b/BossMod/Data/WorldState.cs
@@ -147,6 +147,8 @@ public sealed class WorldState
     public Event<OpSystemLogMessage> SystemLogMessage = new();
     public sealed record class OpSystemLogMessage(uint MessageId, int[] Args) : Operation
     {
+        public readonly int[] Args = Args;
+
         protected override void Exec(WorldState ws) => ws.SystemLogMessage.Fire(this);
         public override void Write(ReplayRecorder.Output output)
         {

--- a/BossMod/Replay/ReplayParserLog.cs
+++ b/BossMod/Replay/ReplayParserLog.cs
@@ -282,6 +282,7 @@ public sealed class ReplayParserLog : IDisposable
             [new("ZONE"u8)] = ParseZoneChange,
             [new("DIRU"u8)] = ParseDirectorUpdate,
             [new("ENVC"u8)] = ParseEnvControl,
+            [new("SLOG"u8)] = ParseSystemLog,
             [new("WAY+"u8)] = () => ParseWaymarkChange(true),
             [new("WAY-"u8)] = () => ParseWaymarkChange(false),
             [new("ACT+"u8)] = ParseActorCreate,
@@ -318,6 +319,7 @@ public sealed class ReplayParserLog : IDisposable
             [new("EANM"u8)] = ParseActorEventObjectAnimation,
             [new("PATE"u8)] = ParseActorPlayActionTimelineEvent,
             [new("NYEL"u8)] = ParseActorEventNpcYell,
+            [new("OPNT"u8)] = ParseActorEventOpenTreasure,
             [new("PAR "u8)] = ParsePartyModify,
             [new("PAR+"u8)] = ParsePartyModify, // legacy (up to v3)
             [new("PAR-"u8)] = ParsePartyLeave, // legacy (up to v3)
@@ -427,6 +429,15 @@ public sealed class ReplayParserLog : IDisposable
         if (_version < 11)
             _input.ReadUInt(true);
         return new(_input.ReadByte(true), _input.ReadUInt(true));
+    }
+    private WorldState.OpSystemLogMessage ParseSystemLog()
+    {
+        var id = _input.ReadUInt(false);
+        var argCount = _input.ReadInt();
+        var args = new int[argCount];
+        for (var i = 0; i < argCount; i++)
+            args[i] = _input.ReadInt();
+        return new(id, args);
     }
 
     private WaymarkState.OpWaymarkChange ParseWaymarkChange(bool set)
@@ -587,6 +598,7 @@ public sealed class ReplayParserLog : IDisposable
     private ActorState.OpEventObjectAnimation ParseActorEventObjectAnimation() => new(_input.ReadActorID(), _input.ReadUShort(true), _input.ReadUShort(true));
     private ActorState.OpPlayActionTimelineEvent ParseActorPlayActionTimelineEvent() => new(_input.ReadActorID(), _input.ReadUShort(true));
     private ActorState.OpEventNpcYell ParseActorEventNpcYell() => new(_input.ReadActorID(), _input.ReadUShort(false));
+    private ActorState.OpEventOpenTreasure ParseActorEventOpenTreasure() => new(_input.ReadActorID());
     private PartyState.OpModify ParsePartyModify() => new(_input.ReadInt(), new(_input.ReadULong(true), _input.ReadULong(true), _version >= 15 && _input.ReadBool(), _version < 15 ? "" : _input.ReadString()));
     private PartyState.OpModify ParsePartyLeave() => new(_input.ReadInt(), new(0, 0, false, ""));
     private PartyState.OpLimitBreakChange ParsePartyLimitBreak() => new(_input.ReadInt(), _input.ReadInt());


### PR DESCRIPTION
useful for PotD:

- system log is the only way to determine the contents of a gold treasure coffer if your pomanders are already capped (the log tells you which pomander is in it)
- packet for "a treasure chest was opened" is needed to stop AI from getting stuck interacting with a brown chest that has already been opened - unlike gold chests, brown chests don't go untargetable when they open (this also applies to regular treasure chests e.g. the ones in any dungeon)