### PR TITLE
extend prio system

### DIFF
--- a/BossMod/ActionTweaks/AutoAutosTweak.cs
+++ b/BossMod/ActionTweaks/AutoAutosTweak.cs
@@ -33,6 +33,9 @@ public sealed class AutoAutosTweak(WorldState ws, AIHints hints)
         if (_config.PyreticThreshold > 0 && hints.ImminentSpecialMode.mode == AIHints.SpecialMode.Pyretic && hints.ImminentSpecialMode.activation < ws.FutureTime(_config.PyreticThreshold))
             return false; // pyretic => disable autos
 
+        if (hints.FindEnemy(target)?.Priority == AIHints.Enemy.PriorityForbidden)
+            return false;
+
         return player.InCombat || ws.Client.CountdownRemaining <= PrePullThreshold; // no reason not to enable autos!
     }
 }

--- a/BossMod/Autorotation/Legacy/LegacyModule.cs
+++ b/BossMod/Autorotation/Legacy/LegacyModule.cs
@@ -9,7 +9,7 @@ public abstract class LegacyModule(RotationModuleManager manager, Actor player) 
             return;
         if (data.Range == 0)
             target = Player; // override range-0 actions to always target player
-        if (target == null || Hints.ForbiddenTargets.FirstOrDefault(e => e.Actor == target)?.Priority == AIHints.Enemy.PriorityForbidFully)
+        if (target == null || Hints.ForbiddenTargets.FirstOrDefault(e => e.Actor == target)?.Priority == AIHints.Enemy.PriorityForbidden)
             return; // forbidden
         Hints.ActionsToExecute.Push(action, target, (data.IsGCD ? ActionQueue.Priority.High : ActionQueue.Priority.Low) + 500);
     }

--- a/BossMod/Framework/ActionManagerEx.cs
+++ b/BossMod/Framework/ActionManagerEx.cs
@@ -122,8 +122,15 @@ public sealed unsafe class ActionManagerEx : IDisposable
         AutoQueue = _hints.ActionsToExecute.FindBest(_ws, player, _ws.Client.Cooldowns, EffectiveAnimationLock, _hints, _animLockTweak.DelayEstimate);
         if (AutoQueue.Delay > 0)
             AutoQueue = default;
-        if (Config.PyreticThreshold > 0 && _hints.ImminentSpecialMode.mode == AIHints.SpecialMode.Pyretic && _hints.ImminentSpecialMode.activation < _ws.FutureTime(Config.PyreticThreshold) && AutoQueue.Priority < ActionQueue.Priority.ManualEmergency)
-            AutoQueue = default; // do not execute non-emergency actions when pyretic is imminent
+
+        if (AutoQueue.Priority < ActionQueue.Priority.ManualEmergency)
+        {
+            if (Config.PyreticThreshold > 0 && _hints.ImminentSpecialMode.mode == AIHints.SpecialMode.Pyretic && _hints.ImminentSpecialMode.activation < _ws.FutureTime(Config.PyreticThreshold))
+                AutoQueue = default; // do not execute non-emergency actions when pyretic is imminent
+
+            if (AutoQueue.Target is Actor t && _hints.FindEnemy(t)?.Priority == AIHints.Enemy.PriorityForbidden)
+                AutoQueue = default; // or if selected target is forbidden
+        }
     }
 
     public Vector3? GetWorldPosUnderCursor()

--- a/BossMod/Framework/Utils.cs
+++ b/BossMod/Framework/Utils.cs
@@ -41,6 +41,16 @@ public static partial class Utils
     public static string CastTimeString(ActorCastInfo cast, DateTime now) => CastTimeString(cast.ElapsedTime, cast.TotalTime);
     public static string LogMessageString(uint id) => $"{id} '{Service.LuminaRow<Lumina.Excel.Sheets.LogMessage>(id)?.Text}'";
 
