### PR TITLE
Add DD to WorldState, pomanders and magicite to ActionID

### DIFF
--- a/BossMod/ActionQueue/ActionDefinition.cs
+++ b/BossMod/ActionQueue/ActionDefinition.cs
@@ -197,6 +197,27 @@ public sealed class ActionDefinitions : IDisposable
         // bozja actions
         for (var i = BozjaHolsterID.None + 1; i < BozjaHolsterID.Count; ++i)
             RegisterBozja(i);
+
+        // pomanders
+        for (var i = PomanderID.Safety; i < PomanderID.Count; ++i)
+        {
+            var pid = new ActionID(ActionType.Pomander, (uint)i);
+            _definitions[pid] = new(pid)
+            {
+                InstantAnimLock = 2.1f,
+                AllowedTargets = ActionTargets.Self
+            };
+        }
+
+        for (var i = 1u; i <= 3; i++)
+        {
+            var mid = new ActionID(ActionType.Magicite, i);
+            _definitions[mid] = new(mid)
+            {
+                InstantAnimLock = 2.1f,
+                AllowedTargets = ActionTargets.Self
+            };
+        }
     }
 
     public void Dispose()

--- a/BossMod/Data/ActionID.cs
+++ b/BossMod/Data/ActionID.cs
@@ -25,6 +25,8 @@ public enum ActionType : byte
     // below are custom additions, these aren't proper actions from game's point of view, but it makes sense for us to treat them as such
     BozjaHolsterSlot0 = 0xE0, // id = BozjaHolsterID, use from holster to replace duty action 0
     BozjaHolsterSlot1 = 0xE1, // id = BozjaHolsterID, use from holster to replace duty action 1
+    Pomander = 0xE2, // id = PomanderID
+    Magicite = 0xE3, // id = slot (1-3)
 }
 
 public enum Positional { Any, Flank, Rear, Front }

