### PR TITLE
xan rotations update

### DIFF
--- a/BossMod/ActionQueue/ActionDefinition.cs
+++ b/BossMod/ActionQueue/ActionDefinition.cs
@@ -18,6 +18,30 @@ public enum ActionTargets
     All = (1 << 9) - 1,
 }
 
+// some debuffs prevent specific categories of action - amnesia, silence, pacification, etc
+public enum ActionCategory : byte
+{
+    None,
+    Autoattack,
+    Spell,
+    Weaponskill,
+    Ability,
+    Item,
+    DoLAbility,
+    DoHAbility,
+    Event,
+    LimitBreak9,
+    System10,
+    System11,
+    Mount,
+    Special,
+    ItemManipulation,
+    LimitBreak15,
+    Unk1,
+    Artillery,
+    Unk2
+}
+
 // used for BLM calculations and possibly BLU optimization
 public enum ActionAspect : byte
 {
@@ -47,6 +71,7 @@ public sealed record class ActionDefinition(ActionID ID)
     public ActionTargets AllowedTargets;
     public float Range; // 0 for self-targeted abilities
     public float CastTime; // 0 for instant-cast; can be adjusted by a number of factors (TODO: add functor)
+    public ActionCategory Category;
     public int MainCooldownGroup = -1;
     public int ExtraCooldownGroup = -1;
     public float Cooldown; // for single charge (if multi-charge action); can be adjusted by a number of factors (TODO: add functor)
@@ -340,7 +365,8 @@ public sealed class ActionDefinitions : IDisposable
             MaxChargesBase = SpellBaseMaxCharges(data),
             InstantAnimLock = instantAnimLock,
             CastAnimLock = castAnimLock,
-            IsRoleAction = data.IsRoleAction
+            IsRoleAction = data.IsRoleAction,
+            Category = (ActionCategory)data.ActionCategory.RowId
         };
         Register(aid, def);
     }

--- a/BossMod/ActionQueue/Casters/SMN.cs
+++ b/BossMod/ActionQueue/Casters/SMN.cs
@@ -136,6 +136,7 @@ public enum SID : uint
     GarudasFavor = 2725, // applied by Summon Garuda II to self
     RubysGlimmer = 3873, // applied by Searing Light to self
     RefulgentLux = 3874, // applied by Summon Solar Bahamut to self
+    CrimsonStrikeReady = 4403, // applied by Crimson Cyclone to self
 
     //Shared
     Addle = ClassShared.SID.Addle, // applied by Addle to target

--- a/BossMod/ActionQueue/ClassShared.cs
+++ b/BossMod/ActionQueue/ClassShared.cs
@@ -92,6 +92,18 @@ public enum SID : uint
     Addle = 1203, // applied by Addle to target
     Swiftcast = 167, // applied by Swiftcast to self
     Raise = 148, // applied by Raise to target
+
+    // Bozja
+    LostChainspell = 2560, // instant cast
+
+    MagicBurst = 1652, // magic damage buff
+    BannerOfNobleEnds = 2326, // damage buff + healing disable
+    BannerOfHonoredSacrifice = 2327, // damage buff + hp drain
+    LostFontOfPower = 2346, // damage/crit buff
+    ClericStance = 2484, // damage buff (from seraph strike)
+    LostExcellence = 2564, // damage buff + invincibility
+    Memorable = 2565, // damage buff
+    BloodRush = 2567, // damage buff + ability haste
     #endregion
 
     #region PvP