+    public static bool ActorIsDying(Actor actor, WorldState ws)
+    {
+        // striking dummy - HP resets to full when "killed"
+        if (actor.NameID == 541)
+            return false;
+
+        var predicted = ws.PendingEffects.PendingHPDifference(actor.InstanceID);
+        return actor.HPMP.CurHP + predicted <= 0;
+    }
+
     public static unsafe T ReadField<T>(void* address, int offset) where T : unmanaged => *(T*)((IntPtr)address + offset);
     public static unsafe void WriteField<T>(void* address, int offset, T value) where T : unmanaged => *(T*)((IntPtr)address + offset) = value;
 

--- a/BossMod/Modules/Dawntrail/Alliance/A13ArkAngels/DecisiveBattle.cs
+++ b/BossMod/Modules/Dawntrail/Alliance/A13ArkAngels/DecisiveBattle.cs
@@ -19,7 +19,7 @@ class DecisiveBattle(BossModule module) : BossComponent(module)
         if (slot < _assignedBoss.Length && _assignedBoss[slot] != null)
             foreach (var enemy in hints.PotentialTargets)
                 if (enemy.Actor != _assignedBoss[slot])
-                    enemy.Priority = AIHints.Enemy.PriorityForbidFully;
+                    enemy.Priority = AIHints.Enemy.PriorityInvincible;
     }
 
     public override void OnTethered(Actor source, ActorTetherInfo tether)

--- a/BossMod/Modules/Endwalker/Ultimate/TOP/P2LimitlessSynergy.cs
+++ b/BossMod/Modules/Endwalker/Ultimate/TOP/P2LimitlessSynergy.cs
@@ -88,9 +88,7 @@ class P2OptimizedPassageOfArms(BossModule module) : BossComponent(module)
         {
             var e = hints.PotentialTargets.FirstOrDefault(e => e.Actor == _invincible);
             if (e != null)
-            {
-                e.Priority = AIHints.Enemy.PriorityForbidFully;
-            }
+                e.Priority = AIHints.Enemy.PriorityInvincible;
         }
     }
 

--- a/BossMod/Modules/RealmReborn/Dungeon/D08Qarn/D083Adjudicator.cs
+++ b/BossMod/Modules/RealmReborn/Dungeon/D08Qarn/D083Adjudicator.cs
@@ -43,7 +43,7 @@ public class D083Adjudicator(WorldState ws, Actor primary) : BossModule(ws, prim
             e.Priority = (OID)e.Actor.OID switch
             {
                 OID.MythrilVerge => 3,
-                OID.SunJuror => WorldState.Actors.Where(other => (OID)other.OID is OID.Platform1 or OID.Platform2 or OID.Platform3).InRadius(e.Actor.Position, 1).Any() ? 2 : AIHints.Enemy.PriorityForbidAI,
+                OID.SunJuror => WorldState.Actors.Where(other => (OID)other.OID is OID.Platform1 or OID.Platform2 or OID.Platform3).InRadius(e.Actor.Position, 1).Any() ? 2 : AIHints.Enemy.PriorityPointless,
                 OID.Boss => 1,
                 _ => 0
             };

--- a/BossMod/Modules/RealmReborn/Extreme/Ex2Garuda/Ex2GarudaAI.cs
+++ b/BossMod/Modules/RealmReborn/Extreme/Ex2Garuda/Ex2GarudaAI.cs
@@ -48,7 +48,7 @@ class Ex2GarudaAI(BossModule module) : BossComponent(module)
                     e.ShouldBeTanked = false;
                     break;
                 case OID.SpinyPlume:
-                    e.Priority = Module.PrimaryActor.IsTargetable ? AIHints.Enemy.PriorityForbidAI : 6;
+                    e.Priority = Module.PrimaryActor.IsTargetable ? AIHints.Enemy.PriorityPointless : 6;
                     e.AttackStrength = 0;
                     e.ShouldBeTanked = false;
                     if (actor.Role == Role.Tank && e.Actor.TargetID != actor.InstanceID && (WorldState.Actors.Find(e.Actor.TargetID)?.FindStatus(SID.ThermalLow)?.Extra ?? 0) >= 2)

--- a/BossMod/Modules/RealmReborn/Extreme/Ex3Titan/Ex3Titan.cs
+++ b/BossMod/Modules/RealmReborn/Extreme/Ex3Titan/Ex3Titan.cs
@@ -21,18 +21,6 @@ public class Ex3Titan : BossModule
         Bombs = Enemies(OID.BombBoulder);
     }
 