--- a/BossMod/Data/DeepDungeonState.cs
+++ b/BossMod/Data/DeepDungeonState.cs
@@ -1,0 +1,180 @@
+﻿using static FFXIVClientStructs.FFXIV.Client.Game.InstanceContent.InstanceContentDeepDungeon;
+
+namespace BossMod;
+
+public sealed class DeepDungeonState
+{
+    public DungeonProgress Progress;
+    public byte DungeonId;
+    public RoomFlags[] MapData = new RoomFlags[25];
+    public PartyMember[] Party = new PartyMember[4];
+    public Item[] Items = new Item[16];
+    public Chest[] Chests = new Chest[16];
+    public byte[] Magicite = new byte[3];
+
+    public enum DungeonType : byte
+    {
+        None = 0,
+        POTD = 1,
+        HOH = 2,
+        EO = 3
+    }
+
+    public DungeonType Type => (DungeonType)DungeonId;
+
+    public record struct DungeonProgress(byte Floor, byte Tileset, byte WeaponLevel, byte ArmorLevel, byte SyncedGearLevel, byte HoardCount, byte ReturnProgress, byte PassageProgress)
+    {
+        public readonly bool IsBossFloor => Floor % 10 == 0;
+    }
+    public record struct PartyMember(ulong EntityId, byte Room);
+    public record struct Item(byte Count, byte Flags)
+    {
+        public readonly bool Usable => (Flags & (1 << 0)) != 0;
+        public readonly bool Active => (Flags & (1 << 1)) != 0;
+    }
+    public record struct Chest(byte Type, byte Room);
+
+    public Item GetItem(PomanderID pid) => GetSlotForPomander(pid) is var s && s >= 0 ? Items[s] : default;
+
+    public int GetSlotForPomander(PomanderID pid) => Service.LuminaRow<Lumina.Excel.Sheets.DeepDungeon>(DungeonId)!.Value.PomanderSlot.ToList().FindIndex(p => p.RowId == (uint)pid);
+    public PomanderID GetPomanderForSlot(int slot)
+    {
+        var slots = Service.LuminaRow<Lumina.Excel.Sheets.DeepDungeon>(DungeonId)!.Value.PomanderSlot;
+        return slot >= 0 && slot < slots.Count ? (PomanderID)slots[slot].RowId : PomanderID.None;
+    }
+
+    public bool ReturnActive => Progress.ReturnProgress >= 11;
+    public bool PassageActive => Progress.PassageProgress >= 11;
+    public byte Floor => Progress.Floor;
+
+    public IEnumerable<WorldState.Operation> CompareToInitial()
+    {
+        if (Progress != default || DungeonId != 0)
+            yield return new OpProgressChange(DungeonId, Progress);
+
+        if (MapData.Any(m => m > 0))
+            yield return new OpMapDataChange(MapData);
+
+        if (Party.Any(p => p != default))
+            yield return new OpPartyStateChange(Party);
+
+        if (Items.Any(i => i != default))
+            yield return new OpItemsChange(Items);
+
+        if (Chests.Any(c => c != default))
+            yield return new OpChestsChange(Chests);
+
+        if (Magicite.Any(c => c > 0))
+            yield return new OpMagiciteChange(Magicite);
+    }
+
+    public Event<OpProgressChange> ProgressChanged = new();
+    public sealed record class OpProgressChange(byte DungeonId, DungeonProgress Value) : WorldState.Operation
+    {
+        protected override void Exec(WorldState ws)
+        {
+            ws.DeepDungeon.DungeonId = DungeonId;
+            ws.DeepDungeon.Progress = Value;
+            ws.DeepDungeon.ProgressChanged.Fire(this);
+        }
+        public override void Write(ReplayRecorder.Output output)
+        {
+            output.EmitFourCC("DDPG"u8)
+                .Emit(DungeonId)
+                .Emit(Value.Floor)
+                .Emit(Value.Tileset)
+                .Emit(Value.WeaponLevel)
+                .Emit(Value.ArmorLevel)
+                .Emit(Value.SyncedGearLevel)
+                .Emit(Value.HoardCount)
+                .Emit(Value.ReturnProgress)
+                .Emit(Value.PassageProgress);
+        }
+    }
+
+    public Event<OpMapDataChange> MapDataChanged = new();
+    public sealed record class OpMapDataChange(RoomFlags[] Value) : WorldState.Operation
+    {
+        public readonly RoomFlags[] Value = Value;
+
+        protected override void Exec(WorldState ws)
+        {
+            ws.DeepDungeon.MapData = Value;
+            ws.DeepDungeon.MapDataChanged.Fire(this);
+        }
+        public override void Write(ReplayRecorder.Output output)
+        {
+            output.EmitFourCC("DDMP"u8).Emit(Array.ConvertAll(Value, r => (byte)r));
+        }
+    }
+
+    public Event<OpPartyStateChange> PartyStateChanged = new();
+    public sealed record class OpPartyStateChange(PartyMember[] Value) : WorldState.Operation
+    {
+        public readonly PartyMember[] Value = Value;
+
+        protected override void Exec(WorldState ws)
+        {
+            ws.DeepDungeon.Party = Value;
+            ws.DeepDungeon.PartyStateChanged.Fire(this);
+        }
+        public override void Write(ReplayRecorder.Output output)
+        {
+            output.EmitFourCC("DDPT"u8);
+            foreach (var member in Value)
+                output.EmitActor(member.EntityId).Emit(member.Room);
+        }
+    }
+
+    public Event<OpItemsChange> ItemsChanged = new();
+    public sealed record class OpItemsChange(Item[] Value) : WorldState.Operation
+    {
+        public readonly Item[] Value = Value;
+
+        protected override void Exec(WorldState ws)
+        {
+            ws.DeepDungeon.Items = Value;
+            ws.DeepDungeon.ItemsChanged.Fire(this);
+        }
+        public override void Write(ReplayRecorder.Output output)
+        {
+            output.EmitFourCC("DDIT"u8);
+            foreach (var item in Value)
+                output.Emit(item.Count).Emit(item.Flags, "X");
+        }
+    }
+
+    public Event<OpChestsChange> ChestsChanged = new();
+    public sealed record class OpChestsChange(Chest[] Value) : WorldState.Operation
+    {
+        public readonly Chest[] Value = Value;
+
+        protected override void Exec(WorldState ws)
+        {
+            ws.DeepDungeon.Chests = Value;
+            ws.DeepDungeon.ChestsChanged.Fire(this);
+        }
+        public override void Write(ReplayRecorder.Output output)
+        {
+            output.EmitFourCC("DDCT"u8);
+            foreach (var chest in Value)
+                output.Emit(chest.Type).Emit(chest.Room);
+        }
+    }
+
+    public Event<OpMagiciteChange> MagiciteChanged = new();
+    public sealed record class OpMagiciteChange(byte[] Value) : WorldState.Operation
+    {
+        public readonly byte[] Value = Value;
+
+        protected override void Exec(WorldState ws)
+        {
+            ws.DeepDungeon.Magicite = Value;
+            ws.DeepDungeon.MagiciteChanged.Fire(this);
+        }
+        public override void Write(ReplayRecorder.Output output)
+        {
+            output.EmitFourCC("DDMG"u8).Emit(Value);
+        }
+    }
+}

--- a/BossMod/Data/PomanderID.cs
+++ b/BossMod/Data/PomanderID.cs
@@ -1,0 +1,48 @@
+﻿namespace BossMod;
+
+public enum PomanderID : uint
+{
+    None,
+
+    // Pomanders - PotD/HoH
+    Safety,
+    Sight,
+    Strength,
+    Steel,
+    Affluence,
+    Flight,
+    Alteration,
+    Purity,
+    Fortune,
+    Witching,
+    Serenity,
+    Rage, // palace only
+    Lust, // palace only
+    Intuition,
+    Raising,
+    Resolution, // palace only
+    Frailty, // HoH only
+    Concealment, // HoH only
+    Petrification, // HoH only
+
+    // Protomanders - EO
+    ProtoLethargy,
+    ProtoStorms,
+    ProtoDread,
+    ProtoSafety,
+    ProtoSight,
+    ProtoStrength,
+    ProtoSteel,
+    ProtoAffluence,
+    ProtoFlight,
+    ProtoAlteration,
+    ProtoPurity,
+    ProtoFortune,
+    ProtoWitching,
+    ProtoSerenity,
+    ProtoIntuition,
+    ProtoRaising,
+
+    Count
+}
+