--- a/BossMod/Autorotation/RotationModule.cs
+++ b/BossMod/Autorotation/RotationModule.cs
@@ -1,4 +1,6 @@
-﻿namespace BossMod.Autorotation;
+﻿using static BossMod.AIHints;
+
+namespace BossMod.Autorotation;
 
 public enum RotationModuleQuality
 {
@@ -119,6 +121,7 @@ public abstract class RotationModule(RotationModuleManager manager, Actor player
         return status != null ? (StatusDuration(status.Value.ExpireAt), status.Value.Extra & 0xFF) : (0, 0);
     }
     protected (float Left, int Stacks) StatusDetails<SID>(Actor? actor, SID sid, ulong sourceID, float pendingDuration = 1000) where SID : Enum => StatusDetails(actor, (uint)(object)sid, sourceID, pendingDuration);
+    protected (float Left, int Stacks) StatusDetails<SID>(Enemy? enemy, SID sid, ulong sourceID, float pendingDuration = 1000) where SID : Enum => StatusDetails(enemy?.Actor, (uint)(object)sid, sourceID, pendingDuration);
     protected (float Left, int Stacks) SelfStatusDetails(uint sid, float pendingDuration = 1000) => StatusDetails(Player, sid, Player.InstanceID, pendingDuration);
     protected (float Left, int Stacks) SelfStatusDetails<SID>(SID sid, float pendingDuration = 1000) where SID : Enum => StatusDetails(Player, sid, Player.InstanceID, pendingDuration);
 

--- a/BossMod/Autorotation/xan/AI/AIBase.cs
+++ b/BossMod/Autorotation/xan/AI/AIBase.cs
@@ -12,12 +12,6 @@ public abstract class AIBase(RotationModuleManager manager, Actor player) : Rota
     internal bool ShouldInterrupt(AIHints.Enemy e) => e.Actor.InCombat && e.ShouldBeInterrupted && (e.Actor.CastInfo?.Interruptible ?? false);
     internal bool ShouldStun(AIHints.Enemy e) => e.Actor.InCombat && e.ShouldBeStunned;
 
-    internal bool IsCastReactable(Actor act)
-    {
-        var castInfo = act.CastInfo;
-        return !(castInfo == null || castInfo.TotalTime <= 1.5 || castInfo.EventHappened);
-    }
-
     internal IEnumerable<AIHints.Enemy> EnemiesAutoingMe => Hints.PriorityTargets.Where(x => x.Actor.CastInfo == null && x.Actor.TargetID == Player.InstanceID && Player.DistanceToHitbox(x.Actor) <= 6);
 
     internal IEnumerable<DateTime> Raidwides => Hints.PredictedDamage.Where(d => World.Party.WithSlot(excludeAlliance: true).IncludedInMask(d.players).Count() >= 2).Select(t => t.activation);

--- a/BossMod/Autorotation/xan/AI/Healer.cs
+++ b/BossMod/Autorotation/xan/AI/Healer.cs
@@ -265,14 +265,17 @@ public class HealerAI(RotationModuleManager manager, Actor player) : AIBase(mana
             Hints.ActionsToExecute.Push(ActionID.MakeSpell(BossMod.AST.AID.EarthlyStar), Player, ActionQueue.Priority.Medium, targetPos: Player.PosRot.XYZ());
     }
 
-    private Vector3? GetArenaCenter()
+    private Vector3? ArenaCenter
     {
-        if (Bossmods.ActiveModule is BossModule m)
+        get
         {
-            var center = m.Arena.Center;
-            return new Vector3(center.X, Player.PosRot.Y, center.Z);
+            if (Bossmods.ActiveModule is BossModule m)
+            {
+                var center = m.Arena.Center;
+                return new Vector3(center.X, Player.PosRot.Y, center.Z);
+            }
+            return null;
         }
-        return null;
     }
 
     private void AutoSCH(StrategyValues strategy, Actor? primaryTarget)
@@ -281,7 +284,7 @@ public class HealerAI(RotationModuleManager manager, Actor player) : AIBase(mana
         {
             if (World.Client.GetGauge<ScholarGauge>().Aetherflow == 0)
                 return;
-            location ??= GetArenaCenter() ?? Player.PosRot.XYZ();
+            location ??= ArenaCenter ?? Player.PosRot.XYZ();
             Hints.ActionsToExecute.Push(ActionID.MakeSpell(BossMod.SCH.AID.SacredSoil), null, ActionQueue.Priority.Medium + 5, targetPos: location.Value);
         }
 

--- a/BossMod/Autorotation/xan/AI/Healer.cs
+++ b/BossMod/Autorotation/xan/AI/Healer.cs
@@ -1,5 +1,6 @@
 ﻿using BossMod.Autorotation.xan.AI;
 using FFXIVClientStructs.FFXIV.Client.Game.Gauge;
+using static BossMod.Autorotation.xan.AI.TrackPartyHealth;
 
 namespace BossMod.Autorotation.xan;
 
@@ -7,7 +8,7 @@ public class HealerAI(RotationModuleManager manager, Actor player) : AIBase(mana
 {
     private readonly TrackPartyHealth Health = new(manager.WorldState);
 
-    public enum Track { Raise, RaiseTarget, Heal, Esuna }
+    public enum Track { Raise, RaiseTarget, Heal, Esuna, StayNearParty }
     public enum RaiseStrategy
     {
         None,
@@ -33,7 +34,7 @@ public class HealerAI(RotationModuleManager manager, Actor player) : AIBase(mana
 
     public static RotationModuleDefinition Definition()
     {
-        var def = new RotationModuleDefinition("Healer AI", "Auto-healer", "AI (xan)", "xan", RotationModuleQuality.WIP, BitMask.Build(Class.CNJ, Class.WHM, Class.ACN, Class.SCH, Class.SGE, Class.AST), 100);
+        var def = new RotationModuleDefinition("Healer AI", "Auto-healer", "AI (xan)", "xan", RotationModuleQuality.WIP, BitMask.Build(Class.CNJ, Class.WHM, Class.SCH, Class.SGE, Class.AST), 100);
 
         def.Define(Track.Raise).As<RaiseStrategy>("Raise")
             .AddOption(RaiseStrategy.None, "Don't automatically raise")
@@ -48,15 +49,38 @@ public class HealerAI(RotationModuleManager manager, Actor player) : AIBase(mana
 
         def.AbilityTrack(Track.Heal, "Heal");
         def.AbilityTrack(Track.Esuna, "Esuna");
+        def.AbilityTrack(Track.StayNearParty, "Stay near party");
 
         return def;
     }
 
-    private void HealSingle(Action<Actor, TrackPartyHealth.PartyMemberState> healFun)
+    private void HealSingle(Action<Actor, PartyMemberState> healFun)
     {
         if (Health.BestSTHealTarget is (var a, var b))
             healFun(a, b);
     }
+
+    /// <summary>
+    /// Run the given Action if the party has exactly one tank, otherwise do nothing
+    /// </summary>
+    /// <param name="tankFun"></param>
+    private void RunForTank(Action<Actor, PartyMemberState> tankFun)
+    {
+        var tankSlot = -1;
+        foreach (var (slot, actor) in World.Party.WithSlot(excludeAlliance: true))
+            if (actor.ClassCategory == ClassCategory.Tank)
+            {
+                if (tankSlot >= 0)
+                    return;
+                else
+                    tankSlot = slot;
+            }
+
+        if (tankSlot >= 0)
+            tankFun(World.Party[tankSlot]!, Health.PartyMemberStates[tankSlot]!);
+    }
+
+    private IEnumerable<Actor> LightParty => World.Party.WithoutSlot(excludeAlliance: true, excludeNPCs: Health.HaveRealPartyMembers);
 
     public override void Execute(StrategyValues strategy, Actor? primaryTarget, float estimatedAnimLockDelay, bool isMoving)
     {
@@ -64,6 +88,12 @@ public class HealerAI(RotationModuleManager manager, Actor player) : AIBase(mana
             return;
 
         Health.Update(Hints);
+
+        if (strategy.Enabled(Track.StayNearParty) && Player.InCombat)
+        {
+            List<(WPos pos, float radius)> allies = [.. LightParty.Exclude(Player).Select(e => (e.Position, e.HitboxRadius))];
+            Hints.GoalZones.Add(p => allies.Count(a => a.pos.InCircle(p, a.radius + Player.HitboxRadius + 15)));
+        }
 
         AutoRaise(strategy);
 
@@ -160,8 +190,8 @@ public class HealerAI(RotationModuleManager manager, Actor player) : AIBase(mana
         var candidates = strategy.Option(Track.RaiseTarget).As<RaiseTarget>() switch
         {
             RaiseTarget.Everyone => World.Actors.Where(x => x.Type is ActorType.Player or ActorType.DutySupport && x.IsAlly),
-            RaiseTarget.Alliance => World.Party.WithoutSlot(true, false),
-            _ => World.Party.WithoutSlot(true, true)
+            RaiseTarget.Alliance => World.Party.WithoutSlot(true, false, true),
+            _ => World.Party.WithoutSlot(true, true, true)
         };
 
         return candidates.Where(x => x.IsDead && Player.DistanceToHitbox(x) <= 30 && !BeingRaised(x)).MaxBy(actor => actor.Class.GetRole() switch
@@ -235,8 +265,30 @@ public class HealerAI(RotationModuleManager manager, Actor player) : AIBase(mana
             Hints.ActionsToExecute.Push(ActionID.MakeSpell(BossMod.AST.AID.EarthlyStar), Player, ActionQueue.Priority.Medium, targetPos: Player.PosRot.XYZ());
     }
 
+    private Vector3? GetArenaCenter()
+    {
+        if (Bossmods.ActiveModule is BossModule m)
+        {
+            var center = m.Arena.Center;
+            return new Vector3(center.X, Player.PosRot.Y, center.Z);
+        }
+        return null;
+    }
+
     private void AutoSCH(StrategyValues strategy, Actor? primaryTarget)
     {
+        void UseSoil(Vector3? location = null)
+        {
+            if (World.Client.GetGauge<ScholarGauge>().Aetherflow == 0)
+                return;
+            location ??= GetArenaCenter() ?? Player.PosRot.XYZ();
+            Hints.ActionsToExecute.Push(ActionID.MakeSpell(BossMod.SCH.AID.SacredSoil), null, ActionQueue.Priority.Medium + 5, targetPos: location.Value);
+        }
+
+        // TODO make this configurable
+        if (primaryTarget != null)
+            UseOGCD(BossMod.SCH.AID.ChainStratagem, primaryTarget);
+
         var gauge = World.Client.GetGauge<ScholarGauge>();
 
         var pet = World.Client.ActivePet.InstanceID == 0xE0000000 ? null : World.Actors.Find(World.Client.ActivePet.InstanceID);
@@ -250,8 +302,15 @@ public class HealerAI(RotationModuleManager manager, Actor player) : AIBase(mana
 
         if (pet != null)
         {
-            if (haveEos && ShouldHealInArea(pet.Position, 20, 0.5f))
-                UseOGCD(BossMod.SCH.AID.FeyBlessing, Player);
+            if (ShouldHealInArea(pet.Position, 30, 0.5f))
+            {
+                if (haveSeraph)
+                    UseOGCD(BossMod.SCH.AID.Consolation, Player);
+                else if (NextChargeIn(BossMod.SCH.AID.SummonSeraph) == 0)
+                    UseOGCD(BossMod.SCH.AID.SummonSeraph, Player);
+                else
+                    UseOGCD(BossMod.SCH.AID.FeyBlessing, Player);
+            }
 
             if (ShouldHealInArea(pet.Position, 15, 0.8f))
                 UseOGCD(BossMod.SCH.AID.WhisperingDawn, Player);
@@ -268,9 +327,30 @@ public class HealerAI(RotationModuleManager manager, Actor player) : AIBase(mana
                     UseOGCD(BossMod.SCH.AID.Lustrate, target);
                 }
                 else
-                    UseGCD(BossMod.SCH.AID.Physick, target);
+                    UseGCD(BossMod.SCH.AID.Adloquium, target);
             }
         });
+
+        RunForTank((tank, tankState) =>
+        {
+            if (!Player.InCombat && (World.CurrentTime - tankState.LastCombat).TotalSeconds > 1)
+            {
+                if (NextChargeIn(BossMod.SCH.AID.Excogitation) == 0)
+                    UseOGCD(BossMod.SCH.AID.Recitation, Player, 5);
+                UseOGCD(BossMod.SCH.AID.Excogitation, tank);
+            }
+
+            if (tank.InCombat && Bossmods.ActiveModule is null && tankState.MoveDelta < 0.75f)
+                UseSoil(tank.PosRot.XYZ());
+        });
+
+        foreach (var rw in Raidwides)
+            if ((rw - World.CurrentTime).TotalSeconds < 5)
+            {
+                var allies = LightParty.ToList();
+                var centroid = allies.Aggregate(allies[0].PosRot.XYZ(), (pos, actor) => (pos + actor.PosRot.XYZ()) / 2f);
+                UseSoil(centroid);
+            }
     }
 
     private void AutoSGE(StrategyValues strategy, Actor? primaryTarget)
@@ -302,9 +382,7 @@ public class HealerAI(RotationModuleManager manager, Actor player) : AIBase(mana
         });
 
         foreach (var rw in Raidwides)
-        {
             if ((rw - World.CurrentTime).TotalSeconds < 15 && haveBalls)
                 UseOGCD(BossMod.SGE.AID.Kerachole, Player);
-        }
     }
 }

--- a/BossMod/Autorotation/xan/AI/Ranged.cs
+++ b/BossMod/Autorotation/xan/AI/Ranged.cs
@@ -19,13 +19,13 @@ public class RangedAI(RotationModuleManager manager, Actor player) : AIBase(mana
         // interrupt
         if (strategy.Enabled(Track.Interrupt) && NextChargeIn(ClassShared.AID.HeadGraze) == 0)
         {
-            var interruptibleEnemy = Hints.PotentialTargets.FirstOrDefault(e => ShouldInterrupt(e.Actor) && Player.DistanceToHitbox(e.Actor) <= 25);
+            var interruptibleEnemy = Hints.PotentialTargets.FirstOrDefault(e => ShouldInterrupt(e) && Player.DistanceToHitbox(e.Actor) <= 25);
             if (interruptibleEnemy != null)
-                Hints.ActionsToExecute.Push(ActionID.MakeSpell(ClassShared.AID.HeadGraze), interruptibleEnemy.Actor, ActionQueue.Priority.Minimal);
+                Hints.ActionsToExecute.Push(ActionID.MakeSpell(ClassShared.AID.HeadGraze), interruptibleEnemy.Actor, ActionQueue.Priority.High);
         }
 
         // second wind
-        if (strategy.Enabled(Track.SecondWind) && Player.InCombat && HPRatio() <= 0.5)
+        if (strategy.Enabled(Track.SecondWind) && Player.InCombat && Player.PredictedHPRatio <= 0.5)
             Hints.ActionsToExecute.Push(ActionID.MakeSpell(ClassShared.AID.SecondWind), Player, ActionQueue.Priority.Medium);
 
         ExecLB(strategy, primaryTarget);

--- a/BossMod/Autorotation/xan/Basexan.cs
+++ b/BossMod/Autorotation/xan/Basexan.cs
@@ -1,8 +1,10 @@
-﻿namespace BossMod.Autorotation.xan;
+﻿using static BossMod.AIHints;
+
+namespace BossMod.Autorotation.xan;
 
 public enum Targeting { Manual, Auto, AutoPrimary, AutoTryPri }
 public enum OffensiveStrategy { Automatic, Delay, Force }
-public enum AOEStrategy { ST, AOE, ForceAOE, ForceST }
+public enum AOEStrategy { AOE, ST, ForceAOE, ForceST }
 
 public enum SharedTrack { Targeting, AOE, Buffs, Count }
 
@@ -30,12 +32,10 @@ public abstract class Basexan<AID, TraitID>(RotationModuleManager manager, Actor
     protected float RaidBuffsLeft { get; private set; }
     protected float DowntimeIn { get; private set; }
     protected float? UptimeIn { get; private set; }
-    /// <summary>
-    /// Player's "actual" target. Is guaranteed to be an enemy.
-    /// </summary>
-    protected Actor? PlayerTarget { get; private set; }
+    protected Enemy? PlayerTarget { get; private set; }
 
     protected float? CountdownRemaining => World.Client.CountdownRemaining;
+    protected float AnimLock => World.Client.AnimationLock;
 
     protected float AttackGCDLength => ActionSpeed.GCDRounded(World.Client.PlayerStats.SkillSpeed, World.Client.PlayerStats.Haste, Player.Level);
     protected float SpellGCDLength => ActionSpeed.GCDRounded(World.Client.PlayerStats.SpellSpeed, World.Client.PlayerStats.Haste, Player.Level);
@@ -50,7 +50,7 @@ public abstract class Basexan<AID, TraitID>(RotationModuleManager manager, Actor
     protected bool OnCooldown(AID aid) => MaxChargesIn(aid) > 0;
 
     public bool CanWeave(float cooldown, float actionLock, int extraGCDs = 0, float extraFixedDelay = 0)
-        => MathF.Max(cooldown, World.Client.AnimationLock) + actionLock + AnimationLockDelay <= GCD + GCDLength * extraGCDs + extraFixedDelay;
+        => MathF.Max(cooldown, AnimLock) + actionLock + AnimationLockDelay <= GCD + GCDLength * extraGCDs + extraFixedDelay;
 
     public bool CanWeave(AID aid, int extraGCDs = 0, float extraFixedDelay = 0)
     {
@@ -59,6 +59,11 @@ public abstract class Basexan<AID, TraitID>(RotationModuleManager manager, Actor
             return false;
 
         var def = ActionDefinitions.Instance[ActionID.MakeSpell(aid)]!;
+
+        // amnesia check
+        if (def.Category == ActionCategory.Ability && Player.FindStatus(1092) != null)
+            return false;
+
         return CanWeave(ReadyIn(aid), def.InstantAnimLock, extraGCDs, extraFixedDelay);
     }
 
@@ -70,6 +75,11 @@ public abstract class Basexan<AID, TraitID>(RotationModuleManager manager, Actor
 
     protected void PushGCD<P>(AID aid, Actor? target, P priority, float delay = 0) where P : Enum
         => PushGCD(aid, target, (int)(object)priority, delay);
+
+    protected void PushGCD<P>(AID aid, Enemy? target, P priority, float delay = 0) where P : Enum
+        => PushGCD(aid, target?.Actor, (int)(object)priority, delay);
+
+    protected void PushGCD(AID aid, Enemy? target, int priority = 2, float delay = 0) => PushGCD(aid, target?.Actor, priority, delay);
 
     protected void PushGCD(AID aid, Actor? target, int priority = 2, float delay = 0)
     {
@@ -85,6 +95,11 @@ public abstract class Basexan<AID, TraitID>(RotationModuleManager manager, Actor
 
     protected void PushOGCD<P>(AID aid, Actor? target, P priority, float delay = 0) where P : Enum
         => PushOGCD(aid, target, (int)(object)priority, delay);
+
+    protected void PushOGCD<P>(AID aid, Enemy? target, P priority, float delay = 0) where P : Enum
+        => PushOGCD(aid, target?.Actor, (int)(object)priority, delay);
+
+    protected void PushOGCD(AID aid, Enemy? target, int priority = 1, float delay = 0) => PushOGCD(aid, target?.Actor, priority, delay);
 
     protected void PushOGCD(AID aid, Actor? target, int priority = 1, float delay = 0)
     {
@@ -134,20 +149,15 @@ public abstract class Basexan<AID, TraitID>(RotationModuleManager manager, Actor
     /// <param name="strategy">Targeting strategy</param>
     /// <param name="primaryTarget">Player's current target - may be null</param>
     /// <param name="range">Maximum distance from the player to search for a candidate target</param>
-    protected void SelectPrimaryTarget(StrategyValues strategy, ref Actor? primaryTarget, float range)
+    protected void SelectPrimaryTarget(StrategyValues strategy, ref Enemy? primaryTarget, float range)
     {
         var t = strategy.Option(SharedTrack.Targeting).As<Targeting>();
-
-        if (!IsValidEnemy(primaryTarget))
-            primaryTarget = null;
-
-        PlayerTarget = primaryTarget;
 
         if (t is Targeting.Auto or Targeting.AutoTryPri)
         {
             if (Player.DistanceToHitbox(primaryTarget) > range)
             {
-                var newTarget = Hints.PriorityTargets.FirstOrDefault(x => Player.DistanceToHitbox(x.Actor) <= range)?.Actor;
+                var newTarget = Hints.PriorityTargets.FirstOrDefault(x => Player.DistanceToHitbox(x.Actor) <= range);
                 if (newTarget != null)
                     primaryTarget = newTarget;
             }
@@ -157,19 +167,19 @@ public abstract class Basexan<AID, TraitID>(RotationModuleManager manager, Actor
     protected delegate bool PositionCheck(Actor playerTarget, Actor targetToTest);
     protected delegate P PriorityFunc<P>(int totalTargets, Actor primaryTarget);
 
-    protected (Actor? Best, int Targets) SelectTarget(
+    protected (Enemy? Best, int Targets) SelectTarget(
         StrategyValues strategy,
-        Actor? primaryTarget,
+        Enemy? primaryTarget,
         float range,
         PositionCheck isInAOE
     ) => SelectTarget(strategy, primaryTarget, range, isInAOE, (numTargets, _) => numTargets, a => a);
 
-    protected (Actor? Best, int Targets) SelectTargetByHP(StrategyValues strategy, Actor? primaryTarget, float range, PositionCheck isInAOE)
+    protected (Enemy? Best, int Targets) SelectTargetByHP(StrategyValues strategy, Enemy? primaryTarget, float range, PositionCheck isInAOE)
         => SelectTarget(strategy, primaryTarget, range, isInAOE, (numTargets, actor) => (numTargets, numTargets > 2 ? actor.HPMP.CurHP : 0), args => args.numTargets);
 
-    protected (Actor? Best, int Priority) SelectTarget<P>(
+    protected (Enemy? Best, int Priority) SelectTarget<P>(
         StrategyValues strategy,
-        Actor? primaryTarget,
+        Enemy? primaryTarget,
         float range,
         PositionCheck isInAOE,
         PriorityFunc<P> prioritize,
@@ -195,17 +205,17 @@ public abstract class Basexan<AID, TraitID>(RotationModuleManager manager, Actor
 
         var (newtarget, newprio) = targeting switch
         {
-            Targeting.Auto => FindBetterTargetBy(primaryTarget, range, targetPrio),
+            Targeting.Auto => FindBetterTargetBy(primaryTarget?.Actor, range, targetPrio),
             Targeting.AutoPrimary => primaryTarget == null ? (null, default) : FindBetterTargetBy(
-                primaryTarget,
+                primaryTarget.Actor,
                 range,
                 targetPrio,
-                enemy => isInAOE(enemy.Actor, primaryTarget)
+                enemy => isInAOE(enemy.Actor, primaryTarget.Actor)
             ),
-            _ => (primaryTarget, primaryTarget == null ? default : targetPrio(primaryTarget))
+            _ => (primaryTarget?.Actor, primaryTarget == null ? default : targetPrio(primaryTarget.Actor))
         };
         var newnewprio = simplify(newprio);
-        return (newnewprio > 0 ? newtarget : null, newnewprio);
+        return (newnewprio > 0 ? Hints.FindEnemy(newtarget) : null, newnewprio);
     }
 
     /// <summary>
@@ -218,21 +228,22 @@ public abstract class Basexan<AID, TraitID>(RotationModuleManager manager, Actor
     /// <param name="getTimer"></param>
     /// <param name="maxAllowedTargets"></param>
     /// <returns></returns>
-    protected (Actor? Target, P Timer) SelectDotTarget<P>(StrategyValues strategy, Actor? initial, Func<Actor?, P> getTimer, int maxAllowedTargets) where P : struct, IComparable
+    protected (Enemy? Target, P Timer) SelectDotTarget<P>(StrategyValues strategy, Enemy? initial, Func<Actor?, P> getTimer, int maxAllowedTargets) where P : struct, IComparable
     {
+        var forbidden = initial?.ForbidDOTs ?? false;
         switch (strategy.Targeting())
         {
             case Targeting.Manual:
             case Targeting.AutoPrimary:
-                return (initial, getTimer(initial));
+                return forbidden ? (null, getTimer(null)) : (initial, getTimer(initial?.Actor));
             case Targeting.AutoTryPri:
                 if (initial != null)
-                    return (initial, getTimer(initial));
+                    return forbidden ? (null, getTimer(null)) : (initial, getTimer(initial?.Actor));
                 break;
         }
 
         var newTarget = initial;
-        var initialTimer = getTimer(initial);
+        var initialTimer = getTimer(initial?.Actor);
         var newTimer = initialTimer;
 
         var numTargets = 0;
@@ -248,7 +259,7 @@ public abstract class Basexan<AID, TraitID>(RotationModuleManager manager, Actor
             var thisTimer = getTimer(dotTarget.Actor);
             if (thisTimer.CompareTo(newTimer) < 0)
             {
-                newTarget = dotTarget.Actor;
+                newTarget = dotTarget;
                 newTimer = thisTimer;
             }
         }
@@ -256,12 +267,29 @@ public abstract class Basexan<AID, TraitID>(RotationModuleManager manager, Actor
         return (newTarget, newTimer);
     }
 
-    protected void GoalZoneCombined(float range, Func<WPos, float> fAoe, int minAoe, Positional pos = Positional.Any)
+    // used for casters that don't have a separate maximize-AOE function
+    protected void GoalZoneSingle(float range)
     {
+        if (PlayerTarget != null)
+            Hints.GoalZones.Add(Hints.GoalSingleTarget(PlayerTarget.Actor, range));
+    }
+
+    protected void GoalZoneCombined(StrategyValues strategy, float range, Func<WPos, float> fAoe, AID firstUnlockedAoeAction, int minAoe, Positional positional = Positional.Any, float? maximumActionRange = null)
+    {
+        if (!strategy.AOEOk() || !Unlocked(firstUnlockedAoeAction))
+            minAoe = 50;
+
         if (PlayerTarget == null)
-            Hints.GoalZones.Add(fAoe);
+        {
+            if (minAoe < 50)
+                Hints.GoalZones.Add(fAoe);
+        }
         else
-            Hints.GoalZones.Add(Hints.GoalCombined(Hints.GoalSingleTarget(PlayerTarget, pos, range), fAoe, minAoe));
+        {
+            Hints.GoalZones.Add(Hints.GoalCombined(Hints.GoalSingleTarget(PlayerTarget.Actor, positional, range), fAoe, minAoe));
+            if (maximumActionRange is float r)
+                Hints.GoalZones.Add(Hints.GoalSingleTarget(PlayerTarget.Actor, r, 0.5f));
+        }
     }
 
     protected int NumMeleeAOETargets(StrategyValues strategy) => NumNearbyTargets(strategy, 5);
@@ -290,7 +318,7 @@ public abstract class Basexan<AID, TraitID>(RotationModuleManager manager, Actor
     /// <returns></returns>
     protected virtual float GetCastTime(AID aid) => SwiftcastLeft > GCD ? 0 : ActionDefinitions.Instance.Spell(aid)!.CastTime * GCDLength / 2.5f;
 
-    protected float NextCastStart => World.Client.AnimationLock > GCD ? World.Client.AnimationLock + AnimationLockDelay : GCD;
+    protected float NextCastStart => AnimLock > GCD ? AnimLock + AnimationLockDelay : GCD;
 
     protected float GetSlidecastTime(AID aid) => MathF.Max(0, GetCastTime(aid) - 0.5f);
     protected float GetSlidecastEnd(AID aid) => NextCastStart + GetSlidecastTime(aid);
@@ -301,15 +329,13 @@ public abstract class Basexan<AID, TraitID>(RotationModuleManager manager, Actor
         if (t == 0)
             return true;
 
-        return NextCastStart + t <= ForceMovementIn;
+        return NextCastStart + t <= MaxCastTime;
     }
 
-    protected float ForceMovementIn;
+    protected float MaxCastTime;
 
     protected bool Unlocked(AID aid) => ActionUnlocked(ActionID.MakeSpell(aid));
     protected bool Unlocked(TraitID tid) => TraitUnlocked((uint)(object)tid);
-
-    private static bool IsValidEnemy(Actor? actor) => actor != null && !actor.IsAlly;
 
     protected Positional GetCurrentPositional(Actor target) => (Player.Position - target.Position).Normalized().Dot(target.Rotation.ToDirection()) switch
     {
@@ -321,8 +347,9 @@ public abstract class Basexan<AID, TraitID>(RotationModuleManager manager, Actor
     protected bool NextPositionalImminent;
     protected bool NextPositionalCorrect;
 
-    protected void UpdatePositionals(Actor? target, ref (Positional pos, bool imm) positional, bool trueNorth)
+    protected void UpdatePositionals(Enemy? enemy, ref (Positional pos, bool imm) positional, bool trueNorth)
     {
+        var target = enemy?.Actor;
         if ((target?.Omnidirectional ?? true) || target?.TargetID == Player.InstanceID && target?.CastInfo == null && positional.pos != Positional.Front && target?.NameID != 541)
             positional = (Positional.Any, false);
 
@@ -333,20 +360,42 @@ public abstract class Basexan<AID, TraitID>(RotationModuleManager manager, Actor
             Positional.Rear => target.Rotation.ToDirection().Dot((Player.Position - target.Position).Normalized()) < -0.7071068f,
             _ => true
         };
-        Manager.Hints.RecommendedPositional = (target, positional.pos, NextPositionalImminent, NextPositionalCorrect);
+        Hints.RecommendedPositional = (target, positional.pos, NextPositionalImminent, NextPositionalCorrect);
+    }
+
+    private readonly SmartRotationConfig _smartrot = Service.Config.Get<SmartRotationConfig>();
+
+    private void EstimateCastTime()
+    {
+        MaxCastTime = Hints.MaxCastTimeEstimate;
+
+        if (Player.PendingKnockbacks.Count > 0)
+        {
+            MaxCastTime = 0f;
+            return;
+        }
+
+        var forbiddenDir = Hints.ForbiddenDirections.Where(d => Player.Rotation.AlmostEqual(d.center, d.halfWidth.Rad)).Select(d => d.activation).DefaultIfEmpty(DateTime.MinValue).Min();
+        if (forbiddenDir > World.CurrentTime)
+        {
+            var cushion = _smartrot.MinTimeToAvoid;
+            var gazeIn = MathF.Max(0, (float)(forbiddenDir - World.CurrentTime).TotalSeconds - cushion);
+            MaxCastTime = MathF.Min(MaxCastTime, gazeIn);
+        }
     }
 
     public sealed override void Execute(StrategyValues strategy, Actor? primaryTarget, float estimatedAnimLockDelay, bool isMoving)
     {
         NextGCD = default;
         NextGCDPrio = 0;
+        PlayerTarget = Hints.FindEnemy(primaryTarget);
 
-        var pelo = Player.FindStatus(BossMod.BRD.SID.Peloton);
+        var pelo = Player.FindStatus(ClassShared.SID.Peloton);
         PelotonLeft = pelo != null ? StatusDuration(pelo.Value.ExpireAt) : 0;
-        SwiftcastLeft = StatusLeft(BossMod.WHM.SID.Swiftcast);
-        TrueNorthLeft = StatusLeft(BossMod.DRG.SID.TrueNorth);
+        SwiftcastLeft = MathF.Max(StatusLeft(ClassShared.SID.Swiftcast), StatusLeft(ClassShared.SID.LostChainspell));
+        TrueNorthLeft = StatusLeft(ClassShared.SID.TrueNorth);
 
-        ForceMovementIn = Hints.MaxCastTimeEstimate;
+        EstimateCastTime();
         AnimationLockDelay = estimatedAnimLockDelay;
 
         CombatTimer = (float)(World.CurrentTime - Manager.CombatStart).TotalSeconds;
@@ -367,25 +416,63 @@ public abstract class Basexan<AID, TraitID>(RotationModuleManager manager, Actor
         MP = (uint)Math.Clamp(Player.PredictedMPRaw, 0, 10000);
 
         if (Player.MountId is not (103 or 117 or 128))
-            Exec(strategy, primaryTarget);
+            Exec(strategy, PlayerTarget);
     }
+
+    // other classes have timed personal buffs to plan around, like blm leylines, mch overheat, gnb nomercy
+    // war could also be here but i dont have a war rotation
+    private bool IsSelfish(Class cls) => cls is Class.VPR or Class.SAM or Class.WHM or Class.SGE;
 
     private new (float Left, float In) EstimateRaidBuffTimings(Actor? primaryTarget)
     {
-        // striking dummy that spawns in Explorer Mode
-        if (primaryTarget?.OID != 0x2DE0)
-            return (Bossmods.RaidCooldowns.DamageBuffLeft(Player), Bossmods.RaidCooldowns.NextDamageBuffIn2());
+        if (Bossmods.ActiveModule?.Info?.GroupType is BossModuleInfo.GroupType.BozjaDuel && IsSelfish(Player.Class))
+            return (float.MaxValue, 0);
 
-        // hack for a dummy: expect that raidbuffs appear at 7.8s and then every 120s
-        var cycleTime = CombatTimer - 7.8f;
-        if (cycleTime < 0)
-            return (0, 7.8f - CombatTimer); // very beginning of a fight
+        // level 100 stone sky sea
+        if (primaryTarget?.OID == 0x41CD)
+        {
+            // hack for a dummy: expect that raidbuffs appear at 7.8s and then every 120s
+            var cycleTime = CombatTimer - 7.8f;
+            if (cycleTime < 0)
+                return (0, 7.8f - CombatTimer); // very beginning of a fight
 
-        cycleTime %= 120;
-        return cycleTime < 20 ? (20 - cycleTime, 0) : (0, 120 - cycleTime);
+            cycleTime %= 120;
+            return cycleTime < 20 ? (20 - cycleTime, 0) : (0, 120 - cycleTime);
+        }
+
+        var buffsIn = Bossmods.RaidCooldowns.NextDamageBuffIn2();
+        if (buffsIn == null)
+        {
+            if (CombatTimer < 7.8f && World.Party.WithoutSlot(false, true, true).Skip(1).Any(HavePartyBuff))
+                buffsIn = 7.8f - CombatTimer;
+            else
+                buffsIn = float.MaxValue;
+        }
+
+        return (Bossmods.RaidCooldowns.DamageBuffLeft(Player), buffsIn.Value);
     }
 
-    public abstract void Exec(StrategyValues strategy, Actor? primaryTarget);
+    private bool HavePartyBuff(Actor player) => player.Class switch
+    {
+        Class.MNK => player.Level >= 70, // brotherhood
+        Class.DRG => player.Level >= 52, // battle litany
+        Class.NIN => player.Level >= 45, // mug/dokumori - level check is for suiton/huton, which grant Shadow Walker
+        Class.RPR => player.Level >= 72, // arcane circle
+
+        Class.SMN => player.Level >= 66, // searing light
+        Class.RDM => player.Level >= 58, // embolden
+        Class.PCT => player.Level >= 70, // starry muse
+
+        Class.BRD => player.Level >= 50, // battle voice - not counting songs since they are permanent kinda
+        Class.DNC => player.Level >= 70, // tech finish
+
+        Class.SCH => player.Level >= 66, // chain
+        Class.AST => player.Level >= 50, // divination
+
+        _ => false
+    };
+
+    public abstract void Exec(StrategyValues strategy, Enemy? primaryTarget);
 
     protected (float Left, int Stacks) Status<SID>(SID status) where SID : Enum => Player.FindStatus(status) is ActorStatus s ? (StatusDuration(s.ExpireAt), s.Extra & 0xFF) : (0, 0);
     protected float StatusLeft<SID>(SID status) where SID : Enum => Status(status).Left;
@@ -414,8 +501,8 @@ static class Extendxan
             .AddOption(xan.Targeting.AutoTryPri, "AutoTryPri", "Automatically select best target for AOE actions - if player has a target, ensure that target is hit");
 
         def.Define(SharedTrack.AOE).As<AOEStrategy>("AOE")
-            .AddOption(AOEStrategy.ST, "ST", "Use single-target actions")
             .AddOption(AOEStrategy.AOE, "AOE", "Use AOE actions if beneficial")
+            .AddOption(AOEStrategy.ST, "ST", "Use single-target actions")
             .AddOption(AOEStrategy.ForceAOE, "ForceAOE", "Always use AOE actions, even on one target")
             .AddOption(AOEStrategy.ForceST, "ForceST", "Forbid any action that can hit multiple targets");
 
@@ -434,4 +521,5 @@ static class Extendxan
     public static Targeting Targeting(this StrategyValues strategy) => strategy.Option(SharedTrack.Targeting).As<Targeting>();
     public static OffensiveStrategy Simple<Index>(this StrategyValues strategy, Index track) where Index : Enum => strategy.Option(track).As<OffensiveStrategy>();
     public static bool BuffsOk(this StrategyValues strategy) => strategy.Option(SharedTrack.Buffs).As<OffensiveStrategy>() != OffensiveStrategy.Delay;
+    public static bool AOEOk(this StrategyValues strategy) => strategy.AOE() is AOEStrategy.AOE or AOEStrategy.ForceAOE;
 }

--- a/BossMod/Autorotation/xan/Casters/RDM.cs
+++ b/BossMod/Autorotation/xan/Casters/RDM.cs
@@ -1,5 +1,6 @@
 ﻿using BossMod.RDM;
 using FFXIVClientStructs.FFXIV.Client.Game.Gauge;
+using static BossMod.AIHints;
 
 namespace BossMod.Autorotation.xan;
 
@@ -57,9 +58,9 @@ public sealed class RDM(RotationModuleManager manager, Actor player) : Castxan<A
     public int NumConeTargets;
     public int NumLineTargets;
 
-    private Actor? BestAOETarget;
-    private Actor? BestConeTarget;
-    private Actor? BestLineTarget;
+    private Enemy? BestAOETarget;
+    private Enemy? BestConeTarget;
+    private Enemy? BestLineTarget;
 
     private bool InCombo
         => ComboLastMove == AID.Riposte && Unlocked(AID.Zwerchhau)
@@ -88,7 +89,7 @@ public sealed class RDM(RotationModuleManager manager, Actor player) : Castxan<A
         return base.GetCastTime(aid);
     }
 
-    public override void Exec(StrategyValues strategy, Actor? primaryTarget)
+    public override void Exec(StrategyValues strategy, Enemy? primaryTarget)
     {
         SelectPrimaryTarget(strategy, ref primaryTarget, 25);
 
@@ -122,8 +123,8 @@ public sealed class RDM(RotationModuleManager manager, Actor player) : Castxan<A
             : Unlocked(AID.Zwerchhau) ? 35
             : 20;
 
-        if (primaryTarget is Actor tar && (Swordplay > 0 || LowestMana >= comboMana || InCombo))
-            Hints.GoalZones.Add(Hints.GoalSingleTarget(tar, 3));
+        if (primaryTarget is { } tar && (Swordplay > 0 || LowestMana >= comboMana || InCombo))
+            Hints.GoalZones.Add(Hints.GoalSingleTarget(tar.Actor, 3));
 
         OGCD(strategy, primaryTarget);
 
@@ -201,7 +202,7 @@ public sealed class RDM(RotationModuleManager manager, Actor player) : Castxan<A
         PushGCD(AID.Jolt, primaryTarget);
     }
 
-    private void OGCD(StrategyValues strategy, Actor? primaryTarget)
+    private void OGCD(StrategyValues strategy, Enemy? primaryTarget)
     {
         if (!Player.InCombat || primaryTarget == null)
             return;
@@ -239,12 +240,12 @@ public sealed class RDM(RotationModuleManager manager, Actor player) : Castxan<A
             PushOGCD(AID.LucidDreaming, Player);
     }
 
-    private bool DashOk(StrategyValues strategy, Actor? primaryTarget) => strategy.Option(Track.Dash).As<DashStrategy>() switch
+    private bool DashOk(StrategyValues strategy, Enemy? primaryTarget) => strategy.Option(Track.Dash).As<DashStrategy>() switch
     {
         DashStrategy.Any => true,
-        DashStrategy.Move => ForceMovementIn > 30,
+        DashStrategy.Move => MaxCastTime > 30,
         DashStrategy.Close => Player.DistanceToHitbox(primaryTarget) < 3,
-        DashStrategy.CloseMove => Player.DistanceToHitbox(primaryTarget) < 3 && ForceMovementIn > 30,
+        DashStrategy.CloseMove => Player.DistanceToHitbox(primaryTarget) < 3 && MaxCastTime > 30,
         _ => false
     };
 }

--- a/BossMod/Autorotation/xan/Healers/SCH.cs
+++ b/BossMod/Autorotation/xan/Healers/SCH.cs
@@ -1,5 +1,6 @@
 ﻿using BossMod.SCH;
 using FFXIVClientStructs.FFXIV.Client.Game.Gauge;
+using static BossMod.AIHints;
 
 namespace BossMod.Autorotation.xan;
 public sealed class SCH(RotationModuleManager manager, Actor player) : Castxan<AID, TraitID>(manager, player)
@@ -46,12 +47,12 @@ public sealed class SCH(RotationModuleManager manager, Actor player) : Castxan<A
     public PetOrder FairyOrder;
 
     private Actor? Eos;
-    private Actor? BestDotTarget;
-    private Actor? BestRangedAOETarget;
+    private Enemy? BestDotTarget;
+    private Enemy? BestRangedAOETarget;
 
     private DateTime _summonWait;
 
-    public override void Exec(StrategyValues strategy, Actor? primaryTarget)
+    public override void Exec(StrategyValues strategy, Enemy? primaryTarget)
     {
         SelectPrimaryTarget(strategy, ref primaryTarget, 25);
 
@@ -106,7 +107,7 @@ public sealed class SCH(RotationModuleManager manager, Actor player) : Castxan<A
 
         var needAOETargets = Unlocked(AID.Broil1) ? 2 : 1;
 
-        GoalZoneCombined(25, Hints.GoalAOECircle(5), needAOETargets);
+        GoalZoneCombined(strategy, 25, Hints.GoalAOECircle(5), AID.ArtOfWar1, needAOETargets);
 
         if (NumAOETargets >= needAOETargets)
             PushGCD(AID.ArtOfWar1, Player);
@@ -117,7 +118,7 @@ public sealed class SCH(RotationModuleManager manager, Actor player) : Castxan<A
         PushGCD(AID.Ruin2, primaryTarget);
     }
 
-    private void OGCD(StrategyValues strategy, Actor? primaryTarget)
+    private void OGCD(StrategyValues strategy, Enemy? primaryTarget)
     {
         if (primaryTarget == null || !Player.InCombat)
             return;

--- a/BossMod/Autorotation/xan/Ranged/BRD.cs
+++ b/BossMod/Autorotation/xan/Ranged/BRD.cs
@@ -1,5 +1,6 @@
 ﻿using BossMod.BRD;
 using FFXIVClientStructs.FFXIV.Client.Game.Gauge;
+using static BossMod.AIHints;
 
 namespace BossMod.Autorotation.xan;
 
@@ -54,14 +55,14 @@ public sealed class BRD(RotationModuleManager manager, Actor player) : Attackxan
     public int NumConeTargets; // 12y/90(?)deg cone - regular aoe gcds
     public int NumLineTargets; // 25y/4y rect - apex arrow and stuff
 
-    private Actor? BestCircleTarget;
-    private Actor? BestConeTarget;
-    private Actor? BestLineTarget;
-    private Actor? BestDotTarget;
+    private Enemy? BestCircleTarget;
+    private Enemy? BestConeTarget;
+    private Enemy? BestLineTarget;
+    private Enemy? BestDotTarget;
 
     public int Codas => (Coda.HasFlag(CodaSongs.MagesBallad) ? 1 : 0) + (Coda.HasFlag(CodaSongs.ArmysPaeon) ? 1 : 0) + (Coda.HasFlag(CodaSongs.WanderersMinuet) ? 1 : 0);
 
-    public override void Exec(StrategyValues strategy, Actor? primaryTarget)
+    public override void Exec(StrategyValues strategy, Enemy? primaryTarget)
     {
         SelectPrimaryTarget(strategy, ref primaryTarget, 25);
 
@@ -99,6 +100,9 @@ public sealed class BRD(RotationModuleManager manager, Actor player) : Attackxan
 
             return;
         }
+
+        if (primaryTarget != null)
+            GoalZoneCombined(strategy, 25, Hints.GoalAOECone(primaryTarget.Actor, 12, 45.Degrees()), AID.QuickNock, minAoe: 2);
 
         var ijDelay = EffectApplicationDelay(AID.IronJaws);
 
@@ -149,7 +153,7 @@ public sealed class BRD(RotationModuleManager manager, Actor player) : Attackxan
         return (MathF.Min(wind, poison), wind, poison);
     }
 
-    private void OGCD(StrategyValues strategy, Actor? primaryTarget)
+    private void OGCD(StrategyValues strategy, Enemy? primaryTarget)
     {
         if (!Player.InCombat || primaryTarget == null)
             return;

--- a/BossMod/Autorotation/xan/Tanks/DRK.cs
+++ b/BossMod/Autorotation/xan/Tanks/DRK.cs
@@ -1,5 +1,6 @@
 ﻿using BossMod.DRK;
 using FFXIVClientStructs.FFXIV.Client.Game.Gauge;
+using static BossMod.AIHints;
 
 namespace BossMod.Autorotation.xan;
 public sealed class DRK(RotationModuleManager manager, Actor player) : Attackxan<AID, TraitID>(manager, player)
@@ -45,10 +46,10 @@ public sealed class DRK(RotationModuleManager manager, Actor player) : Attackxan
     public int NumRangedAOETargets;
     public int NumLineTargets;
 
-    private Actor? BestRangedAOETarget;
-    private Actor? BestLineTarget;
+    private Enemy? BestRangedAOETarget;
+    private Enemy? BestLineTarget;
 
-    public override void Exec(StrategyValues strategy, Actor? primaryTarget)
+    public override void Exec(StrategyValues strategy, Enemy? primaryTarget)
     {
         SelectPrimaryTarget(strategy, ref primaryTarget, 3);
 
@@ -73,7 +74,7 @@ public sealed class DRK(RotationModuleManager manager, Actor player) : Attackxan
         if (CountdownRemaining > 0)
             return;
 
-        GoalZoneCombined(3, Hints.GoalAOECircle(5), 3);
+        GoalZoneCombined(strategy, 3, Hints.GoalAOECircle(5), AID.Unleash, 3, maximumActionRange: 20);
 
         if (Darkside > GCD)
         {
@@ -138,7 +139,7 @@ public sealed class DRK(RotationModuleManager manager, Actor player) : Attackxan
         EdgeRefresh = 900,
     }
 
-    private void OGCD(StrategyValues strategy, Actor? primaryTarget)
+    private void OGCD(StrategyValues strategy, Enemy? primaryTarget)
     {
         if (primaryTarget == null || !Player.InCombat)
             return;
@@ -190,7 +191,7 @@ public sealed class DRK(RotationModuleManager manager, Actor player) : Attackxan
         return Blood + (impendingBlood ? 20 : 0) > 100;
     }
 
-    private void Edge(StrategyValues strategy, Actor? primaryTarget)
+    private void Edge(StrategyValues strategy, Enemy? primaryTarget)
     {
         var canUse = MP >= 3000 || DarkArts;
         var canUseTBN = MP >= 6000 || DarkArts || !Unlocked(AID.TheBlackestNight);

--- a/BossMod/Autorotation/xan/Tanks/GNB.cs
+++ b/BossMod/Autorotation/xan/Tanks/GNB.cs
@@ -20,7 +20,6 @@ public sealed class GNB(RotationModuleManager manager, Actor player) : Attackxan
     public float Reign;
 
     public float SonicBreak;
-    public AID Continuation;
     public float NoMercy;
 
     public int NumAOETargets;
@@ -41,7 +40,6 @@ public sealed class GNB(RotationModuleManager manager, Actor player) : Attackxan
 
         Reign = StatusLeft(SID.ReadyToReign);
         SonicBreak = StatusLeft(SID.ReadyToBreak);
-        Continuation = GetContinuation();
         NoMercy = StatusLeft(SID.NoMercy);
 
         NumAOETargets = NumMeleeAOETargets(strategy);
@@ -162,25 +160,28 @@ public sealed class GNB(RotationModuleManager manager, Actor player) : Attackxan
             PushOGCD(AID.NoMercy, Player, delay: GCD - 0.8f);
     }
 
-    private AID GetContinuation()
+    private AID Continuation
     {
-        foreach (var s in Player.Statuses)
+        get
         {
-            switch ((SID)s.ID)
+            foreach (var s in Player.Statuses)
             {
-                case SID.ReadyToBlast:
-                    return AID.Hypervelocity;
-                case SID.ReadyToRaze:
-                    return AID.FatedBrand;
-                case SID.ReadyToRip:
-                    return AID.JugularRip;
-                case SID.ReadyToGouge:
-                    return AID.EyeGouge;
-                case SID.ReadyToTear:
-                    return AID.AbdomenTear;
+                switch ((SID)s.ID)
+                {
+                    case SID.ReadyToBlast:
+                        return AID.Hypervelocity;
+                    case SID.ReadyToRaze:
+                        return AID.FatedBrand;
+                    case SID.ReadyToRip:
+                        return AID.JugularRip;
+                    case SID.ReadyToGouge:
+                        return AID.EyeGouge;
+                    case SID.ReadyToTear:
+                        return AID.AbdomenTear;
+                }
             }
-        }
 
-        return AID.None;
+            return AID.None;
+        }
     }
 }

--- a/BossMod/Autorotation/xan/Tanks/GNB.cs
+++ b/BossMod/Autorotation/xan/Tanks/GNB.cs
@@ -1,5 +1,6 @@
 ﻿using BossMod.GNB;
 using FFXIVClientStructs.FFXIV.Client.Game.Gauge;
+using static BossMod.AIHints;
 
 namespace BossMod.Autorotation.xan;
 
@@ -19,18 +20,18 @@ public sealed class GNB(RotationModuleManager manager, Actor player) : Attackxan
     public float Reign;
 
     public float SonicBreak;
-    public bool Continuation;
+    public AID Continuation;
     public float NoMercy;
 
     public int NumAOETargets;
     public int NumReignTargets;
 
-    private Actor? BestReignTarget;
+    private Enemy? BestReignTarget;
 
     public bool FastGCD => GCDLength <= 2.47f;
     public int MaxAmmo => Unlocked(TraitID.CartridgeChargeII) ? 3 : 2;
 
-    public override void Exec(StrategyValues strategy, Actor? primaryTarget)
+    public override void Exec(StrategyValues strategy, Enemy? primaryTarget)
     {
         SelectPrimaryTarget(strategy, ref primaryTarget, 3);
 
@@ -40,7 +41,7 @@ public sealed class GNB(RotationModuleManager manager, Actor player) : Attackxan
 
         Reign = StatusLeft(SID.ReadyToReign);
         SonicBreak = StatusLeft(SID.ReadyToBreak);
-        Continuation = Player.Statuses.Any(s => IsContinuationStatus((SID)s.ID));
+        Continuation = GetContinuation();
         NoMercy = StatusLeft(SID.NoMercy);
 
         NumAOETargets = NumMeleeAOETargets(strategy);
@@ -51,7 +52,7 @@ public sealed class GNB(RotationModuleManager manager, Actor player) : Attackxan
         if (CountdownRemaining > 0)
             return;
 
-        GoalZoneCombined(3, Hints.GoalAOECircle(5), Unlocked(AID.FatedCircle) && Ammo > 0 ? 2 : 3);
+        GoalZoneCombined(strategy, 3, Hints.GoalAOECircle(5), AID.DemonSlice, Unlocked(AID.FatedCircle) && Ammo > 0 ? 2 : 3, maximumActionRange: 20);
 
         if (ReadyIn(AID.NoMercy) > 20 && Ammo > 0)
             PushGCD(AID.GnashingFang, primaryTarget);
@@ -127,13 +128,12 @@ public sealed class GNB(RotationModuleManager manager, Actor player) : Attackxan
         return ComboLastMove is AID.BrutalShell or AID.DemonSlice && Ammo == MaxAmmo;
     }
 
-    private void CalcNextBestOGCD(StrategyValues strategy, Actor? primaryTarget)
+    private void CalcNextBestOGCD(StrategyValues strategy, Enemy? primaryTarget)
     {
         if (!Player.InCombat || primaryTarget == null)
             return;
 
-        if (Continuation)
-            PushOGCD(AID.Continuation, primaryTarget);
+        PushOGCD(Continuation, primaryTarget);
 
         if (strategy.BuffsOk() && Unlocked(AID.Bloodfest) && Ammo == 0)
             PushOGCD(AID.Bloodfest, primaryTarget);
@@ -162,5 +162,25 @@ public sealed class GNB(RotationModuleManager manager, Actor player) : Attackxan
             PushOGCD(AID.NoMercy, Player, delay: GCD - 0.8f);
     }
 
-    private bool IsContinuationStatus(SID sid) => sid is SID.ReadyToBlast or SID.ReadyToRaze or SID.ReadyToGouge or SID.ReadyToTear or SID.ReadyToRip;
+    private AID GetContinuation()
+    {
+        foreach (var s in Player.Statuses)
+        {
+            switch ((SID)s.ID)
+            {
+                case SID.ReadyToBlast:
+                    return AID.Hypervelocity;
+                case SID.ReadyToRaze:
+                    return AID.FatedBrand;
+                case SID.ReadyToRip:
+                    return AID.JugularRip;
+                case SID.ReadyToGouge:
+                    return AID.EyeGouge;
+                case SID.ReadyToTear:
+                    return AID.AbdomenTear;
+            }
+        }
+
+        return AID.None;
+    }
 }

--- a/BossMod/BossModule/AIHints.cs
+++ b/BossMod/BossModule/AIHints.cs
@@ -204,7 +204,7 @@ public sealed class AIHints
         var effRsq = radius * radius;
         return p => (p - target).LengthSq() <= effRsq ? weight : 0;
     }
-    public Func<WPos, float> GoalSingleTarget(Actor target, float range) => GoalSingleTarget(target.Position, range + target.HitboxRadius + 0.5f);
+    public Func<WPos, float> GoalSingleTarget(Actor target, float range, float weight = 1) => GoalSingleTarget(target.Position, range + target.HitboxRadius + 0.5f, weight);
 
     // simple goal zone that returns 1 if target is in range (usually melee), 2 if it's also in correct positional
     public Func<WPos, float> GoalSingleTarget(WPos target, Angle rotation, Positional positional, float radius)

--- a/BossMod/BossModule/RaidCooldowns.cs
+++ b/BossMod/BossModule/RaidCooldowns.cs
@@ -39,10 +39,10 @@ public sealed class RaidCooldowns : IDisposable
     }
 
     // TODO: why do we need two versions?..
-    public float NextDamageBuffIn2()
+    public float? NextDamageBuffIn2()
     {
         if (_damageCooldowns.Count == 0)
-            return float.MaxValue;
+            return null;
 
         var firstAvailable = _damageCooldowns.Select(e => e.AvailableAt).Min();
         return MathF.Min(float.MaxValue, (float)(firstAvailable - _ws.CurrentTime).TotalSeconds);

--- a/BossMod/Data/Actor.cs
+++ b/BossMod/Data/Actor.cs
@@ -1,4 +1,6 @@
-﻿namespace BossMod;
+﻿using static BossMod.AIHints;
+
+namespace BossMod;
 
 // objkind << 8 + objsubkind
 public enum ActorType : ushort
@@ -130,6 +132,7 @@ public sealed class Actor(ulong instanceID, uint oid, int spawnIndex, string nam
     public int PredictedMPRaw => (int)HPMP.CurMP + PendingMPDiffence;
     public int PredictedHPClamped => Math.Clamp(PredictedHPRaw, 0, (int)HPMP.MaxHP);
     public bool PredictedDead => PredictedHPRaw <= 1 && !IsStrikingDummy;
+    public float PredictedHPRatio => (float)PredictedHPRaw / HPMP.MaxHP;
 
     // if expirationForPredicted is not null, search pending first, and return one if found; in that case only low byte of extra will be set
     public ActorStatus? FindStatus(uint sid, DateTime? expirationForPending = null)
@@ -163,6 +166,7 @@ public sealed class Actor(ulong instanceID, uint oid, int spawnIndex, string nam
     public Angle AngleTo(Actor other) => Angle.FromDirection(other.Position - Position);
 
     public float DistanceToHitbox(Actor? other) => other == null ? float.MaxValue : (other.Position - Position).Length() - other.HitboxRadius - HitboxRadius;
+    public float DistanceToHitbox(Enemy? other) => DistanceToHitbox(other?.Actor);
 
     public override string ToString() => $"{OID:X} '{Name}' <{InstanceID:X}>";
 }


### PR DESCRIPTION
This changes the `Exec` function to take an Enemy instead of an Actor. i also added a bunch of convenience methods in the codebase to match existing ones that take an Actor as an argument

there are also a ton of rotation improvements, notably in monk, though PLD gets some new CD tracks