-    protected override void CalculateModuleAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
-    {
-        var heart = Heart();
-        if (heart != null && heart.IsTargetable)
-        {
-            // heart is not added by default, since it has weird actor type
-            // boss is not really a valid target, but it still hits tank pretty hard, so we want to set attacker strength (?)
-            hints.PotentialTargets.Add(new(heart, false));
-            //hints.PotentialTargets.Add(new(PrimaryActor, false));
-        }
-    }
-
     protected override void DrawEnemies(int pcSlot, Actor pc)
     {
         Arena.Actor(PrimaryActor, ArenaColor.Enemy, true);

--- a/BossMod/Modules/RealmReborn/Raid/T01Caduceus/T01AI.cs
+++ b/BossMod/Modules/RealmReborn/Raid/T01Caduceus/T01AI.cs
@@ -87,7 +87,7 @@ class T01AI(BossModule module) : BossComponent(module)
                 {
                     e.Priority = 1; // this is a baseline; depending on whether we want to prioritize clone vs boss, clone's priority changes
                     if (cloneSpawningSoon && e.Actor.FindStatus(SID.SteelScales) != null)
-                        e.Priority = AIHints.Enemy.PriorityForbidAI; // stop dps until stack can be dropped
+                        e.Priority = AIHints.Enemy.PriorityPointless; // stop dps until stack can be dropped
                 }
                 else
                 {
@@ -114,7 +114,7 @@ class T01AI(BossModule module) : BossComponent(module)
                 // for now, let kiter damage it until 20%
                 var predictedHP = (int)e.Actor.HPMP.CurHP + WorldState.PendingEffects.PendingHPDifference(e.Actor.InstanceID);
                 //e.Priority = predictedHP > 0.7f * e.Actor.HPMP.MaxHP ? (actor.Role is Role.Ranged or Role.Melee ? 3 : AIHints.Enemy.PriorityForbidAI) : AIHints.Enemy.PriorityForbidAI;
-                e.Priority = predictedHP > 0.2f * e.Actor.HPMP.MaxHP ? (e.Actor.TargetID == actor.InstanceID ? 3 : AIHints.Enemy.PriorityForbidAI) : AIHints.Enemy.PriorityForbidAI;
+                e.Priority = predictedHP > 0.2f * e.Actor.HPMP.MaxHP ? (e.Actor.TargetID == actor.InstanceID ? 3 : AIHints.Enemy.PriorityPointless) : AIHints.Enemy.PriorityPointless;
                 e.ShouldBeTanked = false;
                 e.ForbidDOTs = true;
             }

--- a/BossMod/Modules/RealmReborn/Trial/T02TitanN/T02TitanN.cs
+++ b/BossMod/Modules/RealmReborn/Trial/T02TitanN/T02TitanN.cs
@@ -71,8 +71,6 @@ public class T02TitanN : BossModule
 
     protected override void CalculateModuleAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
     {
-        foreach (var heart in ActiveHeart)
-            hints.PotentialTargets.Add(new(heart, actor.Role == Role.Tank));
         foreach (var e in hints.PotentialTargets)
         {
             e.Priority = (OID)e.Actor.OID switch

--- a/BossMod/Modules/RealmReborn/Trial/T07TitanH/T07TitanH.cs
+++ b/BossMod/Modules/RealmReborn/Trial/T07TitanH/T07TitanH.cs
@@ -133,8 +133,6 @@ public class T07TitanH : BossModule
 
     protected override void CalculateModuleAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
     {
-        foreach (var heart in ActiveHeart)
-            hints.PotentialTargets.Add(new(heart, assignment == PartyRolesConfig.Assignment.MT));
         foreach (var enemy in hints.PotentialTargets)
         {
             enemy.Priority = (OID)enemy.Actor.OID switch

--- a/BossMod/QuestBattle/Shadowbringers/MSQ/LegendsOfTheNotSoHiddenTemple.cs
+++ b/BossMod/QuestBattle/Shadowbringers/MSQ/LegendsOfTheNotSoHiddenTemple.cs
@@ -114,6 +114,6 @@ public class LegendsOfTheNotSoHiddenTemple(WorldState ws) : QuestBattle(ws)
     {
         foreach (var h in hints.PotentialTargets)
             if (h.Actor.OID == 0x2955)
-                h.Priority = AIHints.Enemy.PriorityForbidFully;
+                h.Priority = AIHints.Enemy.PriorityForbidden;
     }
 }

--- a/BossMod/QuestBattle/Stormblood/MSQ/ItsProbablyATrap.cs
+++ b/BossMod/QuestBattle/Stormblood/MSQ/ItsProbablyATrap.cs
@@ -43,7 +43,7 @@ public class ItsProbablyATrap(WorldState ws) : QuestBattle(ws)
         foreach (var h in hints.PotentialTargets)
             // attacking sekiseigumi fails the mission
             if (h.Actor.OID is 0x1A6B or 0x1A66)
-                h.Priority = AIHints.Enemy.PriorityForbidFully;
+                h.Priority = AIHints.Enemy.PriorityForbidden;
 
         if (SmokeBomb && player.FindStatus(SID.Bind) != null)
             hints.ActionsToExecute.Push(ActionID.MakeSpell(ClassShared.AID.SmokeScreen), player, ActionQueue.Priority.Medium);


### PR DESCRIPTION
it's still not perfect but this is a big improvement imo

### background

mobs used to be divided into two-ish categories: forbidden (prio is negative) and not forbidden (prio is not negative). then only the highest non-forbidden mobs were considered as priority targets for AOE target calculation. this system works fairly well but lacks granularity. for example, the way i used to handle uninteresting fate mobs was to just not add them to the enemy list at all.

### explanation

really we just add two new negative priorities, or four depending on how you look at it, because two of them are renamed.

- `-1`: we don't care about this enemy, or pending effectresults indicate that it's about to die, etc etc. doesn't count as an AOE target
- `-2`: enemy is invincible, doesn't count as an aoe target
- `-3`: enemy is out of combat or otherwise uninteresting to us. AI will pick a different target if you manually target one of these.
- `-4`: enemy is actually forbidden. AMEx will refuse to use actions on it (unless they are emergency prio) and auto autos tweak will stop autoattacking it as well.

as a result of these changes, the "OK targets" list continues to start at priority 0, but now the "not OK" targets list begins at -3, giving us room in the PotentialTargets list for actually uninteresting and low priority targets without needing to drastically redesign the system.

additionally, the set of potential enemies is stored in a fixed size array in AIHints. enemies are guaranteed to have even `SpawnIndex`es between 2 and 198, so enemy lookup is now constant time instead of linear (although the performance loss from a linear search on a list of 90 items is negligible anyway...)

you will also notice that i removed some code that was forcibly adding Part-type targets to the enemy list since we add those by default now. i verified in titan normal that Part targets have even spawn indices the same as regular battlenpcs

### also

i would like to add "current target priority" as an argument to the Execute function of RotationModule, because right now the difference between -1 and -2 priority is purely cosmetic, and it will be up to the rotation modules themselves to decide what actions to use on a -1 priority target (-2 should always be ignored)