--- a/BossMod/Data/WorldState.cs
+++ b/BossMod/Data/WorldState.cs
@@ -16,6 +16,7 @@ public sealed class WorldState
     public readonly ActorState Actors = new();
     public readonly PartyState Party;
     public readonly ClientState Client = new();
+    public readonly DeepDungeonState DeepDungeon = new();
     public readonly NetworkState Network = new();
 
     public DateTime CurrentTime => Frame.Timestamp;
@@ -68,6 +69,8 @@ public sealed class WorldState
         foreach (var o in Client.CompareToInitial())
             yield return o;
         foreach (var o in Network.CompareToInitial())
+            yield return o;
+        foreach (var o in DeepDungeon.CompareToInitial())
             yield return o;
     }
 

--- a/BossMod/Replay/ReplayParserLog.cs
+++ b/BossMod/Replay/ReplayParserLog.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using FFXIVClientStructs.FFXIV.Client.Game.InstanceContent;
+using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Threading;
@@ -340,6 +341,12 @@ public sealed class ReplayParserLog : IDisposable
             [new("CLAF"u8)] = ParseClientActiveFate,
             [new("CPET"u8)] = ParseClientActivePet,
             [new("CLFT"u8)] = ParseClientFocusTarget,
+            [new("DDPG"u8)] = ParseDeepDungeonProgress,
+            [new("DDMP"u8)] = ParseDeepDungeonMap,
+            [new("DDPT"u8)] = ParseDeepDungeonParty,
+            [new("DDIT"u8)] = ParseDeepDungeonItems,
+            [new("DDCT"u8)] = ParseDeepDungeonChests,
+            [new("DDMG"u8)] = ParseDeepDungeonMagicite,
             [new("IPCI"u8)] = ParseNetworkIDScramble,
             [new("IPCS"u8)] = ParseNetworkServerIPC,
         };
@@ -685,6 +692,44 @@ public sealed class ReplayParserLog : IDisposable
     private ClientState.OpActiveFateChange ParseClientActiveFate() => new(new(_input.ReadUInt(false), _input.ReadVec3(), _input.ReadFloat()));
     private ClientState.OpActivePetChange ParseClientActivePet() => new(new(_input.ReadULong(true), _input.ReadByte(false), _input.ReadByte(false)));
     private ClientState.OpFocusTargetChange ParseClientFocusTarget() => new(_input.ReadULong(true));
+
+    private DeepDungeonState.OpProgressChange ParseDeepDungeonProgress() => new(_input.ReadByte(false), new DeepDungeonState.DungeonProgress(_input.ReadByte(false), _input.ReadByte(false), _input.ReadByte(false), _input.ReadByte(false), _input.ReadByte(false), _input.ReadByte(false), _input.ReadByte(false), _input.ReadByte(false)));
+    private DeepDungeonState.OpMapDataChange ParseDeepDungeonMap() => new(Array.ConvertAll(_input.ReadBytes(), b => (InstanceContentDeepDungeon.RoomFlags)b));
+    private DeepDungeonState.OpPartyStateChange ParseDeepDungeonParty()
+    {
+        var pt = new DeepDungeonState.PartyMember[4];
+        for (var i = 0; i < pt.Length; i++)
+        {
+            ref var p = ref pt[i];
+            p.EntityId = _input.ReadActorID();
+            p.Room = _input.ReadByte(false);
+        }
+        return new(pt);
+    }
+    private DeepDungeonState.OpItemsChange ParseDeepDungeonItems()
+    {
+        var it = new DeepDungeonState.Item[16];
+        for (var i = 0; i < it.Length; i++)
+        {
+            ref var item = ref it[i];
+            item.Count = _input.ReadByte(false);
+            item.Flags = _input.ReadByte(true);
+        }
+        return new(it);
+    }
+    private DeepDungeonState.OpChestsChange ParseDeepDungeonChests()
+    {
+        var ct = new DeepDungeonState.Chest[16];
+        for (var i = 0; i < ct.Length; i++)
+        {
+            ref var chest = ref ct[i];
+            chest.Type = _input.ReadByte(false);
+            chest.Room = _input.ReadByte(false);
+        }
+        return new(ct);
+    }
+
+    private DeepDungeonState.OpMagiciteChange ParseDeepDungeonMagicite() => new(_input.ReadBytes());
 
     private NetworkState.OpIDScramble ParseNetworkIDScramble() => new(_input.ReadUInt(false));
     private NetworkState.OpServerIPC ParseNetworkServerIPC() => new(new((Network.ServerIPC.PacketID)_input.ReadInt(), _input.ReadUShort(false), _input.ReadUInt(false), _input.ReadUInt(true), new(_input.ReadLong()), _input.ReadBytes()));


### PR DESCRIPTION
I didn't add poms/magicite to actionqueue yet but it doesn't really matter since no modules will be using them. I had a concern about HandleActionRequest but it looks like we're ok with just directly calling it after we call the original function, same as UseBozjaFromHolsterDirectorDetour