### PR TITLE
Add thickness scale

### DIFF
--- a/BossMod/BossModule/BossModuleConfig.cs
+++ b/BossMod/BossModule/BossModuleConfig.cs
@@ -33,6 +33,10 @@ public class BossModuleConfig : ConfigNode
     [PropertySlider(0.1f, 10, Speed = 0.1f, Logarithmic = true)]
     public float ArenaScale = 1;
 
+    [PropertyDisplay("Radar element thickness scale factor", tooltip: "Globally scales the outline thickness of radar elements")]
+    [PropertySlider(0.1f, 10, Speed = 0.1f, Logarithmic = true)]
+    public float ThicknessScale = 1;
+
     [PropertyDisplay("Rotate radar to match camera orientation")]
     public bool RotateArena = true;
 

--- a/BossMod/BossModule/MiniArena.cs
+++ b/BossMod/BossModule/MiniArena.cs
@@ -116,11 +116,13 @@ public sealed class MiniArena(BossModuleConfig config, WPos center, ArenaBounds 
     // unclipped primitive rendering that accept world-space positions; thin convenience wrappers around drawlist api
     public void AddLine(WPos a, WPos b, uint color, float thickness = 1)
     {
+        thickness *= Config.ThicknessScale;
         ImGui.GetWindowDrawList().AddLine(WorldPositionToScreenPosition(a), WorldPositionToScreenPosition(b), color != 0 ? color : ArenaColor.Danger, thickness);
     }
 
     public void AddTriangle(WPos p1, WPos p2, WPos p3, uint color, float thickness = 1)
     {
+        thickness *= Config.ThicknessScale;
         ImGui.GetWindowDrawList().AddTriangle(WorldPositionToScreenPosition(p1), WorldPositionToScreenPosition(p2), WorldPositionToScreenPosition(p3), color != 0 ? color : ArenaColor.Danger, thickness);
     }
 
@@ -131,6 +133,7 @@ public sealed class MiniArena(BossModuleConfig config, WPos center, ArenaBounds 
 
     public void AddQuad(WPos p1, WPos p2, WPos p3, WPos p4, uint color, float thickness = 1)
     {
+        thickness *= Config.ThicknessScale;
         ImGui.GetWindowDrawList().AddQuad(WorldPositionToScreenPosition(p1), WorldPositionToScreenPosition(p2), WorldPositionToScreenPosition(p3), WorldPositionToScreenPosition(p4), color != 0 ? color : ArenaColor.Danger, thickness);
     }
 
@@ -141,6 +144,7 @@ public sealed class MiniArena(BossModuleConfig config, WPos center, ArenaBounds 
 
     public void AddRect(WPos origin, WDir direction, float lenFront, float lenBack, float halfWidth, uint color, float thickness = 1)
     {
+        thickness *= Config.ThicknessScale;
         var side = halfWidth * direction.OrthoR();
         var front = origin + lenFront * direction;
         var back = origin - lenBack * direction;
@@ -149,6 +153,7 @@ public sealed class MiniArena(BossModuleConfig config, WPos center, ArenaBounds 
 
     public void AddCircle(WPos center, float radius, uint color, float thickness = 1)
     {
+        thickness *= Config.ThicknessScale;
         ImGui.GetWindowDrawList().AddCircle(WorldPositionToScreenPosition(center), radius / Bounds.Radius * ScreenHalfSize, color != 0 ? color : ArenaColor.Danger, 0, thickness);
     }
 
@@ -159,6 +164,7 @@ public sealed class MiniArena(BossModuleConfig config, WPos center, ArenaBounds 
 
     public void AddCone(WPos center, float radius, Angle centerDirection, Angle halfAngle, uint color, float thickness = 1)
     {
+        thickness *= Config.ThicknessScale;
         var sCenter = WorldPositionToScreenPosition(center);
         float sDir = MathF.PI / 2 - centerDirection.Rad + _cameraAzimuth.Rad;
         var drawlist = ImGui.GetWindowDrawList();
@@ -169,6 +175,7 @@ public sealed class MiniArena(BossModuleConfig config, WPos center, ArenaBounds 
 
     public void AddDonutCone(WPos center, float innerRadius, float outerRadius, Angle centerDirection, Angle halfAngle, uint color, float thickness = 1)
     {
+        thickness *= Config.ThicknessScale;
         var sCenter = WorldPositionToScreenPosition(center);
         float sDir = MathF.PI / 2 - centerDirection.Rad + _cameraAzimuth.Rad;
         var drawlist = ImGui.GetWindowDrawList();
@@ -179,6 +186,7 @@ public sealed class MiniArena(BossModuleConfig config, WPos center, ArenaBounds 
 
     public void AddPolygon(ReadOnlySpan<WPos> vertices, uint color, float thickness = 1)
     {
+        thickness *= Config.ThicknessScale;
         foreach (var p in vertices)
             PathLineTo(p);
         PathStroke(true, color != 0 ? color : ArenaColor.Danger, thickness);
@@ -186,6 +194,7 @@ public sealed class MiniArena(BossModuleConfig config, WPos center, ArenaBounds 
 
     public void AddPolygon(IEnumerable<WPos> vertices, uint color, float thickness = 1)
     {
+        thickness *= Config.ThicknessScale;
         foreach (var p in vertices)
             PathLineTo(p);
         PathStroke(true, color != 0 ? color : ArenaColor.Danger, thickness);
@@ -193,6 +202,7 @@ public sealed class MiniArena(BossModuleConfig config, WPos center, ArenaBounds 
 
     public void AddPolygonTransformed(WPos center, WDir rotation, ReadOnlySpan<WDir> vertices, uint color, float thickness = 1)
     {
+        thickness *= Config.ThicknessScale;
         foreach (var p in vertices)
             PathLineTo(center + p.Rotate(rotation));
         PathStroke(true, color != 0 ? color : ArenaColor.Danger, thickness);
@@ -200,6 +210,8 @@ public sealed class MiniArena(BossModuleConfig config, WPos center, ArenaBounds 
 
     public void AddComplexPolygon(WPos center, WDir rotation, RelSimplifiedComplexPolygon poly, uint color, float thickness = 1)
     {
+        thickness *= Config.ThicknessScale;
+
         foreach (var part in poly.Parts)
         {
             AddPolygonTransformed(center, rotation, part.Exterior, color, thickness);
@@ -222,6 +234,7 @@ public sealed class MiniArena(BossModuleConfig config, WPos center, ArenaBounds 
 
     public void PathStroke(bool closed, uint color, float thickness = 1)
     {
+        thickness *= Config.ThicknessScale;
         ImGui.GetWindowDrawList().PathStroke(color != 0 ? color : ArenaColor.Danger, closed ? ImDrawFlags.Closed : ImDrawFlags.None, thickness);
     }
 


### PR DESCRIPTION
This PR adds a configurable thickness scale for non-filled elements and lines on the radar.
My primary display is very high resolution, so a lot of things were difficult to read due to the the thickness being so thin, relatively.
It may also be worth scaling using the DPI scale, but this probably works just as well.

There may also be a better way to implement this, but I am not super savvy with c#!