### PR TITLE
fixes/adjustments

### DIFF
--- a/BossMod/Autorotation/Standard/akechi/AkechiTools.cs
+++ b/BossMod/Autorotation/Standard/akechi/AkechiTools.cs
@@ -735,6 +735,9 @@ public abstract class AkechiTools<AID, TraitID>(RotationModuleManager manager, A
 
     /// <summary>Player's <b>actual</b> target; guaranteed to be an enemy.</summary>
     protected Enemy? PlayerTarget { get; private set; }
+
+    /// <summary>Checks if Player is in an <b>odd minute window</b> by checking job's specified <b>120s ability</b> explicitly.</summary>
+    protected bool InOddWindow(AID aid) => TotalCD(aid) is < 90 and > 30;
     #endregion
 
     #region Shared Abilities

--- a/BossMod/Autorotation/Standard/akechi/AkechiTools.cs
+++ b/BossMod/Autorotation/Standard/akechi/AkechiTools.cs
@@ -498,6 +498,9 @@ public abstract class AkechiTools<AID, TraitID>(RotationModuleManager manager, A
     /// <param name="maxDistance">The maximum distance threshold.</param>
     protected bool InRange(Actor? target, float maxDistance) => Player.DistanceToHitbox(target) <= maxDistance - 0.01f;
 
+    /// <summary>Checks if target is within the Melee-range distance in <b>yalms</b>.</summary>
+    protected bool InMeleeRange(Actor? target) => InRange(target, 3.5f);
+
     /// <summary>Checks if the target is within <b>0-yalm</b> range.</summary>
     protected bool In0y(Actor? target) => InRange(target, 0.01f);
 

--- a/BossMod/Autorotation/Standard/akechi/AkechiTools.cs
+++ b/BossMod/Autorotation/Standard/akechi/AkechiTools.cs
@@ -534,14 +534,16 @@ public abstract class AkechiTools<AID, TraitID>(RotationModuleManager manager, A
     /// <param name="strategy">The user's selected <b>strategy</b>.</param>
     /// <param name="primaryTarget">The user's current <b>target</b>.</param>
     /// <param name="range">The <b>max range</b> to consider a new target.</param>
-    protected void GetPvETarget(StrategyValues strategy, ref Enemy? primaryTarget, float range)
+    protected void GetNextTarget(StrategyValues strategy, ref Enemy? primaryTarget, float range)
     {
         if (primaryTarget?.Actor == null || Player.DistanceToHitbox(primaryTarget.Actor) > range)
         {
             var AOEStrat = strategy.Option(SharedTrack.AOE).As<AOEStrategy>();
             if (AOEStrat is AOEStrategy.AutoFinish or AOEStrategy.AutoBreak)
             {
-                primaryTarget = Hints.PriorityTargets.FirstOrDefault(x => Player.DistanceToHitbox(x.Actor) <= range);
+                var newTarget = Hints.PriorityTargets.FirstOrDefault(x => Player.DistanceToHitbox(x.Actor) <= range);
+                if (newTarget != null)
+                    primaryTarget = newTarget;
             }
         }
     }

--- a/BossMod/Autorotation/Standard/akechi/AkechiTools.cs
+++ b/BossMod/Autorotation/Standard/akechi/AkechiTools.cs
@@ -655,11 +655,11 @@ public abstract class AkechiTools<AID, TraitID>(RotationModuleManager manager, A
 
     /// <summary>Checks if player is on specified target's <b>Rear Positional</b>.</summary>
     /// <param name="target">The user's specified <b>Target</b> being checked.</param>
-    protected bool IsOnRear(Actor target) => GetCurrentPositional(target) == Positional.Rear;
+    protected bool IsOnRear(Actor target) => In5y(target) && GetCurrentPositional(target) == Positional.Rear;
 
     /// <summary>Checks if player is on specified target's <b>Flank Positional</b>.</summary>
     /// <param name="target">The user's specified <b>Target</b> being checked.</param>
-    protected bool IsOnFlank(Actor target) => GetCurrentPositional(target) == Positional.Flank;
+    protected bool IsOnFlank(Actor target) => In5y(target) && GetCurrentPositional(target) == Positional.Flank;
     #endregion
 
     #region AI

--- a/BossMod/Autorotation/Standard/akechi/AkechiTools.cs
+++ b/BossMod/Autorotation/Standard/akechi/AkechiTools.cs
@@ -891,8 +891,8 @@ static class ModuleExtensions
         return res.Define(SharedTrack.AOE).As<AOEStrategy>("AOE", uiPriority: 300)
             .AddOption(AOEStrategy.AutoFinish, "Auto (Finish combo)", "Automatically execute optimal rotation based on targets; finishes combo if possible", supportedTargets: ActionTargets.Hostile)
             .AddOption(AOEStrategy.AutoBreak, "Auto (Break combo)", "Automatically execute optimal rotation based on targets; breaks combo if necessary", supportedTargets: ActionTargets.Hostile)
-            .AddOption(AOEStrategy.ForceST, "ForceST", "Force-execute Single Target", supportedTargets: ActionTargets.Hostile)
-            .AddOption(AOEStrategy.ForceAOE, "ForceAOE", "Force-execute AOE rotation", supportedTargets: ActionTargets.Hostile | ActionTargets.Self);
+            .AddOption(AOEStrategy.ForceST, "ForceST", "Force Single-Target rotation execution", supportedTargets: ActionTargets.Hostile)
+            .AddOption(AOEStrategy.ForceAOE, "ForceAOE", "Force AOE rotation execution", supportedTargets: ActionTargets.Hostile | ActionTargets.Self);
     }
 
     /// <summary>Defines our shared <b>Hold</b> strategies.</summary>

--- a/BossMod/Autorotation/Standard/akechi/AkechiTools.cs
+++ b/BossMod/Autorotation/Standard/akechi/AkechiTools.cs
@@ -775,6 +775,25 @@ public abstract class AkechiTools<AID, TraitID>(RotationModuleManager manager, A
 
     /// <summary>Checks if player is inside combat and has a primary target.</summary>
     protected bool InsideCombatWith(Actor? target) => Player.InCombat && target != null;
+
+    //TODO: new stuff
+    /*
+    protected DateTime? movementStartTime;
+    protected void HandleMovement()
+    {
+        if (IsMoving)
+        {
+            if (movementStartTime == null)
+                movementStartTime = DateTime.Now;
+            if (movementStartTime.HasValue && (DateTime.Now - movementStartTime.Value).TotalSeconds >= 1)
+                movementStartTime = null;
+        }
+        else
+        {
+            movementStartTime = null;
+        }
+    }
+    */
     #endregion
 
     #region Shared Abilities

--- a/BossMod/Autorotation/Standard/akechi/AkechiTools.cs
+++ b/BossMod/Autorotation/Standard/akechi/AkechiTools.cs
@@ -674,13 +674,13 @@ public abstract class AkechiTools<AID, TraitID>(RotationModuleManager manager, A
     /// <param name="imm">The next incoming positional for User (Front, Flank, or Rear)</param>
     protected void UpdatePositionals(Enemy? enemy, ref (Positional pos, bool imm) positional)
     {
-        var trueNorth = HasTrueNorth;
+        var tn = HasTrueNorth;
         var target = enemy?.Actor;
         if ((target?.Omnidirectional ?? true) || target?.TargetID == Player.InstanceID && target?.CastInfo == null && positional.pos != Positional.Front && target?.NameID != 541)
             positional = (Positional.Any, false);
 
-        NextPositionalImminent = !trueNorth && positional.imm;
-        NextPositionalCorrect = trueNorth || target == null || positional.pos switch
+        NextPositionalImminent = !tn && positional.imm;
+        NextPositionalCorrect = tn || target == null || positional.pos switch
         {
             Positional.Flank => MathF.Abs(target.Rotation.ToDirection().Dot((Player.Position - target.Position).Normalized())) < 0.7071067f,
             Positional.Rear => target.Rotation.ToDirection().Dot((Player.Position - target.Position).Normalized()) < -0.7071068f,

--- a/BossMod/Autorotation/Standard/akechi/AkechiTools.cs
+++ b/BossMod/Autorotation/Standard/akechi/AkechiTools.cs
@@ -332,7 +332,6 @@ public abstract class AkechiTools<AID, TraitID>(RotationModuleManager manager, A
 
     /// <summary>Checks if Player is in an <b>odd minute window</b> by checking job's specified <b>120s ability</b> explicitly.</summary>
     protected bool InOddWindow(AID aid) => TotalCD(aid) is < 90 and > 30;
-
     #endregion
 
     #region Cooldown

--- a/BossMod/Autorotation/Standard/akechi/AkechiTools.cs
+++ b/BossMod/Autorotation/Standard/akechi/AkechiTools.cs
@@ -329,6 +329,10 @@ public abstract class AkechiTools<AID, TraitID>(RotationModuleManager manager, A
 
     /// <summary>Checks if user can <b>Quarter Weave in</b> any <b>abilities</b>.</summary>
     protected bool CanQuarterWeaveIn => GCD is < 1f and >= 0.6f;
+
+    /// <summary>Checks if Player is in an <b>odd minute window</b> by checking job's specified <b>120s ability</b> explicitly.</summary>
+    protected bool InOddWindow(AID aid) => TotalCD(aid) is < 90 and > 30;
+
     #endregion
 
     #region Cooldown
@@ -698,7 +702,7 @@ public abstract class AkechiTools<AID, TraitID>(RotationModuleManager manager, A
     }
 
     /// <summary>Defines a goal-zone using a combined strategy, factoring in AOE considerations.</summary>
-    /// <param name="strategy">The strategy values that influence the goal zone logic.</param>
+    /// <param name="strategy">The strategy that influences the goal zone logic.</param>
     /// <param name="range">The base range for the goal zone.</param>
     /// <param name="fAoe">A function determining the area of effect.</param>
     /// <param name="firstUnlockedAoeAction">The first available AOE action.</param>
@@ -766,9 +770,7 @@ public abstract class AkechiTools<AID, TraitID>(RotationModuleManager manager, A
     /// <summary>Player's <b>actual</b> target; guaranteed to be an enemy.</summary>
     protected Enemy? PlayerTarget { get; private set; }
 
-    /// <summary>Checks if Player is in an <b>odd minute window</b> by checking job's specified <b>120s ability</b> explicitly.</summary>
-    protected bool InOddWindow(AID aid) => TotalCD(aid) is < 90 and > 30;
-
+    /// <summary>Checks if player is inside combat and has a primary target.</summary>
     protected bool InsideCombatWith(Actor? target) => Player.InCombat && target != null;
     #endregion
 

--- a/BossMod/Autorotation/Standard/akechi/AkechiTools.cs
+++ b/BossMod/Autorotation/Standard/akechi/AkechiTools.cs
@@ -738,6 +738,8 @@ public abstract class AkechiTools<AID, TraitID>(RotationModuleManager manager, A
 
     /// <summary>Checks if Player is in an <b>odd minute window</b> by checking job's specified <b>120s ability</b> explicitly.</summary>
     protected bool InOddWindow(AID aid) => TotalCD(aid) is < 90 and > 30;
+
+    protected bool InsideCombatWith(Actor? target) => Player.InCombat && target != null;
     #endregion
 
     #region Shared Abilities

--- a/BossMod/Autorotation/Standard/akechi/AkechiTools.cs
+++ b/BossMod/Autorotation/Standard/akechi/AkechiTools.cs
@@ -319,16 +319,16 @@ public abstract class AkechiTools<AID, TraitID>(RotationModuleManager manager, A
     protected bool IsFirstGCD() => !Player.InCombat || (World.CurrentTime - Manager.CombatStart).TotalSeconds < 0.1f;
 
     /// <summary>Checks if user can <b>Weave in</b> any <b>abilities</b>.</summary>
-    protected bool CanWeaveIn => GCD is <= 2.49f and >= 0.01f;
+    protected bool CanWeaveIn => GCD is <= 2.49f and >= 0.6f;
 
     /// <summary>Checks if user can <b>Early Weave in</b> any <b>abilities</b>.</summary>
     protected bool CanEarlyWeaveIn => GCD is <= 2.49f and >= 1.26f;
 
     /// <summary>Checks if user can <b>Late Weave in</b> any <b>abilities</b>.</summary>
-    protected bool CanLateWeaveIn => GCD is <= 1.25f and >= 0.01f;
+    protected bool CanLateWeaveIn => GCD is <= 1.25f and >= 0.6f;
 
     /// <summary>Checks if user can <b>Quarter Weave in</b> any <b>abilities</b>.</summary>
-    protected bool CanQuarterWeaveIn => GCD is < 0.9f and >= 0.01f;
+    protected bool CanQuarterWeaveIn => GCD is < 1f and >= 0.6f;
     #endregion
 
     #region Cooldown

--- a/BossMod/Autorotation/Standard/akechi/DPS/AkechiBLM.cs
+++ b/BossMod/Autorotation/Standard/akechi/DPS/AkechiBLM.cs
@@ -543,15 +543,16 @@ public sealed class AkechiBLM(RotationModuleManager manager, Actor player) : Ake
         {
             if (NoStance) //if no stance is active
             {
-                if (Unlocked(AID.Blizzard3) &&
-                    MP < 9600 &&
-                    Player.InCombat) //if Blizzard III is unlocked
-                    QueueGCD(AID.Blizzard3, target, NewGCDPriority.NeedB3); //Queue Blizzard III
-                if (Unlocked(AID.Fire3) &&
-                    (TotalCD(AID.Manafont) < 5 && TotalCD(AID.LeyLines) <= 121 && MP >= 10000 || !Player.InCombat && World.Client.CountdownRemaining <= 4)) //F3 opener
-                    QueueGCD(AID.Fire3, target, canOpen ? NewGCDPriority.Opener : NewGCDPriority.NeedB3);
+                if (Unlocked(AID.Blizzard3))
+                {
+                    if (MP < 9600 && Player.InCombat) //if Blizzard III is unlocked
+                        QueueGCD(AID.Blizzard3, target, NewGCDPriority.NeedB3); //Queue Blizzard III
+                    if (Unlocked(AID.Fire3) &&
+                        (TotalCD(AID.Manafont) < 5 && TotalCD(AID.LeyLines) <= 121 && MP >= 10000 || !Player.InCombat && World.Client.CountdownRemaining <= 4)) //F3 opener
+                        QueueGCD(AID.Fire3, target, canOpen ? NewGCDPriority.Opener : NewGCDPriority.NeedB3);
+                }
             }
-            if (Player.Level is >= 1 and <= 34)
+            if (Player.Level is >= 1 and <= 34 || !Unlocked(AID.Blizzard3))
             {
                 //Fire
                 if (Unlocked(AID.Fire1) && //if Fire is unlocked
@@ -569,7 +570,7 @@ public sealed class AkechiBLM(RotationModuleManager manager, Actor player) : Ake
                     QueueOGCD(AID.Transpose, Player, NewOGCDPriority.Transpose); //Queue Transpose
 
             }
-            if (Player.Level is >= 35 and <= 59)
+            if (Player.Level is >= 35 and <= 59 || (Unlocked(AID.Blizzard3) && !Unlocked(AID.Fire4)))
             {
                 if (InUmbralIce) //if Umbral Ice is active
                 {
@@ -603,7 +604,7 @@ public sealed class AkechiBLM(RotationModuleManager manager, Actor player) : Ake
                         QueueGCD(AID.Blizzard3, target, NewGCDPriority.SecondStep); //Queue Blizzard III
                 }
             }
-            if (Player.Level is >= 60 and <= 71)
+            if (Player.Level is >= 60 and <= 71 || (Unlocked(AID.Fire4) && !Unlocked(AID.Despair)))
             {
                 if (InUmbralIce) //if Umbral Ice is active
                 {

--- a/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
+++ b/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
@@ -641,15 +641,14 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
                     QueueOGCD(AID.RiseOfTheDragon, TargetChoice(rotd) ?? BestDiveTarget?.Actor, OGCDPrio(rotdStrat, OGCDPriority.BelowAverage));
                 if (ShouldUseStarcross(scStrat, primaryTarget?.Actor))
                     QueueOGCD(AID.Starcross, TargetChoice(sc) ?? BestDiveTarget?.Actor, OGCDPrio(scStrat, OGCDPriority.BelowAverage));
+                if (ShouldUseTrueNorth(strategy.Option(Track.TrueNorth).As<TrueNorthStrategy>(), primaryTarget?.Actor))
+                    QueueOGCD(AID.TrueNorth, Player, OGCDPriority.AboveAverage);
             }
             if (!strategy.HoldGauge())
             {
                 if (ShouldUseWyrmwindThrust(wtStrat, primaryTarget?.Actor))
                     QueueOGCD(AID.WyrmwindThrust, TargetChoice(wt) ?? BestSpearTarget?.Actor, wtStrat is OGCDStrategy.Force or OGCDStrategy.AnyWeave or OGCDStrategy.EarlyWeave or OGCDStrategy.LateWeave ? OGCDPriority.Forced : PlayerHasEffect(SID.LanceCharge) ? OGCDPriority.ModeratelyHigh : OGCDPriority.Average);
             }
-            if (ShouldUseTrueNorth(strategy.Option(Track.TrueNorth).As<TrueNorthStrategy>(), primaryTarget?.Actor))
-                QueueOGCD(AID.TrueNorth, Player, OGCDPriority.AboveAverage);
-
         }
         if (Player.Level < 60 && ActionReady(AID.LegSweep))
             QueueOGCD(AID.LegSweep, TargetChoice(AOE) ?? primaryTarget?.Actor, OGCDPrio(mdStrat, OGCDPriority.ExtremelyLow));

--- a/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
+++ b/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
@@ -170,7 +170,7 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
         AID.TrueThrust or AID.RaidenThrust => !Unlocked(AID.VorpalThrust) ? AutoBreak : FullST,
         _ => AutoBreak
     };
-    private AID AutoBreak => ShouldUseAOE && powerLeft > SkSGCDLength * 2 ? FullAOE : ShouldUseDOT ? STBuffs : FullST;
+    private AID AutoBreak => powerLeft <= SkSGCDLength ? LowLevelAOE : (ShouldUseAOE && powerLeft > SkSGCDLength * 2 ? FullAOE : ShouldUseDOT ? STBuffs : FullST);
     private AID FullST => ComboLastMove switch
     {
         AID.TrueThrust or AID.RaidenThrust => Unlocked(AID.Disembowel) && (Unlocked(AID.ChaosThrust) ? (powerLeft <= SkSGCDLength * 6 || chaosLeft <= SkSGCDLength * 4) : (Unlocked(AID.FullThrust) ? powerLeft <= SkSGCDLength * 3 : powerLeft <= SkSGCDLength * 2)) ? Unlocked(AID.SpiralBlow) ? AID.SpiralBlow : AID.Disembowel : Unlocked(AID.LanceBarrage) ? AID.LanceBarrage : Unlocked(AID.VorpalThrust) ? AID.VorpalThrust : AID.TrueThrust,

--- a/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
+++ b/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
@@ -184,24 +184,17 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     #endregion
 
     #region Rotation Helpers
-
-    #region Upgrade Paths
-    private AID BestTrueThrust => PlayerHasEffect(SID.DraconianFire) ? AID.RaidenThrust : AID.TrueThrust;
-    private AID BestDisembowel => Unlocked(AID.SpiralBlow) ? AID.SpiralBlow : AID.Disembowel;
-    #endregion
     private AID AutoFinish => ComboLastMove switch
     {
-        AID.CoerthanTorment => AutoBreak,
         AID.SonicThrust => !Unlocked(AID.CoerthanTorment) ? AutoBreak : FullAOE,
         AID.DoomSpike or AID.DraconianFury => !Unlocked(AID.SonicThrust) ? AutoBreak : FullAOE,
-        AID.Drakesbane => AutoBreak,
         AID.WheelingThrust or AID.FangAndClaw => !Unlocked(AID.Drakesbane) ? AutoBreak : FullST,
         AID.FullThrust or AID.HeavensThrust => !Unlocked(AID.FangAndClaw) ? AutoBreak : FullST,
         AID.ChaosThrust or AID.ChaoticSpring => !Unlocked(AID.WheelingThrust) ? AutoBreak : FullST,
         AID.VorpalThrust or AID.LanceBarrage => !Unlocked(AID.FullThrust) ? AutoBreak : FullST,
         AID.Disembowel or AID.SpiralBlow => !Unlocked(AID.ChaosThrust) ? AutoBreak : FullST,
         AID.TrueThrust or AID.RaidenThrust => !Unlocked(AID.VorpalThrust) ? AutoBreak : FullST,
-        _ => AutoBreak
+        AID.CoerthanTorment or AID.Drakesbane or _ => AutoBreak
     };
     private AID AutoBreak => NeedPower ? LowLevelAOE : (ShouldUseAOE && !NeedPower ? FullAOE : ShouldUseDOT ? BuffsST : FullST);
     private AID FullST => ComboLastMove switch
@@ -242,6 +235,12 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
         AID.TrueThrust or AID.RaidenThrust => BestDisembowel,
         _ => !NeedPower ? (PlayerHasEffect(SID.DraconianFire) ? AID.DraconianFury : AID.DoomSpike) : BestTrueThrust,
     };
+
+    #region Upgrade Paths
+    private AID BestTrueThrust => PlayerHasEffect(SID.DraconianFire) ? AID.RaidenThrust : AID.TrueThrust;
+    private AID BestDisembowel => Unlocked(AID.SpiralBlow) ? AID.SpiralBlow : AID.Disembowel;
+    #endregion
+
     #region DOT
     private static SID[] GetDotStatus() => [SID.ChaosThrust, SID.ChaoticSpring];
     private float ChaosRemaining(Actor? target) => target == null ? float.MaxValue : GetDotStatus().Select(stat => StatusDetails(target, (uint)stat, Player.InstanceID).Left).FirstOrDefault(dur => dur > 6);

--- a/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
+++ b/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
@@ -735,8 +735,8 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
         #endregion
 
         #region AI
-        if (BestDOTTargets != null &&
-            In3y(BestDOTTargets.Actor))
+        if (ComboLastMove is AID.Disembowel or AID.SpiralBlow &&
+            BestDOTTargets != null)
         {
             Hints.ForcedTarget = BestDOTTargets.Actor;
         }

--- a/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
+++ b/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
@@ -222,26 +222,38 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     #region Cooldown Helpers
 
     #region Buffs
-    private bool ShouldUseLanceCharge(OGCDStrategy strategy, Actor? target) => strategy switch
+    private bool ShouldUseLanceCharge(OGCDStrategy strategy, Actor? target)
     {
-        OGCDStrategy.Automatic => InsideCombatWith(target) && canLC && powerLeft > 0,
-        OGCDStrategy.Force => canLC,
-        OGCDStrategy.AnyWeave => canLC && CanWeaveIn,
-        OGCDStrategy.EarlyWeave => canLC && CanEarlyWeaveIn,
-        OGCDStrategy.LateWeave => canLC && CanLateWeaveIn,
-        OGCDStrategy.Delay => false,
-        _ => false
-    };
-    private bool ShouldUseBattleLitany(OGCDStrategy strategy, Actor? target) => strategy switch
+        if (!canLC)
+            return false;
+
+        return strategy switch
+        {
+            OGCDStrategy.Automatic => InsideCombatWith(target) && powerLeft > 0,
+            OGCDStrategy.Force => true,
+            OGCDStrategy.AnyWeave => CanWeaveIn,
+            OGCDStrategy.EarlyWeave => CanEarlyWeaveIn,
+            OGCDStrategy.LateWeave => CanLateWeaveIn,
+            OGCDStrategy.Delay => false,
+            _ => false
+        };
+    }
+    private bool ShouldUseBattleLitany(OGCDStrategy strategy, Actor? target)
     {
-        OGCDStrategy.Automatic => InsideCombatWith(target) && canBL && powerLeft > 0,
-        OGCDStrategy.Force => canBL,
-        OGCDStrategy.AnyWeave => canBL && CanWeaveIn,
-        OGCDStrategy.EarlyWeave => canBL && CanEarlyWeaveIn,
-        OGCDStrategy.LateWeave => canBL && CanLateWeaveIn,
-        OGCDStrategy.Delay => false,
-        _ => false
-    };
+        if (!canBL)
+            return false;
+
+        return strategy switch
+        {
+            OGCDStrategy.Automatic => InsideCombatWith(target) && powerLeft > 0,
+            OGCDStrategy.Force => true,
+            OGCDStrategy.AnyWeave => CanWeaveIn,
+            OGCDStrategy.EarlyWeave => CanEarlyWeaveIn,
+            OGCDStrategy.LateWeave => CanLateWeaveIn,
+            OGCDStrategy.Delay => false,
+            _ => false
+        };
+    }
     private bool ShouldUseLifeSurge(SurgeStrategy strategy, Actor? target)
     {
         if (!canLS)
@@ -284,99 +296,153 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
             _ => false
         };
     }
-    private bool ShouldUseJump(JumpStrategy strategy, Actor? target) => strategy switch
+    private bool ShouldUseJump(JumpStrategy strategy, Actor? target)
     {
-        JumpStrategy.Automatic => InsideCombatWith(target) && In20y(target) && canJump && (lcLeft > 0 || hasLC || lcCD is < 35 and > 17),
-        JumpStrategy.ForceEX => canJump,
-        JumpStrategy.ForceEX2 => canJump,
-        JumpStrategy.ForceWeave => canJump && CanWeaveIn,
-        JumpStrategy.Delay => false,
-        _ => false
-    };
-    private bool ShouldUseStardiver(StardiverStrategy strategy, Actor? target) => strategy switch
+        if (!canJump)
+            return false;
+
+        return strategy switch
+        {
+            JumpStrategy.Automatic => InsideCombatWith(target) && In20y(target) && (hasLC || lcCD is < 35 and > 13),
+            JumpStrategy.ForceEX or JumpStrategy.ForceEX2 => true,
+            JumpStrategy.ForceWeave => CanWeaveIn,
+            JumpStrategy.Delay => false,
+            _ => false
+        };
+
+    }
+    private bool ShouldUseStardiver(StardiverStrategy strategy, Actor? target)
     {
-        StardiverStrategy.Automatic => InsideCombatWith(target) && In20y(target) && canSD && hasLOTD,
-        StardiverStrategy.Force => canSD,
-        StardiverStrategy.ForceEX => canSD,
-        StardiverStrategy.ForceWeave => canSD && CanWeaveIn,
-        StardiverStrategy.Delay => false,
-        _ => false
-    };
-    private bool ShouldUseMirageDive(OGCDStrategy strategy, Actor? target) => strategy switch
+        if (!canSD)
+            return false;
+
+        return strategy switch
+        {
+            StardiverStrategy.Automatic => InsideCombatWith(target) && In20y(target) && hasLOTD,
+            StardiverStrategy.Force or StardiverStrategy.ForceEX => true,
+            StardiverStrategy.ForceWeave => CanWeaveIn,
+            StardiverStrategy.Delay => false,
+            _ => false
+        };
+
+    }
+    private bool ShouldUseMirageDive(OGCDStrategy strategy, Actor? target)
     {
-        OGCDStrategy.Automatic => InsideCombatWith(target) && In20y(target) && canMD,
-        OGCDStrategy.Force => canMD,
-        OGCDStrategy.AnyWeave => canMD && CanWeaveIn,
-        OGCDStrategy.EarlyWeave => canMD && CanEarlyWeaveIn,
-        OGCDStrategy.LateWeave => canMD && CanLateWeaveIn,
-        OGCDStrategy.Delay => false,
-        _ => false
-    };
+        if (!canMD)
+            return false;
+
+        return strategy switch
+        {
+            OGCDStrategy.Automatic => InsideCombatWith(target) && In20y(target),
+            OGCDStrategy.Force => true,
+            OGCDStrategy.AnyWeave => CanWeaveIn,
+            OGCDStrategy.EarlyWeave => CanEarlyWeaveIn,
+            OGCDStrategy.LateWeave => CanLateWeaveIn,
+            OGCDStrategy.Delay => false,
+            _ => false
+        };
+
+    }
     #endregion
 
     #region Spears
-    private bool ShouldUseGeirskogul(GeirskogulStrategy strategy, Actor? target) => strategy switch
+    private bool ShouldUseGeirskogul(GeirskogulStrategy strategy, Actor? target)
     {
-        GeirskogulStrategy.Automatic => InsideCombatWith(target) && In15y(target) && canGeirskogul && ((InOddWindow(AID.BattleLitany) && hasLC) || (!InOddWindow(AID.BattleLitany) && hasLC && hasBL)),
-        GeirskogulStrategy.Force or GeirskogulStrategy.ForceEX => canGeirskogul,
-        GeirskogulStrategy.ForceWeave => canGeirskogul && CanWeaveIn,
-        GeirskogulStrategy.Delay => false,
-        _ => false
-    };
-    private bool ShouldUseNastrond(OGCDStrategy strategy, Actor? target) => strategy switch
+        if (!canGeirskogul)
+            return false;
+
+        return strategy switch
+        {
+            GeirskogulStrategy.Automatic => InsideCombatWith(target) && In15y(target) && ((InOddWindow(AID.BattleLitany) && hasLC) || (!InOddWindow(AID.BattleLitany) && hasLC && hasBL)),
+            GeirskogulStrategy.Force or GeirskogulStrategy.ForceEX => true,
+            GeirskogulStrategy.ForceWeave => CanWeaveIn,
+            GeirskogulStrategy.Delay => false,
+            _ => false
+        };
+    }
+    private bool ShouldUseNastrond(OGCDStrategy strategy, Actor? target)
     {
-        OGCDStrategy.Automatic => InsideCombatWith(target) && In15y(target) && canNastrond,
-        OGCDStrategy.Force => canNastrond,
-        OGCDStrategy.AnyWeave => canNastrond && CanWeaveIn,
-        OGCDStrategy.EarlyWeave => canNastrond && CanEarlyWeaveIn,
-        OGCDStrategy.LateWeave => canNastrond && CanLateWeaveIn,
-        OGCDStrategy.Delay => false,
-        _ => false
-    };
-    private bool ShouldUseWyrmwindThrust(OGCDStrategy strategy, Actor? target) => strategy switch
+        if (!canNastrond)
+            return false;
+
+        return strategy switch
+        {
+            OGCDStrategy.Automatic => InsideCombatWith(target) && In15y(target),
+            OGCDStrategy.Force => true,
+            OGCDStrategy.AnyWeave => CanWeaveIn,
+            OGCDStrategy.EarlyWeave => CanEarlyWeaveIn,
+            OGCDStrategy.LateWeave => CanLateWeaveIn,
+            OGCDStrategy.Delay => false,
+            _ => false
+        };
+    }
+    private bool ShouldUseWyrmwindThrust(OGCDStrategy strategy, Actor? target)
     {
-        OGCDStrategy.Automatic => InsideCombatWith(target) && In15y(target) && canWT && lcCD > SkSGCDLength * 2,
-        OGCDStrategy.Force => canWT,
-        OGCDStrategy.AnyWeave => canWT && CanWeaveIn,
-        OGCDStrategy.EarlyWeave => canWT && CanEarlyWeaveIn,
-        OGCDStrategy.LateWeave => canWT && CanLateWeaveIn,
-        OGCDStrategy.Delay => false,
-        _ => false
-    };
+        if (!canWT)
+            return false;
+
+        return strategy switch
+        {
+            OGCDStrategy.Automatic => InsideCombatWith(target) && In15y(target) && lcCD > SkSGCDLength * 2,
+            OGCDStrategy.Force => true,
+            OGCDStrategy.AnyWeave => CanWeaveIn,
+            OGCDStrategy.EarlyWeave => CanEarlyWeaveIn,
+            OGCDStrategy.LateWeave => CanLateWeaveIn,
+            OGCDStrategy.Delay => false,
+            _ => false
+        };
+    }
     #endregion
 
-    private bool ShouldUseRiseOfTheDragon(OGCDStrategy strategy, Actor? target) => strategy switch
+    private bool ShouldUseRiseOfTheDragon(OGCDStrategy strategy, Actor? target)
     {
-        OGCDStrategy.Automatic => InsideCombatWith(target) && In20y(target) && canROTD,
-        OGCDStrategy.Force => canROTD,
-        OGCDStrategy.AnyWeave => canROTD && CanWeaveIn,
-        OGCDStrategy.EarlyWeave => canROTD && CanEarlyWeaveIn,
-        OGCDStrategy.LateWeave => canROTD && CanLateWeaveIn,
-        OGCDStrategy.Delay => false,
-        _ => false
-    };
-    private bool ShouldUseStarcross(OGCDStrategy strategy, Actor? target) => strategy switch
+        if (!canROTD)
+            return false;
+
+        return strategy switch
+        {
+            OGCDStrategy.Automatic => InsideCombatWith(target) && In20y(target),
+            OGCDStrategy.Force => true,
+            OGCDStrategy.AnyWeave => CanWeaveIn,
+            OGCDStrategy.EarlyWeave => CanEarlyWeaveIn,
+            OGCDStrategy.LateWeave => CanLateWeaveIn,
+            OGCDStrategy.Delay => false,
+            _ => false
+        };
+    }
+    private bool ShouldUseStarcross(OGCDStrategy strategy, Actor? target)
     {
-        OGCDStrategy.Automatic => InsideCombatWith(target) && In20y(target) && canSC,
-        OGCDStrategy.Force => canSC,
-        OGCDStrategy.AnyWeave => canSC && CanWeaveIn,
-        OGCDStrategy.EarlyWeave => canSC && CanEarlyWeaveIn,
-        OGCDStrategy.LateWeave => canSC && CanLateWeaveIn,
-        OGCDStrategy.Delay => false,
-        _ => false
-    };
-    private bool ShouldUsePiercingTalon(Actor? target, PiercingTalonStrategy strategy) => strategy switch
+        if (!canSC)
+            return false;
+
+        return strategy switch
+        {
+            OGCDStrategy.Automatic => InsideCombatWith(target) && In20y(target),
+            OGCDStrategy.Force => true,
+            OGCDStrategy.AnyWeave => CanWeaveIn,
+            OGCDStrategy.EarlyWeave => CanEarlyWeaveIn,
+            OGCDStrategy.LateWeave => CanLateWeaveIn,
+            OGCDStrategy.Delay => false,
+            _ => false
+        };
+    }
+    private bool ShouldUsePiercingTalon(Actor? target, PiercingTalonStrategy strategy)
     {
-        PiercingTalonStrategy.AllowEX => InsideCombatWith(target) && !In3y(target) && PlayerHasEffect(SID.EnhancedPiercingTalon),
-        PiercingTalonStrategy.Allow => InsideCombatWith(target) && !In3y(target),
-        PiercingTalonStrategy.Force => true,
-        PiercingTalonStrategy.ForceEX => PlayerHasEffect(SID.EnhancedPiercingTalon),
-        PiercingTalonStrategy.Forbid => false,
-        _ => false
-    };
+        var allow = InsideCombatWith(target) && !In3y(target);
+        return strategy switch
+        {
+            PiercingTalonStrategy.AllowEX => allow && PlayerHasEffect(SID.EnhancedPiercingTalon),
+            PiercingTalonStrategy.Allow => allow,
+            PiercingTalonStrategy.Force => true,
+            PiercingTalonStrategy.ForceEX => PlayerHasEffect(SID.EnhancedPiercingTalon),
+            PiercingTalonStrategy.Forbid => false,
+            _ => false
+        };
+
+    }
     private bool ShouldUsePotion(PotionStrategy strategy) => strategy switch
     {
-        PotionStrategy.AlignWithRaidBuffs => Player.InCombat && lcCD <= GCD * 2 && blCD <= GCD * 2,
+        PotionStrategy.AlignWithRaidBuffs => Player.InCombat && lcCD <= SkSGCDLength * 2 && blCD <= SkSGCDLength * 2,
         PotionStrategy.Immediate => true,
         _ => false
     };

--- a/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
+++ b/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
@@ -232,7 +232,7 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     };
     private AID FullAOE => ComboLastMove switch
     {
-        AID.DoomSpike => Unlocked(AID.SonicThrust) ? AID.SonicThrust : LowLevelAOE,
+        AID.DoomSpike or AID.DraconianFury => Unlocked(AID.SonicThrust) ? AID.SonicThrust : LowLevelAOE,
         AID.SonicThrust => Unlocked(AID.CoerthanTorment) ? AID.CoerthanTorment : LowLevelAOE,
         _ => PlayerHasEffect(SID.DraconianFire) ? AID.DraconianFury : LowLevelAOE,
     };
@@ -597,11 +597,11 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
         ShouldUseAOE = Unlocked(AID.DoomSpike) && NumAOETargets > 2 && !NeedPower;
         ShouldUseSpears = Unlocked(AID.Geirskogul) && NumSpearTargets > 1;
         ShouldUseDives = Unlocked(AID.Stardiver) && NumDiveTargets > 1;
-        ShouldUseDOT = Unlocked(AID.ChaosThrust) && Hints.NumPriorityTargetsInAOECircle(Player.Position, 3.5f) == 2 && InMeleeRange(BestDOTTarget?.Actor) && ComboLastMove is AID.Disembowel or AID.SpiralBlow;
+        ShouldUseDOT = Unlocked(AID.ChaosThrust) && Hints.NumPriorityTargetsInAOECircle(Player.Position, 8) == 2 && InMeleeRange(BestDOTTarget?.Actor) && ComboLastMove is AID.Disembowel or AID.SpiralBlow;
         (BestAOETargets, NumAOETargets) = GetBestTarget(primaryTarget, 10, Is10yRectTarget);
         (BestSpearTargets, NumSpearTargets) = GetBestTarget(primaryTarget, 15, Is15yRectTarget);
         (BestDiveTargets, NumDiveTargets) = GetBestTarget(primaryTarget, 20, IsSplashTarget);
-        (BestDOTTargets, ChaosLeft) = GetDOTTarget(primaryTarget, ChaosRemaining, 2, 3.5f);
+        (BestDOTTargets, ChaosLeft) = GetDOTTarget(primaryTarget, ChaosRemaining, 2, 8);
         BestAOETarget = ShouldUseAOE ? BestAOETargets : BestDOTTarget;
         BestSpearTarget = ShouldUseSpears ? BestSpearTargets : primaryTarget;
         BestDiveTarget = ShouldUseDives ? BestDiveTargets : primaryTarget;
@@ -734,7 +734,10 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
         #endregion
 
         #region AI
-        GetNextTarget(strategy, ref primaryTarget, 3);
+        if (BestDOTTargets != null)
+        {
+            Hints.ForcedTarget = BestDOTTargets.Actor;
+        }
         var pos = GetBestPositional(strategy, primaryTarget);
         UpdatePositionals(primaryTarget, ref pos);
         if (primaryTarget != null)

--- a/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
+++ b/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
@@ -159,10 +159,10 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     #region Rotation Helpers
     private AID AutoFinish => ComboLastMove switch
     {
-        AID.Drakesbane or AID.CoerthanTorment => ShouldUseAOE ? FullAOE : ShouldUseDOT ? STBuffs : FullST,
-        AID.DoomSpike or AID.DraconianFury or AID.SonicThrust => FullAOE,
+        AID.Drakesbane or AID.CoerthanTorment => AutoBreak,
+        AID.DoomSpike or AID.DraconianFury or AID.SonicThrust => !Unlocked(AID.SonicThrust) ? AutoBreak : FullAOE,
         AID.TrueThrust or AID.RaidenThrust or AID.VorpalThrust or AID.LanceBarrage or AID.Disembowel or AID.SpiralBlow or AID.HeavensThrust or AID.FullThrust or AID.WheelingThrust or AID.FangAndClaw => FullST,
-        _ => ShouldUseAOE ? FullAOE : ShouldUseDOT ? STBuffs : FullST
+        _ => AutoBreak
     };
     private AID AutoBreak => ShouldUseAOE ? FullAOE : ShouldUseDOT ? STBuffs : FullST;
     private AID FullST => ComboLastMove switch
@@ -195,7 +195,7 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     {
         AID.DoomSpike => Unlocked(AID.SonicThrust) ? AID.SonicThrust : AID.DoomSpike,
         AID.SonicThrust => Unlocked(AID.CoerthanTorment) ? AID.CoerthanTorment : AID.DoomSpike,
-        _ => PlayerHasEffect(SID.DraconianFire) ? AID.DraconianFury : AID.DoomSpike,
+        _ => powerLeft > SkSGCDLength * 2 ? (PlayerHasEffect(SID.DraconianFire) ? AID.DraconianFury : AID.DoomSpike) : (ComboLastMove is AID.TrueThrust or AID.RaidenThrust ? (Unlocked(AID.SpiralBlow) ? AID.SpiralBlow : AID.Disembowel) : (PlayerHasEffect(SID.DraconianFire) ? AID.RaidenThrust : AID.TrueThrust)),
     };
 
     #region DOT
@@ -408,7 +408,7 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
         (BestSpearTargets, NumSpearTargets) = GetBestTarget(primaryTarget, 15, Is15yRectTarget);
         (BestDiveTargets, NumDiveTargets) = GetBestTarget(primaryTarget, 20, IsSplashTarget);
         (BestDOTTargets, chaosLeft) = GetDOTTarget(primaryTarget, ChaosRemaining, 2, 3.5f);
-        BestAOETarget = ShouldUseAOE ? BestAOETargets : ShouldUseDOT ? BestDOTTargets : BestDOTTarget;
+        BestAOETarget = ShouldUseAOE ? BestAOETargets : BestDOTTarget;
         BestSpearTarget = ShouldUseSpears ? BestSpearTargets : primaryTarget;
         BestDiveTarget = ShouldUseDives ? BestDiveTargets : primaryTarget;
         BestDOTTarget = ShouldUseDOT ? BestDOTTargets : primaryTarget;

--- a/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
+++ b/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
@@ -284,10 +284,8 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     #region Buffs
     private bool ShouldUseLanceCharge(BuffsStrategy strategy, Actor? target)
     {
-        //if Lance Charge is unavailable, skip entirely
         if (!CanLC)
             return false;
-        //otherwise, we continue
         var condition = InsideCombatWith(target) && InsideRange && HasPower;
         return strategy switch
         {
@@ -301,10 +299,8 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     }
     private bool ShouldUseBattleLitany(BuffsStrategy strategy, Actor? target)
     {
-        //if Battle Litany is unavailable, skip entirely
         if (!CanBL)
             return false;
-        //otherwise, we continue
         var condition = InsideCombatWith(target) && InsideRange && HasPower;
         return strategy switch
         {
@@ -318,10 +314,8 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     }
     private bool ShouldUseLifeSurge(SurgeStrategy strategy, Actor? target)
     {
-        //if Life Surge is unavailable, skip entirely
         if (!CanLS)
             return false;
-        //otherwise, we continue
         var lv6to17 = ComboLastMove is AID.TrueThrust;
         var lv18to25 = !Unlocked(AID.FullThrust) && (Unlocked(AID.Disembowel) ? (lv6to17 && !NeedPower) : lv6to17);
         var lv26to88 = (Unlocked(AID.FullThrust) && ComboLastMove is AID.VorpalThrust or AID.LanceBarrage) || (Unlocked(AID.Drakesbane) && ComboLastMove is AID.WheelingThrust or AID.FangAndClaw);
@@ -347,10 +341,8 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     #region Dives
     private bool ShouldUseDragonfireDive(CommonStrategy strategy, Actor? target)
     {
-        //if Dragonfire Dive is unavailable, skip entirely
         if (!CanDD)
             return false;
-        //otherwise, we continue
         var lv60plus = HasLC && HasBL && HasLOTD;
         var lv52to59 = HasLC && HasBL;
         var lv50to51 = HasLC;
@@ -366,10 +358,8 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     }
     private bool ShouldUseJump(CommonStrategy strategy, Actor? target)
     {
-        //if Jump is unavailable, skip entirely
         if (!CanJump)
             return false;
-        //otherwise, we continue
         return strategy switch
         {
             CommonStrategy.Automatic => InsideCombatWith(target) && In20y(target) && (HasLC || LCcd is < 35 and > 13),
@@ -381,10 +371,8 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     }
     private bool ShouldUseStardiver(CommonStrategy strategy, Actor? target)
     {
-        //if Stardiver is unavailable, skip entirely
         if (!CanSD)
             return false;
-        //otherwise, we continue
         return strategy switch
         {
             CommonStrategy.Automatic => InsideCombatWith(target) && In20y(target) && HasLOTD,
@@ -396,10 +384,8 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     }
     private bool ShouldUseMirageDive(OGCDStrategy strategy, Actor? target)
     {
-        //if Mirage Dive is unavailable, skip entirely
         if (!CanMD)
             return false;
-        //otherwise, we continue
         return strategy switch
         {
             OGCDStrategy.Automatic => InsideCombatWith(target) && In20y(target),
@@ -416,10 +402,8 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     #region Spears
     private bool ShouldUseGeirskogul(CommonStrategy strategy, Actor? target)
     {
-        //if Geirskogul is unavailable, skip entirely
         if (!CanGeirskogul)
             return false;
-        //otherwise, we continue
         return strategy switch
         {
             CommonStrategy.Automatic => InsideCombatWith(target) && In15y(target) && ((InOddWindow(AID.BattleLitany) && HasLC) || (!InOddWindow(AID.BattleLitany) && HasLC && HasBL)),
@@ -431,10 +415,8 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     }
     private bool ShouldUseNastrond(OGCDStrategy strategy, Actor? target)
     {
-        //if Nastrond is unavailable, skip entirely
         if (!CanNastrond)
             return false;
-        //otherwise, we continue
         return strategy switch
         {
             OGCDStrategy.Automatic => InsideCombatWith(target) && In15y(target),
@@ -448,10 +430,8 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     }
     private bool ShouldUseWyrmwindThrust(OGCDStrategy strategy, Actor? target)
     {
-        //if Wyrmwind Thrust is unavailable, skip entirely
         if (!CanWT)
             return false;
-        //otherwise, we continue
         return strategy switch
         {
             OGCDStrategy.Automatic => InsideCombatWith(target) && In15y(target) && LCcd > SkSGCDLength * 2,
@@ -467,10 +447,8 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
 
     private bool ShouldUseRiseOfTheDragon(OGCDStrategy strategy, Actor? target)
     {
-        //if Rise of the Dragon is unavailable, skip entirely
         if (!CanROTD)
             return false;
-        //otherwise, we continue
         return strategy switch
         {
             OGCDStrategy.Automatic => InsideCombatWith(target) && In20y(target),
@@ -484,10 +462,8 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     }
     private bool ShouldUseStarcross(OGCDStrategy strategy, Actor? target)
     {
-        //if Starcross is unavailable, skip entirely
         if (!CanSC)
             return false;
-        //otherwise, we continue
         return strategy switch
         {
             OGCDStrategy.Automatic => InsideCombatWith(target) && In20y(target),
@@ -521,10 +497,8 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     }
     private bool ShouldUsePiercingTalon(Actor? target, PiercingTalonStrategy strategy)
     {
-        //if Piercing Talon is unavailable, skip entirely
         if (!Unlocked(AID.PiercingTalon))
             return false;
-        //otherwise, we continue
         var allow = InsideCombatWith(target) && OutsideRange;
         return strategy switch
         {
@@ -545,10 +519,8 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     };
     private bool ShouldUseTrueNorth(TrueNorthStrategy strategy, Actor? target)
     {
-        //if True North is unavailable, skip entirely
         if (!CanTrueNorth)
             return false;
-        //otherwise, we continue
         var condition = InsideCombatWith(target) && !ShouldUseAOE && In3y(target) && NextPositionalImminent && !NextPositionalCorrect;
         var needRear = !IsOnRear(target!) && ((Unlocked(AID.ChaosThrust) && ComboLastMove is AID.Disembowel or AID.SpiralBlow) || (Unlocked(AID.WheelingThrust) && ComboLastMove is AID.ChaosThrust or AID.ChaoticSpring));
         var needFlank = !IsOnFlank(target!) && Unlocked(AID.FangAndClaw) && ComboLastMove is AID.HeavensThrust or AID.FullThrust;

--- a/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
+++ b/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
@@ -1,6 +1,8 @@
-﻿using static BossMod.AIHints;
+﻿#region Dependencies
+using static BossMod.AIHints;
 using FFXIVClientStructs.FFXIV.Client.Game.Gauge;
 using BossMod.DRG;
+#endregion
 
 namespace BossMod.Autorotation.akechi;
 //Contribution by Akechi
@@ -9,13 +11,14 @@ namespace BossMod.Autorotation.akechi;
 public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : AkechiTools<AID, TraitID>(manager, player)
 {
     #region Enums: Abilities / Strategies
-    public enum Track { Combo = SharedTrack.Count, Dives, Potion, LanceCharge, BattleLitany, LifeSurge, PiercingTalon, TrueNorth, DragonfireDive, Geirskogul, Stardiver, Jump, MirageDive, Nastrond, WyrmwindThrust, RiseOfTheDragon, Starcross }
+    public enum Track { Combo = SharedTrack.Count, Dives, Potion, ElusiveJump, LanceCharge, BattleLitany, LifeSurge, PiercingTalon, TrueNorth, DragonfireDive, Geirskogul, Stardiver, Jump, MirageDive, Nastrond, WyrmwindThrust, RiseOfTheDragon, Starcross }
     public enum SingleTargetOption { FullST, Force123ST, ForceBuffsST }
     public enum DivesStrategy { AllowMaxMelee, AllowCloseMelee, Allow, Forbid }
     public enum PotionStrategy { Manual, AlignWithRaidBuffs, Immediate }
     public enum SurgeStrategy { Automatic, WhenBuffed, Force, ForceWeave, ForceNextOpti, ForceNextOptiWeave, Delay }
     public enum PiercingTalonStrategy { AllowEX, Allow, Force, ForceEX, Forbid }
     public enum TrueNorthStrategy { Automatic, ASAP, Rear, Flank, Force, Delay }
+    public enum ElusiveDirection { None, CharacterForward, CharacterBackward, CameraForward, CameraBackward }
     public enum BuffsStrategy { Automatic, Together, Force, ForceWeave, Delay }
     public enum CommonStrategy { Automatic, Force, ForceEX, ForceWeave, ForceWeaveEX, Delay }
     #endregion
@@ -47,6 +50,13 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
             .AddOption(PotionStrategy.AlignWithRaidBuffs, "Align With Raid Buffs", "Use potion in sync with 2-minute raid buffs (e.g., 0/6, 2/8)")
             .AddOption(PotionStrategy.Immediate, "Immediate", "Use potion as soon as possible, regardless of any buffs")
             .AddAssociatedAction(ActionDefinitions.IDPotionStr);
+        res.Define(Track.ElusiveJump).As<ElusiveDirection>("Elusive Jump", uiPriority: -1)
+            .AddOption(ElusiveDirection.None, "None", "Do not use Elusive Jump")
+            .AddOption(ElusiveDirection.CharacterForward, "Character Forward", "Jump into the direction forward of the character", 30, 15, ActionTargets.Self, 35)
+            .AddOption(ElusiveDirection.CharacterBackward, "Character Backward", "Jump into the direction backward of the character (default)", 30, 15, ActionTargets.Self, 35)
+            .AddOption(ElusiveDirection.CameraForward, "Camera Forward", "Jump into the direction forward of the camera", 30, 15, ActionTargets.Self, 35)
+            .AddOption(ElusiveDirection.CameraBackward, "Camera Backward", "Jump into the direction backward of the camera", 30, 15, ActionTargets.Self, 35)
+            .AddAssociatedActions(AID.ElusiveJump);
         res.Define(Track.LanceCharge).As<BuffsStrategy>("Lance Charge", "L. Charge", uiPriority: 170)
             .AddOption(BuffsStrategy.Automatic, "Automatic", "Use Lance Charge normally")
             .AddOption(BuffsStrategy.Together, "Together", "Use Lance Charge only with Battle Litany; will delay in attempt to align itself with Battle Litany (up to 30s)", 60, 20, ActionTargets.Self, 52)
@@ -154,7 +164,9 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     private float PowerLeft; //time left on Power Surge
     private float ChaosLeft; //time left on Chaos Thrust or Chaotic Spring
     private bool InsideRange; //inside range of target for ST (3.5y) or AOE (10y)
+    private bool OutsideRange; //outside range of target for ST (3.5y) or AOE (10y)
     private bool NeedPower; //need to reapply Power Surge
+    private bool NeedBoth; //need to reapply personal buffs
     private int NumAOETargets; //number of targets in range for AOE
     private int NumSpearTargets; //number of targets in range for Spears
     private int NumDiveTargets; //number of targets in range for Dives
@@ -173,6 +185,15 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     #endregion
 
     #region Rotation Helpers
+
+    #region Upgrade Paths
+    private AID BestTrueThrust => Unlocked(AID.RaidenThrust) && PlayerHasEffect(SID.DraconianFire) ? AID.RaidenThrust : AID.TrueThrust;
+    private AID BestDoomSpike => Unlocked(AID.DraconianFury) && PlayerHasEffect(SID.DraconianFire) ? AID.DraconianFury : AID.DoomSpike;
+    private AID BestDisembowel => Unlocked(AID.SpiralBlow) ? AID.SpiralBlow : AID.Disembowel;
+    private AID BestVorpalThrust => Unlocked(AID.LanceBarrage) ? AID.LanceBarrage : AID.VorpalThrust;
+    private AID BestFullThrust => Unlocked(AID.HeavensThrust) ? AID.HeavensThrust : AID.FullThrust;
+    private AID BestChaosThrust => Unlocked(AID.ChaoticSpring) ? AID.ChaoticSpring : AID.ChaosThrust;
+    #endregion
     private AID AutoFinish => ComboLastMove switch
     {
         AID.CoerthanTorment => AutoBreak,
@@ -187,44 +208,44 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
         AID.TrueThrust or AID.RaidenThrust => !Unlocked(AID.VorpalThrust) ? AutoBreak : FullST,
         _ => AutoBreak
     };
-    private AID AutoBreak => NeedPower ? LowLevelAOE : (ShouldUseAOE && !NeedPower ? FullAOE : ShouldUseDOT ? BuffsST : FullST);
+    private AID AutoBreak => NeedPower ? GetPower : (ShouldUseAOE && !NeedPower ? FullAOE : ShouldUseDOT ? BuffsST : FullST);
     private AID FullST => ComboLastMove switch
     {
-        AID.TrueThrust or AID.RaidenThrust => Unlocked(AID.Disembowel) && (Unlocked(AID.ChaosThrust) ? (PowerLeft <= SkSGCDLength * 6 || ChaosLeft <= SkSGCDLength * 4) : (Unlocked(AID.FullThrust) ? PowerLeft <= SkSGCDLength * 3 : NeedPower)) ? Unlocked(AID.SpiralBlow) ? AID.SpiralBlow : AID.Disembowel : Unlocked(AID.LanceBarrage) ? AID.LanceBarrage : Unlocked(AID.VorpalThrust) ? AID.VorpalThrust : AID.TrueThrust,
-        AID.Disembowel or AID.SpiralBlow => Unlocked(AID.ChaoticSpring) ? AID.ChaoticSpring : Unlocked(AID.ChaosThrust) ? AID.ChaosThrust : AID.TrueThrust,
-        AID.VorpalThrust or AID.LanceBarrage => Unlocked(AID.HeavensThrust) ? AID.HeavensThrust : Unlocked(AID.FullThrust) ? AID.FullThrust : AID.TrueThrust,
+        AID.TrueThrust or AID.RaidenThrust => Unlocked(AID.Disembowel) && NeedBoth ? BestDisembowel : Unlocked(AID.VorpalThrust) ? BestVorpalThrust : AID.TrueThrust,
+        AID.Disembowel or AID.SpiralBlow => Unlocked(AID.ChaosThrust) ? BestChaosThrust : AID.TrueThrust,
+        AID.VorpalThrust or AID.LanceBarrage => Unlocked(AID.FullThrust) ? BestFullThrust : AID.TrueThrust,
         AID.FullThrust or AID.HeavensThrust => Unlocked(AID.FangAndClaw) ? AID.FangAndClaw : AID.TrueThrust,
         AID.ChaosThrust or AID.ChaoticSpring => Unlocked(AID.WheelingThrust) ? AID.WheelingThrust : AID.TrueThrust,
         AID.WheelingThrust or AID.FangAndClaw => Unlocked(AID.Drakesbane) ? AID.Drakesbane : AID.TrueThrust,
-        _ => PlayerHasEffect(SID.DraconianFire) ? AID.RaidenThrust : AID.TrueThrust,
+        _ => BestTrueThrust,
     };
     private AID NormalST => ComboLastMove switch
     {
-        AID.TrueThrust or AID.RaidenThrust => Unlocked(AID.LanceBarrage) ? AID.LanceBarrage : Unlocked(AID.VorpalThrust) ? AID.VorpalThrust : AID.TrueThrust,
-        AID.VorpalThrust or AID.LanceBarrage => Unlocked(AID.HeavensThrust) ? AID.HeavensThrust : Unlocked(AID.FullThrust) ? AID.FullThrust : AID.TrueThrust,
+        AID.TrueThrust or AID.RaidenThrust => Unlocked(AID.VorpalThrust) ? BestVorpalThrust : AID.TrueThrust,
+        AID.VorpalThrust or AID.LanceBarrage => Unlocked(AID.FullThrust) ? BestFullThrust : AID.TrueThrust,
         AID.FullThrust or AID.HeavensThrust => Unlocked(AID.FangAndClaw) ? AID.FangAndClaw : AID.TrueThrust,
         AID.WheelingThrust or AID.FangAndClaw => Unlocked(AID.Drakesbane) ? AID.Drakesbane : AID.TrueThrust,
-        _ => PlayerHasEffect(SID.DraconianFire) ? AID.RaidenThrust : AID.TrueThrust,
+        _ => BestTrueThrust,
     };
     private AID BuffsST => ComboLastMove switch
     {
-        AID.TrueThrust or AID.RaidenThrust => Unlocked(AID.Disembowel) ? (Unlocked(AID.SpiralBlow) ? AID.SpiralBlow : AID.Disembowel) : AID.TrueThrust,
-        AID.Disembowel or AID.SpiralBlow => Unlocked(AID.ChaoticSpring) ? AID.ChaoticSpring : Unlocked(AID.ChaosThrust) ? AID.ChaosThrust : AID.TrueThrust,
+        AID.TrueThrust or AID.RaidenThrust => Unlocked(AID.Disembowel) ? BestDisembowel : AID.TrueThrust,
+        AID.Disembowel or AID.SpiralBlow => Unlocked(AID.ChaosThrust) ? BestChaosThrust : AID.TrueThrust,
         AID.ChaosThrust or AID.ChaoticSpring => Unlocked(AID.WheelingThrust) ? AID.WheelingThrust : AID.TrueThrust,
         AID.WheelingThrust or AID.FangAndClaw => Unlocked(AID.Drakesbane) ? AID.Drakesbane : AID.TrueThrust,
-        _ => PlayerHasEffect(SID.DraconianFire) ? AID.RaidenThrust : AID.TrueThrust,
+        _ => BestTrueThrust,
     };
     private AID FullAOE => ComboLastMove switch
     {
-        AID.DoomSpike => Unlocked(AID.SonicThrust) ? AID.SonicThrust : LowLevelAOE,
-        AID.SonicThrust => Unlocked(AID.CoerthanTorment) ? AID.CoerthanTorment : LowLevelAOE,
-        _ => PlayerHasEffect(SID.DraconianFire) ? AID.DraconianFury : LowLevelAOE,
+        AID.DoomSpike or AID.DraconianFury => Unlocked(AID.SonicThrust) ? AID.SonicThrust : GetPower,
+        AID.SonicThrust => Unlocked(AID.CoerthanTorment) ? AID.CoerthanTorment : GetPower,
+        _ => !NeedPower ? BestDoomSpike : GetPower,
     };
-    private AID LowLevelAOE => ComboLastMove switch
+    private AID GetPower => ComboLastMove switch
     {
         AID.Disembowel or AID.SpiralBlow => !NeedPower ? AID.DoomSpike : AID.TrueThrust,
-        AID.TrueThrust or AID.RaidenThrust => Unlocked(AID.SpiralBlow) ? AID.SpiralBlow : AID.Disembowel,
-        _ => !NeedPower ? (PlayerHasEffect(SID.DraconianFire) ? AID.DraconianFury : AID.DoomSpike) : (PlayerHasEffect(SID.DraconianFire) ? AID.RaidenThrust : AID.TrueThrust),
+        AID.TrueThrust or AID.RaidenThrust => BestDisembowel,
+        _ => !NeedPower ? BestDoomSpike : BestTrueThrust,
     };
 
     #region DOT
@@ -273,10 +294,11 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
         if (!CanLC)
             return false;
         //otherwise, we continue
+        var condition = InsideCombatWith(target) && InsideRange && HasPower;
         return strategy switch
         {
-            BuffsStrategy.Automatic => InsideCombatWith(target) && InsideRange && HasPower,
-            BuffsStrategy.Together => HasPower && (BLcd > 30 || BLcd < 1),
+            BuffsStrategy.Automatic => condition,
+            BuffsStrategy.Together => condition && (BLcd > 30 || BLcd < 1),
             BuffsStrategy.Force => true,
             BuffsStrategy.ForceWeave => CanWeaveIn,
             BuffsStrategy.Delay => false,
@@ -289,10 +311,11 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
         if (!CanBL)
             return false;
         //otherwise, we continue
+        var condition = InsideCombatWith(target) && InsideRange && HasPower;
         return strategy switch
         {
-            BuffsStrategy.Automatic => InsideCombatWith(target) && InsideRange && HasPower,
-            BuffsStrategy.Together => HasPower && HasLC,
+            BuffsStrategy.Automatic => condition,
+            BuffsStrategy.Together => condition && HasLC,
             BuffsStrategy.Force => true,
             BuffsStrategy.ForceWeave => CanWeaveIn,
             BuffsStrategy.Delay => false,
@@ -481,13 +504,33 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
             _ => false
         };
     }
+    private void ShouldUseElusive(ElusiveDirection strategy, Actor? target)
+    {
+        if (!Unlocked(AID.ElusiveJump))
+            return;
+
+        if (ActionReady(AID.ElusiveJump))
+        {
+            if (strategy != ElusiveDirection.None)
+            {
+                var angle = strategy switch
+                {
+                    ElusiveDirection.CharacterForward => Player.Rotation,
+                    ElusiveDirection.CameraForward => World.Client.CameraAzimuth,
+                    ElusiveDirection.CameraBackward => World.Client.CameraAzimuth + 180.Degrees(),
+                    _ => Player.Rotation + 180.Degrees()
+                };
+                Hints.ActionsToExecute.Push(ActionID.MakeSpell(AID.ElusiveJump), Player, ActionQueue.Priority.Low, facingAngle: angle);
+            }
+        }
+    }
     private bool ShouldUsePiercingTalon(Actor? target, PiercingTalonStrategy strategy)
     {
         //if Piercing Talon is unavailable, skip entirely
         if (!Unlocked(AID.PiercingTalon))
             return false;
         //otherwise, we continue
-        var allow = InsideCombatWith(target) && !InsideRange;
+        var allow = InsideCombatWith(target) && OutsideRange;
         return strategy switch
         {
             PiercingTalonStrategy.AllowEX => allow && PlayerHasEffect(SID.EnhancedPiercingTalon),
@@ -557,6 +600,7 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
         CanROTD = Unlocked(AID.RiseOfTheDragon) && HasROTD;
         CanSC = Unlocked(AID.Starcross) && HasSC;
         NeedPower = PowerLeft <= SkSGCDLength * 2;
+        NeedBoth = Unlocked(AID.ChaosThrust) ? (PowerLeft <= SkSGCDLength * 6 || ChaosLeft <= SkSGCDLength * 4) : Unlocked(AID.FullThrust) ? (PowerLeft <= SkSGCDLength * 3) : NeedPower;
         ShouldUseAOE = Unlocked(AID.DoomSpike) && NumAOETargets > 2 && !NeedPower;
         ShouldUseSpears = Unlocked(AID.Geirskogul) && NumSpearTargets > 1;
         ShouldUseDives = Unlocked(AID.Stardiver) && NumDiveTargets > 1;
@@ -570,6 +614,7 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
         BestDiveTarget = ShouldUseDives ? BestDiveTargets : primaryTarget;
         BestDOTTarget = ShouldUseDOT ? BestDOTTargets : primaryTarget;
         InsideRange = ShouldUseAOE ? In10y(BestAOETarget?.Actor) : InMeleeRange(BestDOTTarget?.Actor);
+        OutsideRange = ShouldUseAOE ? !In10y(BestAOETarget?.Actor) : !InMeleeRange(BestDOTTarget?.Actor);
 
         #region Strategy Definitions
         var AOE = strategy.Option(SharedTrack.AOE);
@@ -690,6 +735,7 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
             QueueGCD(AID.PiercingTalon, TargetChoice(pt) ?? primaryTarget?.Actor, ptStrat is PiercingTalonStrategy.Force or PiercingTalonStrategy.ForceEX ? GCDPriority.Forced : GCDPriority.SlightlyLow);
         if (ShouldUsePotion(strategy.Option(Track.Potion).As<PotionStrategy>()))
             Hints.ActionsToExecute.Push(ActionDefinitions.IDPotionStr, Player, ActionQueue.Priority.VeryHigh + (int)OGCDPriority.VeryCritical, 0, GCD - 0.9f);
+        ShouldUseElusive(strategy.Option(Track.ElusiveJump).As<ElusiveDirection>(), primaryTarget?.Actor);
         #endregion
 
         #endregion

--- a/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
+++ b/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
@@ -159,12 +159,19 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     #region Rotation Helpers
     private AID AutoFinish => ComboLastMove switch
     {
-        AID.Drakesbane or AID.CoerthanTorment => AutoBreak,
-        AID.DoomSpike or AID.DraconianFury or AID.SonicThrust => !Unlocked(AID.SonicThrust) ? AutoBreak : FullAOE,
-        AID.TrueThrust or AID.RaidenThrust or AID.VorpalThrust or AID.LanceBarrage or AID.Disembowel or AID.SpiralBlow or AID.HeavensThrust or AID.FullThrust or AID.WheelingThrust or AID.FangAndClaw => FullST,
+        AID.CoerthanTorment => AutoBreak,
+        AID.SonicThrust => !Unlocked(AID.CoerthanTorment) ? AutoBreak : FullAOE,
+        AID.DoomSpike or AID.DraconianFury => !Unlocked(AID.SonicThrust) ? AutoBreak : FullAOE,
+        AID.Drakesbane => AutoBreak,
+        AID.WheelingThrust or AID.FangAndClaw => !Unlocked(AID.Drakesbane) ? AutoBreak : FullST,
+        AID.FullThrust or AID.HeavensThrust => !Unlocked(AID.FangAndClaw) ? AutoBreak : FullST,
+        AID.ChaosThrust or AID.ChaoticSpring => !Unlocked(AID.WheelingThrust) ? AutoBreak : FullST,
+        AID.VorpalThrust or AID.LanceBarrage => !Unlocked(AID.FullThrust) ? AutoBreak : FullST,
+        AID.Disembowel or AID.SpiralBlow => !Unlocked(AID.ChaosThrust) ? AutoBreak : FullST,
+        AID.TrueThrust or AID.RaidenThrust => !Unlocked(AID.VorpalThrust) ? AutoBreak : FullST,
         _ => AutoBreak
     };
-    private AID AutoBreak => ShouldUseAOE ? FullAOE : ShouldUseDOT ? STBuffs : FullST;
+    private AID AutoBreak => ShouldUseAOE && powerLeft > SkSGCDLength * 2 ? FullAOE : ShouldUseDOT ? STBuffs : FullST;
     private AID FullST => ComboLastMove switch
     {
         AID.TrueThrust or AID.RaidenThrust => Unlocked(AID.Disembowel) && (Unlocked(AID.ChaosThrust) ? (powerLeft <= SkSGCDLength * 6 || chaosLeft <= SkSGCDLength * 4) : (Unlocked(AID.FullThrust) ? powerLeft <= SkSGCDLength * 3 : powerLeft <= SkSGCDLength * 2)) ? Unlocked(AID.SpiralBlow) ? AID.SpiralBlow : AID.Disembowel : Unlocked(AID.LanceBarrage) ? AID.LanceBarrage : Unlocked(AID.VorpalThrust) ? AID.VorpalThrust : AID.TrueThrust,
@@ -193,9 +200,16 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     };
     private AID FullAOE => ComboLastMove switch
     {
-        AID.DoomSpike => Unlocked(AID.SonicThrust) ? AID.SonicThrust : AID.DoomSpike,
-        AID.SonicThrust => Unlocked(AID.CoerthanTorment) ? AID.CoerthanTorment : AID.DoomSpike,
-        _ => powerLeft > SkSGCDLength * 2 ? (PlayerHasEffect(SID.DraconianFire) ? AID.DraconianFury : AID.DoomSpike) : (ComboLastMove is AID.TrueThrust or AID.RaidenThrust ? (Unlocked(AID.SpiralBlow) ? AID.SpiralBlow : AID.Disembowel) : (PlayerHasEffect(SID.DraconianFire) ? AID.RaidenThrust : AID.TrueThrust)),
+        AID.DoomSpike => Unlocked(AID.SonicThrust) ? AID.SonicThrust : LowLevelAOE,
+        AID.SonicThrust => Unlocked(AID.CoerthanTorment) ? AID.CoerthanTorment : LowLevelAOE,
+        _ => PlayerHasEffect(SID.DraconianFire) ? AID.DraconianFury : LowLevelAOE,
+    };
+
+    private AID LowLevelAOE => ComboLastMove switch
+    {
+        AID.Disembowel or AID.SpiralBlow => powerLeft > SkSGCDLength * 2 ? AID.DoomSpike : AID.TrueThrust,
+        AID.TrueThrust or AID.RaidenThrust => Unlocked(AID.SpiralBlow) ? AID.SpiralBlow : AID.Disembowel,
+        _ => powerLeft > SkSGCDLength * 2 ? (PlayerHasEffect(SID.DraconianFire) ? AID.DraconianFury : AID.DoomSpike) : (PlayerHasEffect(SID.DraconianFire) ? AID.RaidenThrust : AID.TrueThrust),
     };
 
     #region DOT

--- a/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
+++ b/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
@@ -336,21 +336,15 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
         OGCDStrategy.Delay => false,
         _ => false
     };
-    private bool ShouldUsePiercingTalon(Actor? target, PiercingTalonStrategy strategy)
+    private bool ShouldUsePiercingTalon(Actor? target, PiercingTalonStrategy strategy) => strategy switch
     {
-        //EPT is 250p (Lv1-75) / (Lv76+) 350p; NPT is 100p (Lv1-75) / (Lv76+) 150p - given by Elusive Jump procs
-        //Due to no reliable info anywhere, we'll assume numbers here
-        //So we call EPT if the potency is better than our next attack
-        return strategy switch
-        {
-            PiercingTalonStrategy.AllowEX => Player.InCombat && target != null && (!In3y(target) || (In3y(target) && powerLeft > 5 && ComboLastMove is AID.Drakesbane or AID.TrueThrust or AID.RaidenThrust)) && PlayerHasEffect(SID.EnhancedPiercingTalon),
-            PiercingTalonStrategy.Allow => Player.InCombat && target != null && !In3y(target),
-            PiercingTalonStrategy.Force => true,
-            PiercingTalonStrategy.ForceEX => PlayerHasEffect(SID.EnhancedPiercingTalon),
-            PiercingTalonStrategy.Forbid => false,
-            _ => false
-        };
-    }
+        PiercingTalonStrategy.AllowEX => Player.InCombat && target != null && !In3y(target) && PlayerHasEffect(SID.EnhancedPiercingTalon),
+        PiercingTalonStrategy.Allow => Player.InCombat && target != null && !In3y(target),
+        PiercingTalonStrategy.Force => true,
+        PiercingTalonStrategy.ForceEX => PlayerHasEffect(SID.EnhancedPiercingTalon),
+        PiercingTalonStrategy.Forbid => false,
+        _ => false
+    };
     private bool ShouldUsePotion(PotionStrategy strategy) => strategy switch
     {
         PotionStrategy.AlignWithRaidBuffs => Player.InCombat && lcCD <= GCD * 2 && blCD <= GCD * 2,

--- a/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
+++ b/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
@@ -327,12 +327,13 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
         var lv26to88 = (Unlocked(AID.FullThrust) && ComboLastMove is AID.VorpalThrust or AID.LanceBarrage) || (Unlocked(AID.Drakesbane) && ComboLastMove is AID.WheelingThrust or AID.FangAndClaw);
         var lv88plus = HasLC && (TotalCD(AID.LifeSurge) < 40 || TotalCD(AID.BattleLitany) > 50) && lv26to88;
         var st = Unlocked(TraitID.EnhancedLifeSurge) ? lv88plus : (lv26to88 || lv18to25);
+        var tt = (CanLC ? HasLC : CanLS) && (Unlocked(AID.ChaosThrust) ? (Unlocked(TraitID.EnhancedLifeSurge) ? ComboLastMove is AID.FangAndClaw or AID.WheelingThrust or AID.Drakesbane : ComboLastMove is AID.FangAndClaw or AID.WheelingThrust) : lv26to88);
         var aoe = Unlocked(AID.CoerthanTorment) ? ComboLastMove is AID.SonicThrust : Unlocked(AID.SonicThrust) ? ComboLastMove is AID.DoomSpike : Unlocked(AID.DoomSpike) && !NeedPower;
         var minimal = InsideCombatWith(target) && HasPower && InsideRange;
         var buffed = ((HasLC && HasLOTD) || HasBL) && (ShouldUseAOE ? aoe : lv26to88);
         return strategy switch
         {
-            SurgeStrategy.Automatic => minimal && (ShouldUseAOE ? aoe : st),
+            SurgeStrategy.Automatic => minimal && (ShouldUseAOE ? aoe : ShouldUseDOT ? tt : st),
             SurgeStrategy.WhenBuffed => minimal && buffed,
             SurgeStrategy.Force => true,
             SurgeStrategy.ForceWeave => CanWeaveIn,
@@ -737,6 +738,10 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
         if (BestDOTTargets != null)
         {
             Hints.ForcedTarget = BestDOTTargets.Actor;
+        }
+        if (BestDOTTargets == null)
+        {
+            GetNextTarget(strategy, ref primaryTarget, 3);
         }
         var pos = GetBestPositional(strategy, primaryTarget);
         UpdatePositionals(primaryTarget, ref pos);

--- a/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
+++ b/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
@@ -9,18 +9,15 @@ namespace BossMod.Autorotation.akechi;
 public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : AkechiTools<AID, TraitID>(manager, player)
 {
     #region Enums: Abilities / Strategies
-    public enum Track { Combo = SharedTrack.Count, Dives, Potion, BattleLitany, LifeSurge, Jump, DragonfireDive, Geirskogul, Stardiver, PiercingTalon, TrueNorth, LanceCharge, MirageDive, Nastrond, WyrmwindThrust, RiseOfTheDragon, Starcross }
+    public enum Track { Combo = SharedTrack.Count, Dives, Potion, BattleLitany, LifeSurge, PiercingTalon, TrueNorth, DragonfireDive, Geirskogul, Stardiver, Jump, LanceCharge, MirageDive, Nastrond, WyrmwindThrust, RiseOfTheDragon, Starcross }
     public enum ComboStrategy { None, Force123ST, ForceBuffsST }
     public enum DivesStrategy { AllowMaxMelee, AllowCloseMelee, Allow, Forbid }
     public enum PotionStrategy { Manual, AlignWithRaidBuffs, Immediate }
     public enum LitanyStrategy { Automatic, Together, Force, ForceWeave, Delay }
     public enum SurgeStrategy { Automatic, Force, ForceWeave, ForceNextOpti, ForceNextOptiWeave, Delay }
-    public enum JumpStrategy { Automatic, Force, ForceEX, ForceEX2, ForceWeave, Delay }
-    public enum DragonfireStrategy { Automatic, Force, ForceEX, ForceWeave, Delay }
-    public enum GeirskogulStrategy { Automatic, Force, ForceEX, ForceWeave, Delay }
-    public enum StardiverStrategy { Automatic, Force, ForceEX, ForceWeave, Delay }
     public enum PiercingTalonStrategy { AllowEX, Allow, Force, ForceEX, Forbid }
     public enum TrueNorthStrategy { Automatic, ASAP, Rear, Flank, Force, Delay }
+    public enum CommonStrategy { Automatic, Force, ForceEX, ForceWeave, ForceWeaveEX, Delay }
     #endregion
 
     #region Module Definitions
@@ -65,35 +62,6 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
             .AddOption(SurgeStrategy.ForceNextOptiWeave, "Force Weave Optimally", "Force Life Surge optimally inside the next possible weave window", 40, 5, ActionTargets.Hostile, 6)
             .AddOption(SurgeStrategy.Delay, "Delay", "Delay the use of Life Surge", 0, 0, ActionTargets.None, 6)
             .AddAssociatedActions(AID.LifeSurge);
-        res.Define(Track.Jump).As<JumpStrategy>("Jump", uiPriority: 145)
-            .AddOption(JumpStrategy.Automatic, "Automatic", "Use Jump normally")
-            .AddOption(JumpStrategy.Force, "Force Jump", "Force Jump usage", 30, 0, ActionTargets.Self, 30, 67)
-            .AddOption(JumpStrategy.ForceEX, "Force Jump (EX)", "Force Jump usage (Grants Dive Ready buff)", 30, 15, ActionTargets.Self, 68, 74)
-            .AddOption(JumpStrategy.ForceEX2, "Force High Jump", "Force High Jump usage", 30, 15, ActionTargets.Self, 75)
-            .AddOption(JumpStrategy.ForceWeave, "Force Weave", "Force Jump usage inside the next possible weave window", 30, 15, ActionTargets.Hostile, 68)
-            .AddOption(JumpStrategy.Delay, "Delay", "Delay Jump usage", 0, 0, ActionTargets.None, 30)
-            .AddAssociatedActions(AID.Jump, AID.HighJump);
-        res.Define(Track.DragonfireDive).As<DragonfireStrategy>("Dragonfire Dive", "D.Dive", uiPriority: 155)
-            .AddOption(DragonfireStrategy.Automatic, "Automatic", "Use Dragonfire Dive normally")
-            .AddOption(DragonfireStrategy.Force, "Force", "Force Dragonfire Dive usage", 120, 0, ActionTargets.Hostile, 50, 91)
-            .AddOption(DragonfireStrategy.ForceEX, "ForceEX", "Force Dragonfire Dive (Grants Dragon's Flight)", 120, 30, ActionTargets.Hostile, 92)
-            .AddOption(DragonfireStrategy.ForceWeave, "Force Weave", "Force Dragonfire Dive usage inside the next possible weave window", 120, 0, ActionTargets.Hostile, 68)
-            .AddOption(DragonfireStrategy.Delay, "Delay", "Delay Dragonfire Dive usage", 0, 0, ActionTargets.None, 50)
-            .AddAssociatedActions(AID.DragonfireDive);
-        res.Define(Track.Geirskogul).As<GeirskogulStrategy>("Geirskogul", "Geirs.", uiPriority: 150)
-            .AddOption(GeirskogulStrategy.Automatic, "Automatic", "Use Geirskogul normally")
-            .AddOption(GeirskogulStrategy.Force, "Force", "Force Geirskogul usage", 60, 0, ActionTargets.Hostile, 60, 69)
-            .AddOption(GeirskogulStrategy.ForceEX, "ForceEX", "Force Geirskogul (Grants Life of the Dragon & Nastrond Ready)", 60, 20, ActionTargets.Hostile, 70)
-            .AddOption(GeirskogulStrategy.ForceWeave, "Force Weave", "Force Geirskogul usage inside the next possible weave window", 60, 20, ActionTargets.Hostile, 70)
-            .AddOption(GeirskogulStrategy.Delay, "Delay", "Delay Geirskogul usage", 0, 0, ActionTargets.None, 60)
-            .AddAssociatedActions(AID.Geirskogul);
-        res.Define(Track.Stardiver).As<StardiverStrategy>("Stardiver", "S.diver", uiPriority: 140)
-            .AddOption(StardiverStrategy.Automatic, "Automatic", "Use Stardiver normally")
-            .AddOption(StardiverStrategy.Force, "Force", "Force Stardiver usage", 30, 0, ActionTargets.Hostile, 80, 99)
-            .AddOption(StardiverStrategy.ForceEX, "ForceEX", "Force Stardiver (Grants Starcross Ready)", 30, 0, ActionTargets.Hostile, 100)
-            .AddOption(StardiverStrategy.ForceWeave, "Force Weave", "Force Stardiver usage inside the next possible weave window", 30, 0, ActionTargets.Hostile, 80)
-            .AddOption(StardiverStrategy.Delay, "Delay", "Delay Stardiver usage", 0, 0, ActionTargets.None, 80)
-            .AddAssociatedActions(AID.Stardiver);
         res.Define(Track.PiercingTalon).As<PiercingTalonStrategy>("Piercing Talon", "P.Talon", uiPriority: 100)
             .AddOption(PiercingTalonStrategy.AllowEX, "AllowEX", "Allow use of Piercing Talon if already in combat, outside melee range, & is Enhanced")
             .AddOption(PiercingTalonStrategy.Allow, "Allow", "Allow use of Piercing Talon if already in combat & outside melee range")
@@ -109,6 +77,38 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
             .AddOption(TrueNorthStrategy.Force, "Force", "Force True North usage", 45, 10, ActionTargets.Self, 50)
             .AddOption(TrueNorthStrategy.Delay, "Delay", "Delay True North usage", 0, 0, ActionTargets.None, 50)
             .AddAssociatedActions(ClassShared.AID.TrueNorth);
+        res.Define(Track.DragonfireDive).As<CommonStrategy>("Dragonfire Dive", "D.Dive", uiPriority: 155)
+            .AddOption(CommonStrategy.Automatic, "Automatic", "Use Dragonfire Dive normally")
+            .AddOption(CommonStrategy.Force, "Force", "Force Dragonfire Dive usage", 120, 0, ActionTargets.Hostile, 50, 91)
+            .AddOption(CommonStrategy.ForceEX, "ForceEX", "Force Dragonfire Dive (Grants Dragon's Flight)", 120, 30, ActionTargets.Hostile, 92)
+            .AddOption(CommonStrategy.ForceWeave, "Force Weave", "Force Dragonfire Dive usage inside the next possible weave window", 120, 0, ActionTargets.Hostile, 68)
+            .AddOption(CommonStrategy.ForceWeaveEX, "Force Weave (EX)", "Force Dragonfire Dive usage inside the next possible weave window (Grants Dragon's Flight)", 120, 30, ActionTargets.Hostile, 92)
+            .AddOption(CommonStrategy.Delay, "Delay", "Delay Dragonfire Dive usage", 0, 0, ActionTargets.None, 50)
+            .AddAssociatedActions(AID.DragonfireDive);
+        res.Define(Track.Geirskogul).As<CommonStrategy>("Geirskogul", "Geirs.", uiPriority: 150)
+            .AddOption(CommonStrategy.Automatic, "Automatic", "Use Geirskogul normally")
+            .AddOption(CommonStrategy.Force, "Force", "Force Geirskogul usage", 60, 0, ActionTargets.Hostile, 60, 69)
+            .AddOption(CommonStrategy.ForceEX, "ForceEX", "Force Geirskogul (Grants Life of the Dragon & Nastrond Ready)", 60, 20, ActionTargets.Hostile, 70)
+            .AddOption(CommonStrategy.ForceWeave, "Force Weave", "Force Geirskogul usage inside the next possible weave window", 60, 20, ActionTargets.Hostile, 70)
+            .AddOption(CommonStrategy.ForceWeaveEX, "Force Weave (EX)", "Force Geirskogul usage inside the next possible weave window (Grants Life of the Dragon & Nastrond Ready)", 60, 20, ActionTargets.Hostile, 70)
+            .AddOption(CommonStrategy.Delay, "Delay", "Delay Geirskogul usage", 0, 0, ActionTargets.None, 60)
+            .AddAssociatedActions(AID.Geirskogul);
+        res.Define(Track.Stardiver).As<CommonStrategy>("Stardiver", "S.diver", uiPriority: 140)
+            .AddOption(CommonStrategy.Automatic, "Automatic", "Use Stardiver normally")
+            .AddOption(CommonStrategy.Force, "Force", "Force Stardiver usage", 30, 0, ActionTargets.Hostile, 80, 99)
+            .AddOption(CommonStrategy.ForceEX, "ForceEX", "Force Stardiver (Grants Starcross Ready)", 30, 0, ActionTargets.Hostile, 100)
+            .AddOption(CommonStrategy.ForceWeave, "Force Weave", "Force Stardiver usage inside the next possible weave window", 30, 0, ActionTargets.Hostile, 80)
+            .AddOption(CommonStrategy.ForceWeaveEX, "Force Weave (EX)", "Force Stardiver usage inside the next possible weave window (Grants Starcross Ready)", 30, 0, ActionTargets.Hostile, 100)
+            .AddOption(CommonStrategy.Delay, "Delay", "Delay Stardiver usage", 0, 0, ActionTargets.None, 80)
+            .AddAssociatedActions(AID.Stardiver);
+        res.Define(Track.Jump).As<CommonStrategy>("Jump", uiPriority: 145)
+            .AddOption(CommonStrategy.Automatic, "Automatic", "Use Jump normally")
+            .AddOption(CommonStrategy.Force, "Force Jump", "Force Jump usage", 30, 0, ActionTargets.Self, 30, 67)
+            .AddOption(CommonStrategy.ForceEX, "Force Jump (EX)", "Force Jump usage (Grants Dive Ready buff)", 30, 15, ActionTargets.Self, 68)
+            .AddOption(CommonStrategy.ForceWeave, "Force Weave", "Force Jump usage inside the next possible weave window", 30, 0, ActionTargets.Hostile, 30, 67)
+            .AddOption(CommonStrategy.ForceWeaveEX, "Force Weave (EX)", "Force Jump usage inside the next possible weave window (Grants Dive Ready buff)", 30, 15, ActionTargets.Hostile, 68)
+            .AddOption(CommonStrategy.Delay, "Delay", "Delay Jump usage", 0, 0, ActionTargets.None, 30)
+            .AddAssociatedActions(AID.Jump, AID.HighJump);
         res.DefineOGCD(Track.LanceCharge, AID.LanceCharge, "Lance Charge", "L.Charge", uiPriority: 170, 60, 20, ActionTargets.Self, 30);
         res.DefineOGCD(Track.MirageDive, AID.MirageDive, "Mirage Dive", "M.Dive", uiPriority: 130, 0, 0, ActionTargets.Hostile, 68);
         res.DefineOGCD(Track.Nastrond, AID.Nastrond, "Nastrond", "Nast.", uiPriority: 135, 0, 0, ActionTargets.Hostile, 70);
@@ -210,7 +210,6 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
         AID.SonicThrust => Unlocked(AID.CoerthanTorment) ? AID.CoerthanTorment : LowLevelAOE,
         _ => PlayerHasEffect(SID.DraconianFire) ? AID.DraconianFury : LowLevelAOE,
     };
-
     private AID LowLevelAOE => ComboLastMove switch
     {
         AID.Disembowel or AID.SpiralBlow => powerLeft > SkSGCDLength * 2 ? AID.DoomSpike : AID.TrueThrust,
@@ -313,7 +312,7 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     #endregion
 
     #region Dives
-    private bool ShouldUseDragonfireDive(DragonfireStrategy strategy, Actor? target)
+    private bool ShouldUseDragonfireDive(CommonStrategy strategy, Actor? target)
     {
         if (!canDD)
             return false;
@@ -324,39 +323,39 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
         var condition = Unlocked(AID.Geirskogul) ? lv60plus : Unlocked(AID.BattleLitany) ? lv52to59 : lv50to51;
         return strategy switch
         {
-            DragonfireStrategy.Automatic => InsideCombatWith(target) && In20y(target) && condition,
-            DragonfireStrategy.Force => true,
-            DragonfireStrategy.ForceEX => true,
-            DragonfireStrategy.ForceWeave => CanWeaveIn,
+            CommonStrategy.Automatic => InsideCombatWith(target) && In20y(target) && condition,
+            CommonStrategy.Force => true,
+            CommonStrategy.ForceEX => true,
+            CommonStrategy.ForceWeave => CanWeaveIn,
             _ => false
         };
     }
-    private bool ShouldUseJump(JumpStrategy strategy, Actor? target)
+    private bool ShouldUseJump(CommonStrategy strategy, Actor? target)
     {
         if (!canJump)
             return false;
 
         return strategy switch
         {
-            JumpStrategy.Automatic => InsideCombatWith(target) && In20y(target) && (hasLC || lcCD is < 35 and > 13),
-            JumpStrategy.ForceEX or JumpStrategy.ForceEX2 => true,
-            JumpStrategy.ForceWeave => CanWeaveIn,
-            JumpStrategy.Delay => false,
+            CommonStrategy.Automatic => InsideCombatWith(target) && In20y(target) && (hasLC || lcCD is < 35 and > 13),
+            CommonStrategy.ForceEX or CommonStrategy.ForceEX => true,
+            CommonStrategy.ForceWeave or CommonStrategy.ForceWeaveEX => CanWeaveIn,
+            CommonStrategy.Delay => false,
             _ => false
         };
 
     }
-    private bool ShouldUseStardiver(StardiverStrategy strategy, Actor? target)
+    private bool ShouldUseStardiver(CommonStrategy strategy, Actor? target)
     {
         if (!canSD)
             return false;
 
         return strategy switch
         {
-            StardiverStrategy.Automatic => InsideCombatWith(target) && In20y(target) && hasLOTD,
-            StardiverStrategy.Force or StardiverStrategy.ForceEX => true,
-            StardiverStrategy.ForceWeave => CanWeaveIn,
-            StardiverStrategy.Delay => false,
+            CommonStrategy.Automatic => InsideCombatWith(target) && In20y(target) && hasLOTD,
+            CommonStrategy.ForceEX or CommonStrategy.ForceEX => true,
+            CommonStrategy.ForceWeave or CommonStrategy.ForceWeaveEX => CanWeaveIn,
+            CommonStrategy.Delay => false,
             _ => false
         };
 
@@ -381,17 +380,17 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     #endregion
 
     #region Spears
-    private bool ShouldUseGeirskogul(GeirskogulStrategy strategy, Actor? target)
+    private bool ShouldUseGeirskogul(CommonStrategy strategy, Actor? target)
     {
         if (!canGeirskogul)
             return false;
 
         return strategy switch
         {
-            GeirskogulStrategy.Automatic => InsideCombatWith(target) && In15y(target) && ((InOddWindow(AID.BattleLitany) && hasLC) || (!InOddWindow(AID.BattleLitany) && hasLC && hasBL)),
-            GeirskogulStrategy.Force or GeirskogulStrategy.ForceEX => true,
-            GeirskogulStrategy.ForceWeave => CanWeaveIn,
-            GeirskogulStrategy.Delay => false,
+            CommonStrategy.Automatic => InsideCombatWith(target) && In15y(target) && ((InOddWindow(AID.BattleLitany) && hasLC) || (!InOddWindow(AID.BattleLitany) && hasLC && hasBL)),
+            CommonStrategy.ForceEX or CommonStrategy.ForceEX => true,
+            CommonStrategy.ForceWeave or CommonStrategy.ForceWeaveEX => CanWeaveIn,
+            CommonStrategy.Delay => false,
             _ => false
         };
     }
@@ -463,7 +462,7 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     }
     private bool ShouldUsePiercingTalon(Actor? target, PiercingTalonStrategy strategy)
     {
-        var allow = InsideCombatWith(target) && !In3y(target);
+        var allow = InsideCombatWith(target) && ((!ShouldUseAOE && !InMeleeRange(target)) || (ShouldUseAOE && !In10y(target)));
         return strategy switch
         {
             PiercingTalonStrategy.AllowEX => allow && PlayerHasEffect(SID.EnhancedPiercingTalon),
@@ -483,7 +482,7 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     };
     private bool ShouldUseTrueNorth(TrueNorthStrategy strategy, Actor? target)
     {
-        var condition = target != null && Player.InCombat && CanTrueNorth && NextPositionalImminent && !NextPositionalCorrect;
+        var condition = target != null && Player.InCombat && InMeleeRange(target) && CanTrueNorth && NextPositionalImminent && !NextPositionalCorrect;
         var needRear = !IsOnRear(target!) && ((Unlocked(AID.ChaosThrust) && ComboLastMove is AID.Disembowel or AID.SpiralBlow) || (Unlocked(AID.WheelingThrust) && ComboLastMove is AID.ChaosThrust or AID.ChaoticSpring));
         var needFlank = !IsOnFlank(target!) && Unlocked(AID.FangAndClaw) && ComboLastMove is AID.HeavensThrust or AID.FullThrust;
         return strategy switch
@@ -553,13 +552,13 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
         var ls = strategy.Option(Track.LifeSurge);
         var lsStrat = ls.As<SurgeStrategy>();
         var jump = strategy.Option(Track.Jump);
-        var jumpStrat = jump.As<JumpStrategy>();
+        var jumpStrat = jump.As<CommonStrategy>();
         var dd = strategy.Option(Track.DragonfireDive);
-        var ddStrat = dd.As<DragonfireStrategy>();
+        var ddStrat = dd.As<CommonStrategy>();
         var geirskogul = strategy.Option(Track.Geirskogul);
-        var geirskogulStrat = geirskogul.As<GeirskogulStrategy>();
+        var geirskogulStrat = geirskogul.As<CommonStrategy>();
         var sd = strategy.Option(Track.Stardiver);
-        var sdStrat = sd.As<StardiverStrategy>();
+        var sdStrat = sd.As<CommonStrategy>();
         var wt = strategy.Option(Track.WyrmwindThrust);
         var wtStrat = wt.As<OGCDStrategy>();
         var rotd = strategy.Option(Track.RiseOfTheDragon);
@@ -630,14 +629,14 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
                 if (divesGood)
                 {
                     if (ShouldUseJump(jumpStrat, primaryTarget?.Actor))
-                        QueueOGCD(Unlocked(AID.HighJump) ? AID.HighJump : AID.Jump, TargetChoice(jump) ?? primaryTarget?.Actor, jumpStrat is JumpStrategy.Force or JumpStrategy.ForceEX or JumpStrategy.ForceEX2 or JumpStrategy.ForceWeave ? OGCDPriority.Forced : OGCDPriority.SlightlyHigh);
+                        QueueOGCD(Unlocked(AID.HighJump) ? AID.HighJump : AID.Jump, TargetChoice(jump) ?? primaryTarget?.Actor, jumpStrat is CommonStrategy.Force or CommonStrategy.ForceEX or CommonStrategy.ForceWeave or CommonStrategy.ForceWeaveEX ? OGCDPriority.Forced : OGCDPriority.SlightlyHigh);
                     if (ShouldUseDragonfireDive(ddStrat, primaryTarget?.Actor))
-                        QueueOGCD(AID.DragonfireDive, TargetChoice(dd) ?? BestDiveTarget?.Actor, ddStrat is DragonfireStrategy.Force or DragonfireStrategy.ForceWeave ? OGCDPriority.Forced : OGCDPriority.High);
+                        QueueOGCD(AID.DragonfireDive, TargetChoice(dd) ?? BestDiveTarget?.Actor, ddStrat is CommonStrategy.Force or CommonStrategy.ForceWeave or CommonStrategy.ForceWeaveEX ? OGCDPriority.Forced : OGCDPriority.High);
                     if (ShouldUseStardiver(sdStrat, primaryTarget?.Actor))
-                        QueueOGCD(AID.Stardiver, TargetChoice(sd) ?? BestDiveTarget?.Actor, sdStrat is StardiverStrategy.Force or StardiverStrategy.ForceEX or StardiverStrategy.ForceWeave ? OGCDPriority.Forced : OGCDPriority.Low);
+                        QueueOGCD(AID.Stardiver, TargetChoice(sd) ?? BestDiveTarget?.Actor, sdStrat is CommonStrategy.Force or CommonStrategy.ForceEX or CommonStrategy.ForceWeave or CommonStrategy.ForceWeaveEX ? OGCDPriority.Forced : OGCDPriority.Low);
                 }
                 if (ShouldUseGeirskogul(geirskogulStrat, primaryTarget?.Actor))
-                    QueueOGCD(AID.Geirskogul, TargetChoice(geirskogul) ?? BestSpearTarget?.Actor, geirskogulStrat is GeirskogulStrategy.Force or GeirskogulStrategy.ForceEX or GeirskogulStrategy.ForceWeave ? OGCDPriority.Forced : OGCDPriority.ExtremelyHigh);
+                    QueueOGCD(AID.Geirskogul, TargetChoice(geirskogul) ?? BestSpearTarget?.Actor, geirskogulStrat is CommonStrategy.Force or CommonStrategy.ForceEX or CommonStrategy.ForceWeave or CommonStrategy.ForceWeaveEX ? OGCDPriority.Forced : OGCDPriority.ExtremelyHigh);
                 if (ShouldUseMirageDive(mdStrat, primaryTarget?.Actor))
                     QueueOGCD(AID.MirageDive, TargetChoice(md) ?? primaryTarget?.Actor, OGCDPrio(mdStrat, OGCDPriority.ExtremelyLow));
                 if (ShouldUseNastrond(nastrondStrat, primaryTarget?.Actor))
@@ -655,8 +654,6 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
                     QueueOGCD(AID.WyrmwindThrust, TargetChoice(wt) ?? BestSpearTarget?.Actor, wtStrat is OGCDStrategy.Force or OGCDStrategy.AnyWeave or OGCDStrategy.EarlyWeave or OGCDStrategy.LateWeave ? OGCDPriority.Forced : PlayerHasEffect(SID.LanceCharge) ? OGCDPriority.ModeratelyHigh : OGCDPriority.Average);
             }
         }
-        if (Player.Level < 60 && ActionReady(AID.LegSweep))
-            QueueOGCD(AID.LegSweep, TargetChoice(AOE) ?? primaryTarget?.Actor, OGCDPrio(mdStrat, OGCDPriority.ExtremelyLow));
         if (ShouldUsePiercingTalon(primaryTarget?.Actor, ptStrat))
             QueueGCD(AID.PiercingTalon, TargetChoice(pt) ?? primaryTarget?.Actor, ptStrat is PiercingTalonStrategy.Force or PiercingTalonStrategy.ForceEX ? GCDPriority.Forced : GCDPriority.SlightlyLow);
         if (ShouldUsePotion(strategy.Option(Track.Potion).As<PotionStrategy>()))

--- a/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
+++ b/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
@@ -134,7 +134,6 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     private bool canROTD;
     private bool canSC;
     private float blCD;
-    private float lcLeft;
     private float lcCD;
     private float powerLeft;
     private float chaosLeft;
@@ -472,8 +471,7 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
         hasLOTD = gauge.LotdTimer > 0;
         blCD = TotalCD(AID.BattleLitany);
         lcCD = TotalCD(AID.LanceCharge);
-        lcLeft = SelfStatusLeft(SID.LanceCharge, 20);
-        powerLeft = SelfStatusLeft(SID.PowerSurge, 30);
+        powerLeft = StatusRemaining(Player, SID.PowerSurge, 30);
         chaosLeft = MathF.Max(StatusDetails(primaryTarget?.Actor, SID.ChaosThrust, Player.InstanceID).Left, StatusDetails(primaryTarget?.Actor, SID.ChaoticSpring, Player.InstanceID).Left);
         hasMD = PlayerHasEffect(SID.DiveReady);
         hasNastrond = PlayerHasEffect(SID.NastrondReady);

--- a/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
+++ b/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
@@ -237,7 +237,7 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
         var minute = Unlocked(TraitID.EnhancedLifeSurge) ? optimal : (normal || lowlvl);
         return strategy switch
         {
-            SurgeStrategy.Automatic => Player.InCombat && target != null && minute,
+            SurgeStrategy.Automatic => Player.InCombat && target != null && canLS && minute,
             SurgeStrategy.Force => canLS,
             SurgeStrategy.ForceWeave => canLS && CanWeaveIn,
             SurgeStrategy.ForceNextOpti => canLS && normal,
@@ -390,7 +390,7 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
         hasSC = PlayerHasEffect(SID.StarcrossReady);
         canLC = ActionReady(AID.LanceCharge);
         canBL = ActionReady(AID.BattleLitany);
-        canLS = Unlocked(AID.LifeSurge) && (Unlocked(TraitID.EnhancedLifeSurge) ? TotalCD(AID.LifeSurge) < 40.6f : TotalCD(AID.LifeSurge) < 0.6f) && !PlayerHasEffect(SID.LifeSurge);
+        canLS = Unlocked(AID.LifeSurge) && !PlayerHasEffect(SID.LifeSurge) && (Unlocked(TraitID.EnhancedLifeSurge) ? TotalCD(AID.LifeSurge) < 40.6f : ChargeCD(AID.LifeSurge) < 0.6f);
         canJump = ActionReady(AID.Jump);
         canDD = ActionReady(AID.DragonfireDive);
         canGeirskogul = ActionReady(AID.Geirskogul);

--- a/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
+++ b/BossMod/Autorotation/Standard/akechi/DPS/AkechiDRG.cs
@@ -249,9 +249,10 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
         var normal = (Unlocked(AID.FullThrust) && ComboLastMove is AID.VorpalThrust or AID.LanceBarrage) || (Unlocked(AID.Drakesbane) && ComboLastMove is AID.WheelingThrust or AID.FangAndClaw);
         var optimal = hasLC && (TotalCD(AID.LifeSurge) < 40 || TotalCD(AID.BattleLitany) > 50) && normal;
         var minute = Unlocked(TraitID.EnhancedLifeSurge) ? optimal : (normal || lowlvl);
+        var aoe = Unlocked(AID.CoerthanTorment) ? ComboLastMove is AID.SonicThrust : Unlocked(AID.SonicThrust) ? ComboLastMove is AID.DoomSpike : Unlocked(AID.DoomSpike) && powerLeft > SkSGCDLength * 2;
         return strategy switch
         {
-            SurgeStrategy.Automatic => Player.InCombat && target != null && canLS && minute,
+            SurgeStrategy.Automatic => Player.InCombat && target != null && canLS && (ShouldUseAOE ? aoe : minute),
             SurgeStrategy.Force => canLS,
             SurgeStrategy.ForceWeave => canLS && CanWeaveIn,
             SurgeStrategy.ForceNextOpti => canLS && normal,
@@ -264,7 +265,7 @@ public sealed class AkechiDRG(RotationModuleManager manager, Actor player) : Ake
     #region Dives
     private bool ShouldUseDragonfireDive(DragonfireStrategy strategy, Actor? target) => strategy switch
     {
-        DragonfireStrategy.Automatic => Player.InCombat && target != null && In20y(target) && canDD && hasLC && hasBL && hasLOTD,
+        DragonfireStrategy.Automatic => Player.InCombat && target != null && In20y(target) && canDD && ((hasLC && hasBL && hasLOTD) || (!Unlocked(AID.BattleLitany) && hasLC)),
         DragonfireStrategy.Force => canDD,
         DragonfireStrategy.ForceEX => canDD,
         DragonfireStrategy.ForceWeave => canDD && CanWeaveIn,

--- a/BossMod/Autorotation/Standard/akechi/Tank/AkechiDRK.cs
+++ b/BossMod/Autorotation/Standard/akechi/Tank/AkechiDRK.cs
@@ -459,7 +459,7 @@ public sealed class AkechiDRK(RotationModuleManager manager, Actor player) : Ake
             }
         }
         if (ShouldUseDisesteem(deStrat, primaryTarget))
-            QueueGCD(AID.Disesteem, TargetChoice(de) ?? BestRectTarget?.Actor, deStrat is GCDStrategy.Force ? GCDPriority.Forced : GCDPriority.AboveAverage);
+            QueueGCD(AID.Disesteem, TargetChoice(de) ?? BestRectTarget?.Actor, deStrat is GCDStrategy.Force ? GCDPriority.Forced : CombatTimer < 30 ? GCDPriority.VeryHigh : GCDPriority.AboveAverage);
         if (ShouldUseMP(mpStrat))
         {
             switch (mpStrat)

--- a/BossMod/Autorotation/Standard/akechi/Tank/AkechiDRK.cs
+++ b/BossMod/Autorotation/Standard/akechi/Tank/AkechiDRK.cs
@@ -14,7 +14,7 @@ public sealed class AkechiDRK(RotationModuleManager manager, Actor player) : Ake
     public enum MPStrategy { Optimal, Auto3k, Auto6k, Auto9k, AutoRefresh, Edge3k, Edge6k, Edge9k, EdgeRefresh, Flood3k, Flood6k, Flood9k, FloodRefresh, ForceEdge, ForceFlood, Delay }
     public enum CarveStrategy { Automatic, OnlyCarve, OnlyDrain, ForceCarve, ForceDrain, Delay }
     public enum DeliriumComboStrategy { Automatic, ScarletDelirum, Comeuppance, Torcleaver, Impalement, Delay }
-    public enum PotionStrategy { Manual, AlignWithRaidBuffs, Immediate }
+    public enum PotionStrategy { Manual, AlignWithLivingShadow, Immediate }
     public enum UnmendStrategy { OpenerFar, OpenerForce, Force, Allow, Forbid }
     #endregion
 
@@ -69,7 +69,7 @@ public sealed class AkechiDRK(RotationModuleManager manager, Actor player) : Ake
             .AddAssociatedActions(AID.ScarletDelirium, AID.Comeuppance, AID.Torcleaver, AID.Impalement);
         res.Define(Track.Potion).As<PotionStrategy>("Potion", uiPriority: 20)
             .AddOption(PotionStrategy.Manual, "Manual", "Do not use automatically")
-            .AddOption(PotionStrategy.AlignWithRaidBuffs, "AlignWithRaidBuffs", "Align with Living Shadow (to ensure use on 2-minute windows)", 270, 30, ActionTargets.Self)
+            .AddOption(PotionStrategy.AlignWithLivingShadow, "AlignWithLivingShadow", "Align with Living Shadow (to ensure use on 2-minute windows)", 270, 30, ActionTargets.Self)
             .AddOption(PotionStrategy.Immediate, "Immediate", "Use ASAP, regardless of any buffs", 270, 30, ActionTargets.Self)
             .AddAssociatedAction(ActionDefinitions.IDPotionStr);
         res.Define(Track.Unmend).As<UnmendStrategy>("Ranged", "Ranged", uiPriority: 30)
@@ -318,7 +318,7 @@ public sealed class AkechiDRK(RotationModuleManager manager, Actor player) : Ake
     };
     private bool ShouldUsePotion(PotionStrategy strategy) => strategy switch
     {
-        PotionStrategy.AlignWithRaidBuffs => LivingShadow.CD < 5,
+        PotionStrategy.AlignWithLivingShadow => LivingShadow.CD < 5,
         PotionStrategy.Immediate => true,
         _ => false
     };

--- a/BossMod/Autorotation/Standard/akechi/Tank/AkechiDRK.cs
+++ b/BossMod/Autorotation/Standard/akechi/Tank/AkechiDRK.cs
@@ -11,7 +11,7 @@ public sealed class AkechiDRK(RotationModuleManager manager, Actor player) : Ake
     #region Enums: Abilities / Strategies
     public enum Track { Blood = SharedTrack.Count, MP, Carve, DeliriumCombo, Potion, Unmend, Delirium, SaltedEarth, SaltAndDarkness, LivingShadow, Shadowbringer, Disesteem }
     public enum BloodStrategy { Automatic, OnlyBloodspiller, OnlyQuietus, ForceBloodspiller, ForceQuietus, Conserve }
-    public enum MPStrategy { Optimal, Auto3k, Auto6k, Auto9k, AutoRefresh, Edge3k, Edge6k, Edge9k, EdgeRefresh, Flood3k, Flood6k, Flood9k, FloodRefresh, Delay }
+    public enum MPStrategy { Optimal, Auto3k, Auto6k, Auto9k, AutoRefresh, Edge3k, Edge6k, Edge9k, EdgeRefresh, Flood3k, Flood6k, Flood9k, FloodRefresh, ForceEdge, ForceFlood, Delay }
     public enum CarveStrategy { Automatic, OnlyCarve, OnlyDrain, ForceCarve, ForceDrain, Delay }
     public enum DeliriumComboStrategy { Automatic, ScarletDelirum, Comeuppance, Torcleaver, Impalement, Delay }
     public enum PotionStrategy { Manual, AlignWithRaidBuffs, Immediate }
@@ -35,18 +35,20 @@ public sealed class AkechiDRK(RotationModuleManager manager, Actor player) : Ake
             .AddAssociatedActions(AID.Bloodspiller, AID.Quietus);
         res.Define(Track.MP).As<MPStrategy>("MP", "MP", uiPriority: 190)
             .AddOption(MPStrategy.Optimal, "Optimal", "Use MP actions optimally; 2 for 1 minute, 4 (or 5 if Dark Arts is active) for 2 minutes")
-            .AddOption(MPStrategy.Auto3k, "Auto 3k", "Automatically decide best MP action to use; Uses when at 3000+ MP", 0, 0, ActionTargets.Self, 30)
-            .AddOption(MPStrategy.Auto6k, "Auto 6k", "Automatically decide best MP action to use; Uses when at 6000+ MP", 0, 0, ActionTargets.Self, 30)
-            .AddOption(MPStrategy.Auto9k, "Auto 9k", "Automatically decide best MP action to use; Uses when at 9000+ MP", 0, 0, ActionTargets.Self, 30)
-            .AddOption(MPStrategy.AutoRefresh, "Auto Refresh", "Automatically decide best MP action to use as Darkside refresher only", 0, 0, ActionTargets.Self, 30)
-            .AddOption(MPStrategy.Edge3k, "Edge 3k", "Use Edge of Shadow as Darkside refresher & MP spender; Uses when at 3000+ MP", 0, 0, ActionTargets.Self, 40)
-            .AddOption(MPStrategy.Edge6k, "Edge 6k", "Use Edge of Shadow as Darkside refresher & MP spender; Uses when at 6000+ MP", 0, 0, ActionTargets.Self, 40)
-            .AddOption(MPStrategy.Edge9k, "Edge 9k", "Use Edge of Shadow as Darkside refresher & MP spender; Uses when at 9000+ MP", 0, 0, ActionTargets.Self, 40)
-            .AddOption(MPStrategy.EdgeRefresh, "Edge Refresh", "Use Edge abilities as Darkside refresher only", 0, 0, ActionTargets.Self, 40)
-            .AddOption(MPStrategy.Flood3k, "Flood 3k", "Use Flood of Shadow as Darkside refresher & MP spender; Uses when at 3000+ MP", 0, 0, ActionTargets.Self, 30)
-            .AddOption(MPStrategy.Flood6k, "Flood 6k", "Use Flood of Shadow as Darkside refresher & MP spender; Uses when at 6000+ MP", 0, 0, ActionTargets.Self, 30)
-            .AddOption(MPStrategy.Flood9k, "Flood 9k", "Use Flood of Shadow as Darkside refresher & MP spender; Uses when at 9000+ MP", 0, 0, ActionTargets.Self, 30)
-            .AddOption(MPStrategy.FloodRefresh, "Flood Refresh", "Use Flood abilities as Darkside refresher only", 0, 0, ActionTargets.Self, 30)
+            .AddOption(MPStrategy.Auto3k, "Auto 3k", "Automatically decide best MP action to use; Uses when at 3000+ MP", 0, 0, ActionTargets.Hostile, 30)
+            .AddOption(MPStrategy.Auto6k, "Auto 6k", "Automatically decide best MP action to use; Uses when at 6000+ MP", 0, 0, ActionTargets.Hostile, 30)
+            .AddOption(MPStrategy.Auto9k, "Auto 9k", "Automatically decide best MP action to use; Uses when at 9000+ MP", 0, 0, ActionTargets.Hostile, 30)
+            .AddOption(MPStrategy.AutoRefresh, "Auto Refresh", "Automatically decide best MP action to use as Darkside refresher only", 0, 0, ActionTargets.Hostile, 30)
+            .AddOption(MPStrategy.Edge3k, "Edge 3k", "Use Edge of Shadow as Darkside refresher & MP spender; Uses when at 3000+ MP", 0, 0, ActionTargets.Hostile, 40)
+            .AddOption(MPStrategy.Edge6k, "Edge 6k", "Use Edge of Shadow as Darkside refresher & MP spender; Uses when at 6000+ MP", 0, 0, ActionTargets.Hostile, 40)
+            .AddOption(MPStrategy.Edge9k, "Edge 9k", "Use Edge of Shadow as Darkside refresher & MP spender; Uses when at 9000+ MP", 0, 0, ActionTargets.Hostile, 40)
+            .AddOption(MPStrategy.EdgeRefresh, "Edge Refresh", "Use Edge abilities as Darkside refresher only", 0, 0, ActionTargets.Hostile, 40)
+            .AddOption(MPStrategy.Flood3k, "Flood 3k", "Use Flood of Shadow as Darkside refresher & MP spender; Uses when at 3000+ MP", 0, 0, ActionTargets.Hostile, 30)
+            .AddOption(MPStrategy.Flood6k, "Flood 6k", "Use Flood of Shadow as Darkside refresher & MP spender; Uses when at 6000+ MP", 0, 0, ActionTargets.Hostile, 30)
+            .AddOption(MPStrategy.Flood9k, "Flood 9k", "Use Flood of Shadow as Darkside refresher & MP spender; Uses when at 9000+ MP", 0, 0, ActionTargets.Hostile, 30)
+            .AddOption(MPStrategy.FloodRefresh, "Flood Refresh", "Use Flood abilities as Darkside refresher only", 0, 0, ActionTargets.Hostile, 30)
+            .AddOption(MPStrategy.ForceEdge, "Force Edge", "Force use Edge abilities ASAP", 0, 0, ActionTargets.Hostile, 40)
+            .AddOption(MPStrategy.ForceFlood, "Force Flood", "Force use Flood abilities ASAP", 0, 0, ActionTargets.Hostile, 30)
             .AddOption(MPStrategy.Delay, "Delay", "Delay the use of MP actions for strategic reasons", 0, 0, ActionTargets.None, 30)
             .AddAssociatedActions(AID.EdgeOfDarkness, AID.EdgeOfShadow, AID.FloodOfDarkness, AID.FloodOfShadow);
         res.Define(Track.Carve).As<CarveStrategy>("Carve & Spit / Abyssal Drain", "Carve", uiPriority: 160)
@@ -89,32 +91,40 @@ public sealed class AkechiDRK(RotationModuleManager manager, Actor player) : Ake
     #endregion
 
     #region Module Variables
-    public byte Blood;
-    public (byte State, bool IsActive) DarkArts;
-    public (float Timer, bool IsActive, bool NeedsRefresh) Darkside;
-    public bool RiskingBlood;
-    public bool RiskingMP;
-    public (float Left, float CD, bool IsActive, bool IsReady) SaltedEarth;
-    public (float CD, bool IsReady) AbyssalDrain;
-    public (float CD, bool IsReady) CarveAndSpit;
-    public (ushort Step, float Left, int Stacks, float CD, bool IsActive, bool IsReady) Delirium;
-    public (float Timer, float CD, bool IsActive, bool IsReady) LivingShadow;
-    public (float TotalCD, float ChargeCD, bool HasCharges, bool IsReady) Shadowbringer;
-    public (float Left, bool IsActive, bool IsReady) Disesteem;
+    private byte Blood;
+    private (byte State, bool IsActive) DarkArts;
+    private (float Timer, bool IsActive, bool NeedsRefresh) Darkside;
+    private bool RiskingBlood;
+    private bool RiskingMP;
+    private (float Left, float CD, bool IsActive, bool IsReady) SaltedEarth;
+    private (float CD, bool IsReady) AbyssalDrain;
+    private (float CD, bool IsReady) CarveAndSpit;
+    private (ushort Step, float Left, int Stacks, float CD, bool IsActive, bool IsReady) Delirium;
+    private (float Timer, float CD, bool IsActive, bool IsReady) LivingShadow;
+    private (float TotalCD, float ChargeCD, bool HasCharges, bool IsReady) Shadowbringer;
+    private (float Left, bool IsActive, bool IsReady) Disesteem;
     private bool ShouldUseAOE;
-    public int NumAOERectTargets;
-    public int NumMPRectTargets;
-    public Enemy? BestAOERectTargets;
-    public Enemy? BestMPRectTargets;
-    public Enemy? BestTargetAOERect;
-    public Enemy? BestTargetMPRectHigh;
-    public Enemy? BestTargetMPRectLow;
-    public Enemy? BestTargetMPRect;
+    private int NumAOERectTargets;
+    private Enemy? BestAOERectTargets;
+    private Enemy? BestRectTarget;
+    private Enemy? BestMPTarget;
     #endregion
+
+    #region Rotation Helpers
+    private AID AutoFinish => ComboLastMove switch
+    {
+        AID.SyphonStrike => !Unlocked(AID.Souleater) ? AutoBreak : FullST,
+        AID.HardSlash => !Unlocked(AID.SyphonStrike) ? AutoBreak : FullST,
+        AID.Unleash => !Unlocked(AID.StalwartSoul) ? AutoBreak : FullAOE,
+        AID.Souleater or AID.StalwartSoul or _ => AutoBreak,
+    };
+    private AID AutoBreak => ShouldUseAOE ? FullAOE : FullST;
+    private AID FullST => Unlocked(AID.Souleater) && ComboLastMove is AID.SyphonStrike ? AID.Souleater : Unlocked(AID.SyphonStrike) && ComboLastMove is AID.HardSlash ? AID.SyphonStrike : AID.HardSlash;
+    private AID FullAOE => Unlocked(AID.StalwartSoul) && ComboLastMove is AID.Unleash ? AID.StalwartSoul : AID.Unleash;
 
     #region Upgrade Paths
     private AID BestEdge => Unlocked(AID.EdgeOfShadow) ? AID.EdgeOfShadow : Unlocked(AID.EdgeOfDarkness) ? AID.EdgeOfDarkness : AID.FloodOfDarkness;
-    private AID BestFlood => !Unlocked(AID.FloodOfShadow) ? AID.FloodOfDarkness : AID.FloodOfShadow;
+    private AID BestFlood => Unlocked(AID.FloodOfShadow) ? AID.FloodOfShadow : AID.FloodOfDarkness;
     private AID BestQuietus => Unlocked(AID.Quietus) ? AID.Quietus : AID.Bloodspiller;
     private AID BestBloodSpender => ShouldUseAOE ? BestQuietus : AID.Bloodspiller;
     private AID BestDelirium => Unlocked(AID.Delirium) ? AID.Delirium : AID.BloodWeapon;
@@ -124,16 +134,6 @@ public sealed class AkechiDRK(RotationModuleManager manager, Actor player) : Ake
     private AID DeliriumCombo => Delirium.Step is 2 ? AID.Torcleaver : Delirium.Step is 1 ? AID.Comeuppance : ShouldUseAOE ? AID.Impalement : Unlocked(AID.ScarletDelirium) && Delirium.IsActive && Delirium.Step is 0 ? AID.ScarletDelirium : BestBloodSpender;
     #endregion
 
-    #region Rotation Helpers
-    private AID AutoFinish => ComboLastMove switch
-    {
-        AID.SyphonStrike or AID.HardSlash => FullST,
-        AID.Unleash => FullAOE,
-        AID.Souleater or AID.StalwartSoul or _ => ShouldUseAOE ? FullAOE : FullST,
-    };
-    private AID AutoBreak => ShouldUseAOE ? FullAOE : FullST;
-    private AID FullST => Unlocked(AID.Souleater) && ComboLastMove is AID.SyphonStrike ? AID.Souleater : Unlocked(AID.SyphonStrike) && ComboLastMove is AID.HardSlash ? AID.SyphonStrike : AID.HardSlash;
-    private AID FullAOE => Unlocked(AID.StalwartSoul) && ComboLastMove is AID.Unleash ? AID.StalwartSoul : Unlocked(AID.Unleash) ? AID.Unleash : FullST;
     #endregion
 
     #region Cooldown Helpers
@@ -141,47 +141,68 @@ public sealed class AkechiDRK(RotationModuleManager manager, Actor player) : Ake
     #region MP
     private bool ShouldSpendMP(MPStrategy strategy)
     {
-        if (strategy != MPStrategy.Optimal)
+        //if locked, skip
+        if (strategy != MPStrategy.Optimal || !Unlocked(AID.FloodOfDarkness))
             return false;
-        if (strategy == MPStrategy.Optimal)
+        if (strategy == MPStrategy.Optimal && Unlocked(AID.FloodOfDarkness))
         {
+            //if we're risking MP we should spend it
             if (RiskingMP)
-                return true;
-
-            if (DarkArts.IsActive)
+                return MP >= 3000 || DarkArts.IsActive;
+            if (Unlocked(AID.Delirium))
             {
-                if (Delirium.CD >= 40)
-                    return true;
-                if (Delirium.CD >= Darkside.Timer + GCD)
-                    return true;
+                //Dark Arts
+                if (Unlocked(AID.TheBlackestNight) && DarkArts.IsActive)
+                {
+                    //if Delirium is active, burn it
+                    if (Delirium.CD >= 40)
+                        return true;
+                    //if Delirium is down longer than Darkside, burn it
+                    if (Delirium.CD >= Darkside.Timer + GCD)
+                        return true;
+                }
+                //1 minute window - 2 uses expected
+                if (Delirium.CD >= 40 && InOddWindow(AID.LivingShadow))
+                    return MP >= 6000;
+                //2 minute window - 4 uses expected; 5 with Dark Arts
+                if (Delirium.CD >= 40 && !InOddWindow(AID.LivingShadow))
+                    return MP >= 3000;
             }
-            //2 uses
-            if (Delirium.CD >= 40 && InOddWindow(AID.LivingShadow))
-                return MP >= 6000;
-            //4 uses (5 with DA)
-            if (Delirium.CD >= 40 && !InOddWindow(AID.LivingShadow))
+            //if no Delirium, just use it whenever we have more than 3000 MP
+            if (!Unlocked(AID.Delirium))
                 return MP >= 3000;
         }
+        if (strategy is MPStrategy.ForceEdge or MPStrategy.ForceFlood)
+            return MP >= 3000;
         return false;
     }
-    private bool ShouldUseMP(MPStrategy strategy) => strategy switch
+    private bool ShouldUseMP(MPStrategy strategy)
     {
-        MPStrategy.Optimal => ShouldSpendMP(MPStrategy.Optimal),
-        MPStrategy.Auto3k => CanWeaveIn && MP >= 3000,
-        MPStrategy.Auto6k => CanWeaveIn && MP >= 6000,
-        MPStrategy.Auto9k => CanWeaveIn && MP >= 9000,
-        MPStrategy.AutoRefresh => CanWeaveIn && RiskingMP,
-        MPStrategy.Edge3k => CanWeaveIn && MP >= 3000,
-        MPStrategy.Edge6k => CanWeaveIn && MP >= 6000,
-        MPStrategy.Edge9k => CanWeaveIn && MP >= 9000,
-        MPStrategy.EdgeRefresh => CanWeaveIn && RiskingMP,
-        MPStrategy.Flood3k => CanWeaveIn && MP >= 3000,
-        MPStrategy.Flood6k => CanWeaveIn && MP >= 6000,
-        MPStrategy.Flood9k => CanWeaveIn && MP >= 9000,
-        MPStrategy.FloodRefresh => CanWeaveIn && RiskingMP,
-        MPStrategy.Delay => false,
-        _ => false
-    };
+        if (!CanWeaveIn)
+            return false;
+
+        return strategy switch
+        {
+            MPStrategy.Optimal => ShouldSpendMP(MPStrategy.Optimal),
+            MPStrategy.Auto3k => MP >= 3000,
+            MPStrategy.Auto6k => MP >= 6000,
+            MPStrategy.Auto9k => MP >= 9000,
+            MPStrategy.AutoRefresh => RiskingMP,
+            MPStrategy.Edge3k => MP >= 3000,
+            MPStrategy.Edge6k => MP >= 6000,
+            MPStrategy.Edge9k => MP >= 9000,
+            MPStrategy.EdgeRefresh => RiskingMP,
+            MPStrategy.Flood3k => MP >= 3000,
+            MPStrategy.Flood6k => MP >= 6000,
+            MPStrategy.Flood9k => MP >= 9000,
+            MPStrategy.FloodRefresh => RiskingMP,
+            MPStrategy.ForceEdge => MP >= 3000 || DarkArts.IsActive,
+            MPStrategy.ForceFlood => MP >= 3000 || DarkArts.IsActive,
+            MPStrategy.Delay => false,
+            _ => false
+        };
+
+    }
     #endregion
 
     private bool ShouldUseBlood(BloodStrategy strategy, Enemy? target) => strategy switch
@@ -336,11 +357,11 @@ public sealed class AkechiDRK(RotationModuleManager manager, Actor player) : Ake
         Shadowbringer.HasCharges = TotalCD(AID.Shadowbringer) <= 60; //Checks if Shadowbringer has charges
         Shadowbringer.IsReady = Unlocked(AID.Shadowbringer) && Shadowbringer.HasCharges; //Shadowbringer ability
         ShouldUseAOE = ShouldUseAOECircle(5).OnThreeOrMore;
-        (BestAOERectTargets, NumAOERectTargets) = GetBestTarget(PlayerTarget, 10, Is10yRectTarget);
-        BestTargetAOERect = Unlocked(AID.Shadowbringer) && NumAOERectTargets > 1 ? BestAOERectTargets : primaryTarget;
-        BestTargetMPRectHigh = Unlocked(AID.FloodOfShadow) && NumAOERectTargets > 2 ? BestAOERectTargets : primaryTarget;
-        BestTargetMPRectLow = !Unlocked(AID.FloodOfShadow) && NumAOERectTargets > 3 ? BestAOERectTargets : primaryTarget;
-        BestTargetMPRect = Unlocked(AID.FloodOfShadow) ? BestTargetMPRectHigh : BestTargetMPRectLow;
+        (BestAOERectTargets, NumAOERectTargets) = GetBestTarget(primaryTarget, 10, Is10yRectTarget);
+        BestRectTarget = Unlocked(AID.Shadowbringer) && NumAOERectTargets > 1 ? BestAOERectTargets : primaryTarget;
+        var BestHighMPTarget = NumAOERectTargets > 2 ? BestAOERectTargets : primaryTarget;
+        var BestLowMPTarget = NumAOERectTargets > 3 ? BestAOERectTargets : primaryTarget;
+        BestMPTarget = Unlocked(AID.FloodOfShadow) ? BestHighMPTarget : BestLowMPTarget;
 
         #region Strategy Definitions
         var mp = strategy.Option(Track.MP);
@@ -398,7 +419,7 @@ public sealed class AkechiDRK(RotationModuleManager manager, Actor player) : Ake
                 if (ShouldUseSaltedEarth(seStrat, primaryTarget))
                     QueueOGCD(AID.SaltedEarth, Player, seStrat is OGCDStrategy.Force or OGCDStrategy.AnyWeave or OGCDStrategy.EarlyWeave or OGCDStrategy.LateWeave ? OGCDPriority.Forced : OGCDPriority.AboveAverage);
                 if (ShouldUseShadowbringer(sbStrat, primaryTarget))
-                    QueueOGCD(AID.Shadowbringer, TargetChoice(sb) ?? BestTargetAOERect?.Actor, sbStrat is OGCDStrategy.Force or OGCDStrategy.AnyWeave or OGCDStrategy.EarlyWeave or OGCDStrategy.LateWeave ? OGCDPriority.Forced : OGCDPriority.Average);
+                    QueueOGCD(AID.Shadowbringer, TargetChoice(sb) ?? BestRectTarget?.Actor, sbStrat is OGCDStrategy.Force or OGCDStrategy.AnyWeave or OGCDStrategy.EarlyWeave or OGCDStrategy.LateWeave ? OGCDPriority.Forced : OGCDPriority.Average);
                 if (ShouldUseCarveOrDrain(cdStrat, primaryTarget))
                 {
                     switch (cdStrat)
@@ -432,7 +453,7 @@ public sealed class AkechiDRK(RotationModuleManager manager, Actor player) : Ake
             }
         }
         if (ShouldUseDisesteem(deStrat, primaryTarget))
-            QueueGCD(AID.Disesteem, TargetChoice(de) ?? BestTargetAOERect?.Actor, deStrat is GCDStrategy.Force ? GCDPriority.Forced : GCDPriority.AboveAverage);
+            QueueGCD(AID.Disesteem, TargetChoice(de) ?? BestRectTarget?.Actor, deStrat is GCDStrategy.Force ? GCDPriority.Forced : GCDPriority.AboveAverage);
         if (ShouldUseMP(mpStrat))
         {
             switch (mpStrat)
@@ -442,22 +463,24 @@ public sealed class AkechiDRK(RotationModuleManager manager, Actor player) : Ake
                 case MPStrategy.Auto6k:
                 case MPStrategy.Auto3k:
                 case MPStrategy.AutoRefresh:
-                    if (NumAOERectTargets >= 3)
-                        QueueOGCD(BestFlood, TargetChoice(mp) ?? BestTargetMPRectHigh?.Actor, RiskingMP ? OGCDPriority.Forced : OGCDPriority.Low);
-                    if (NumAOERectTargets <= 2)
+                    if (NumAOERectTargets >= 3 && Unlocked(AID.FloodOfDarkness))
+                        QueueOGCD(BestFlood, TargetChoice(mp) ?? BestMPTarget?.Actor, RiskingMP ? OGCDPriority.Forced : OGCDPriority.Low);
+                    if (NumAOERectTargets <= 2 && Unlocked(AID.EdgeOfDarkness))
                         QueueOGCD(BestEdge, TargetChoice(mp) ?? primaryTarget?.Actor, RiskingMP ? OGCDPriority.Forced : OGCDPriority.Low);
                     break;
                 case MPStrategy.Edge9k:
                 case MPStrategy.Edge6k:
                 case MPStrategy.Edge3k:
                 case MPStrategy.EdgeRefresh:
+                case MPStrategy.ForceEdge:
                     QueueOGCD(BestEdge, TargetChoice(mp) ?? primaryTarget?.Actor, RiskingMP ? OGCDPriority.Forced : OGCDPriority.Low);
                     break;
                 case MPStrategy.Flood9k:
                 case MPStrategy.Flood6k:
                 case MPStrategy.Flood3k:
                 case MPStrategy.FloodRefresh:
-                    QueueOGCD(BestFlood, TargetChoice(mp) ?? (NumAOERectTargets > 1 ? BestAOERectTargets?.Actor : primaryTarget?.Actor), RiskingMP ? OGCDPriority.Forced : OGCDPriority.Low);
+                case MPStrategy.ForceFlood:
+                    QueueOGCD(BestFlood, TargetChoice(mp) ?? BestRectTarget?.Actor, RiskingMP ? OGCDPriority.Forced : OGCDPriority.Low);
                     break;
             }
         }

--- a/BossMod/Autorotation/Standard/akechi/Tank/AkechiGNB.cs
+++ b/BossMod/Autorotation/Standard/akechi/Tank/AkechiGNB.cs
@@ -12,7 +12,7 @@ public sealed class AkechiGNB(RotationModuleManager manager, Actor player) : Ake
     public enum Track { Combo = SharedTrack.Count, Cartridges, Potion, LightningShot, Zone, NoMercy, SonicBreak, GnashingFang, BowShock, Continuation, Bloodfest, DoubleDown, Reign, }
     public enum ComboStrategy { ForceSTwithO, ForceSTwithoutO, ForceAOEwithO, ForceAOEwithoutO }
     public enum CartridgeStrategy { Automatic, OnlyBS, OnlyFC, ForceBS, ForceBS1, ForceBS2, ForceBS3, ForceFC, ForceFC1, ForceFC2, ForceFC3, Delay }
-    public enum PotionStrategy { Manual, AlignWithRaidBuffs, Immediate }
+    public enum PotionStrategy { Manual, AlignWithBloodfest, Immediate }
     public enum LightningShotStrategy { OpenerFar, OpenerForce, Force, Allow, Forbid }
     public enum NoMercyStrategy { Automatic, BurstReady, Force, ForceW, ForceQW, Force1, Force1W, Force1QW, Force2, Force2W, Force2QW, Force3, Force3W, Force3QW, Delay }
     public enum SonicBreakStrategy { Automatic, Force, Early, Late, Delay }
@@ -51,7 +51,7 @@ public sealed class AkechiGNB(RotationModuleManager manager, Actor player) : Ake
             .AddAssociatedActions(AID.BurstStrike, AID.FatedCircle);
         res.Define(Track.Potion).As<PotionStrategy>("Potion", uiPriority: 90)
             .AddOption(PotionStrategy.Manual, "Manual", "Do not use automatically")
-            .AddOption(PotionStrategy.AlignWithRaidBuffs, "AlignWithRaidBuffs", "Align with No Mercy & Bloodfest together (to ensure use on 2-minute windows)", 270, 30, ActionTargets.Self)
+            .AddOption(PotionStrategy.AlignWithBloodfest, "AlignWithBloodfest", "Align with No Mercy & Bloodfest together (to ensure use on 2-minute windows)", 270, 30, ActionTargets.Self)
             .AddOption(PotionStrategy.Immediate, "Immediate", "Use ASAP, regardless of any buffs", 270, 30, ActionTargets.Self)
             .AddAssociatedAction(ActionDefinitions.IDPotionStr);
         res.Define(Track.LightningShot).As<LightningShotStrategy>("Lightning Shot", "L.Shot", uiPriority: 100)
@@ -358,7 +358,7 @@ public sealed class AkechiGNB(RotationModuleManager manager, Actor player) : Ake
     };
     private bool ShouldUsePotion(PotionStrategy strategy) => strategy switch
     {
-        PotionStrategy.AlignWithRaidBuffs => NMcd < 5 && BFcd < 15,
+        PotionStrategy.AlignWithBloodfest => NMcd < 5 && BFcd < 15,
         PotionStrategy.Immediate => true,
         _ => false
     };

--- a/BossMod/Autorotation/Standard/akechi/Tank/AkechiPLD.cs
+++ b/BossMod/Autorotation/Standard/akechi/Tank/AkechiPLD.cs
@@ -12,7 +12,7 @@ public sealed class AkechiPLD(RotationModuleManager manager, Actor player) : Ake
     public enum Track { AOE, Cooldowns, Potion, Atonement, BladeCombo, Holy, Dash, Ranged, FightOrFlight, Requiescat, SpiritsWithin, CircleOfScorn, GoringBlade, BladeOfHonor }
     public enum AOEStrategy { AutoFinish, AutoBreak, ForceST, ForceAOE }
     public enum CooldownStrategy { Allow, Forbid }
-    public enum PotionStrategy { Manual, AlignWithRaidBuffs, Immediate }
+    public enum PotionStrategy { Manual, AlignWithFOF, Immediate }
     public enum AtonementStrategy { Automatic, ForceAtonement, ForceSupplication, ForceSepulchre, Delay }
     public enum BladeComboStrategy { Automatic, ForceConfiteor, ForceFaith, ForceTruth, ForceValor, Delay }
     public enum HolyStrategy { Automatic, Spirit, Circle, Delay }
@@ -36,7 +36,7 @@ public sealed class AkechiPLD(RotationModuleManager manager, Actor player) : Ake
             .AddOption(CooldownStrategy.Forbid, "Hold", "Forbids the use of all cooldowns & buffs; will not use any actions with a cooldown timer");
         res.Define(Track.Potion).As<PotionStrategy>("Potion", uiPriority: 90)
             .AddOption(PotionStrategy.Manual, "Manual", "Do not use potions automatically")
-            .AddOption(PotionStrategy.AlignWithRaidBuffs, "Align With Raid Buffs", "Align potion usage with raid buffs", 270, 30, ActionTargets.Self)
+            .AddOption(PotionStrategy.AlignWithFOF, "AlignWithFOF", "Align with Fight or Flight & Requiescat together", 270, 30, ActionTargets.Self)
             .AddOption(PotionStrategy.Immediate, "Immediate", "Use potions immediately when available", 270, 30, ActionTargets.Self)
             .AddAssociatedAction(ActionDefinitions.IDPotionStr);
         res.Define(Track.Atonement).As<AtonementStrategy>("Atonement", "Atones", uiPriority: 155)
@@ -255,7 +255,7 @@ public sealed class AkechiPLD(RotationModuleManager manager, Actor player) : Ake
     };
     private bool ShouldUsePotion(PotionStrategy strategy) => strategy switch
     {
-        PotionStrategy.AlignWithRaidBuffs => FightOrFlight.CD < 5,
+        PotionStrategy.AlignWithFOF => FightOrFlight.CD < 5,
         PotionStrategy.Immediate => true,
         _ => false
     };

--- a/BossMod/Autorotation/Standard/akechi/Tank/AkechiPLD.cs
+++ b/BossMod/Autorotation/Standard/akechi/Tank/AkechiPLD.cs
@@ -134,7 +134,7 @@ public sealed class AkechiPLD(RotationModuleManager manager, Actor player) : Ake
     };
     private AID AutoBreak => ShouldUseAOE ? FullAOE : FullST;
     private AID FullST => ComboLastMove is AID.RiotBlade ? (Unlocked(AID.RoyalAuthority) ? AID.RoyalAuthority : Unlocked(AID.RageOfHalone) ? AID.RageOfHalone : AID.FastBlade) : Unlocked(AID.RiotBlade) && ComboLastMove is AID.FastBlade ? AID.RiotBlade : AID.FastBlade;
-    private AID FullAOE => Unlocked(AID.TotalEclipse) && ComboLastMove is AID.TotalEclipse ? AID.TotalEclipse : AID.Prominence;
+    private AID FullAOE => Unlocked(AID.Prominence) && ComboLastMove is AID.TotalEclipse ? AID.Prominence : AID.TotalEclipse;
     #endregion
 
     #region Cooldown Helpers

--- a/BossMod/Autorotation/Standard/akechi/Tank/AkechiWAR.cs
+++ b/BossMod/Autorotation/Standard/akechi/Tank/AkechiWAR.cs
@@ -17,7 +17,7 @@ public sealed class AkechiWAR(RotationModuleManager manager, Actor player) : Ake
     public enum UpheavalStrategy { Automatic, OnlyUpheaval, OnlyOrogeny, ForceUpheaval, ForceOrogeny, Delay }
     public enum OnslaughtStrategy { Automatic, Force, Hold0, Hold1, Hold2, GapClose, Delay }
     public enum TomahawkStrategy { OpenerFar, OpenerForce, Force, Allow, Forbid }
-    public enum PotionStrategy { Manual, AlignWithRaidBuffs, Immediate }
+    public enum PotionStrategy { Manual, AlignWithInnerRelease, Immediate }
     #endregion
 
     #region Module Definitions
@@ -89,7 +89,7 @@ public sealed class AkechiWAR(RotationModuleManager manager, Actor player) : Ake
             .AddAssociatedActions(AID.Tomahawk);
         res.Define(Track.Potion).As<PotionStrategy>("Potion", uiPriority: 20)
             .AddOption(PotionStrategy.Manual, "Manual", "Do not use automatically")
-            .AddOption(PotionStrategy.AlignWithRaidBuffs, "AlignWithRaidBuffs", "Align with Inner Release & Infuriate charges to ensure use on 2-minute windows", 270, 30, ActionTargets.Self)
+            .AddOption(PotionStrategy.AlignWithInnerRelease, "AlignWithInnerRelease", "Align with Inner Release", 270, 30, ActionTargets.Self)
             .AddOption(PotionStrategy.Immediate, "Immediate", "Use ASAP, regardless of any buffs", 270, 30, ActionTargets.Self)
             .AddAssociatedAction(ActionDefinitions.IDPotionStr);
         res.DefineOGCD(Track.InnerRelease, AID.InnerRelease, "Inner Release", "InnerR.", uiPriority: 170, 60, 15, ActionTargets.Self, 6).AddAssociatedActions(AID.InnerRelease);
@@ -717,7 +717,7 @@ public sealed class AkechiWAR(RotationModuleManager manager, Actor player) : Ake
     };
     private bool ShouldUsePotion(PotionStrategy strategy) => strategy switch
     {
-        PotionStrategy.AlignWithRaidBuffs => InnerRelease.CD < 5,
+        PotionStrategy.AlignWithInnerRelease => InnerRelease.CD < 5,
         PotionStrategy.Immediate => true,
         _ => false
     };

--- a/BossMod/Modules/Stormblood/Dungeon/D01SirensongSea/D011Lugat.cs
+++ b/BossMod/Modules/Stormblood/Dungeon/D01SirensongSea/D011Lugat.cs
@@ -29,7 +29,7 @@ public enum IOD : uint
 {
     Stack = 62
 }
-class ConcussiveOscillationBoss(BossModule module) : LocationTargetedAOEs(module, ActionID.MakeSpell(AID.ConcussiveOscillationBoss), 8);
+class ConcussiveOscillationBoss(BossModule module) : LocationTargetedAOEs(module, ActionID.MakeSpell(AID.ConcussiveOscillationBoss), 7);
 class ConcussiveOscillation(BossModule module) : LocationTargetedAOEs(module, ActionID.MakeSpell(AID.ConcussiveOscillation), 8);
 class AmorphousApplause(BossModule module) : SelfTargetedAOEs(module, ActionID.MakeSpell(AID.AmorphousApplause), new AOEShapeCone(30, 90.Degrees()));
 

--- a/BossMod/Modules/Stormblood/Dungeon/D01SirensongSea/D012TheGovernor.cs
+++ b/BossMod/Modules/Stormblood/Dungeon/D01SirensongSea/D012TheGovernor.cs
@@ -67,7 +67,6 @@ class Tether(BossModule module) : BaitAwayTethers(module, new AOEShapeCone(0, 0.
         base.AddAIHints(slot, actor, assignment, hints);
         if (target == actor.InstanceID && CurrentBaits.Count > 0)
             hints.AddForbiddenZone(ShapeDistance.Circle(Module.PrimaryActor.Position, 19));
-
     }
 }
 

--- a/BossMod/Modules/Stormblood/Dungeon/D01SirensongSea/D012TheGovernor.cs
+++ b/BossMod/Modules/Stormblood/Dungeon/D01SirensongSea/D012TheGovernor.cs
@@ -1,5 +1,4 @@
-﻿using BossMod;
-using BossMod.Components;
+﻿using BossMod.Components;
 
 namespace BossMod.Stormblood.Dungeon.D01SirensongSea.D012TheGovernor;
 
@@ -76,7 +75,6 @@ class ShadowFlow(BossModule module) : GenericAOEs(module)
 {
     public List<AOEInstance> aoes = [];
     public List<Actor> Grovellers = [];
-    public List<Actor> Boss = [];
 
     DateTime activation;
 

--- a/BossMod/Modules/Stormblood/Dungeon/D01SirensongSea/D012TheGovernor.cs
+++ b/BossMod/Modules/Stormblood/Dungeon/D01SirensongSea/D012TheGovernor.cs
@@ -68,6 +68,7 @@ class Tether(BossModule module) : BaitAwayTethers(module, new AOEShapeCone(0, 0.
         base.AddAIHints(slot, actor, assignment, hints);
         if (target == actor.InstanceID && CurrentBaits.Count > 0)
             hints.AddForbiddenZone(ShapeDistance.Circle(Module.PrimaryActor.Position, 19));
+
     }
 }
 
@@ -75,6 +76,7 @@ class ShadowFlow(BossModule module) : GenericAOEs(module)
 {
     public List<AOEInstance> aoes = [];
     public List<Actor> Grovellers = [];
+    public List<Actor> Boss = [];
 
     DateTime activation;
 
@@ -88,7 +90,7 @@ class ShadowFlow(BossModule module) : GenericAOEs(module)
         }
         foreach (Actor groveller in Grovellers)
         {
-            yield return new AOEInstance(new AOEShapeCircle(7f), groveller.Position, Activation: activation);
+            yield return new AOEInstance(new AOEShapeCircle(6), groveller.Position, Activation: activation);
         }
     }
 
@@ -104,7 +106,7 @@ class ShadowFlow(BossModule module) : GenericAOEs(module)
     {
         if ((AID)spell.Action.ID == AID.ShadowFlow)
         {
-            aoes.Add(new AOEInstance(new AOEShapeCircle(7f), Module.Center, Activation: Module.CastFinishAt(spell, 10f)));
+            aoes.Add(new AOEInstance(new AOEShapeCircle(6), Module.Center, Activation: Module.CastFinishAt(spell, 10f)));
         }
     }
 


### PR DESCRIPTION
`BLM` is still borked. 
Leaving it be until I see some new stuff to follow up on after 7.2 adjustments. 

`DRG`, `GNB`, `DRK`, and `PLD` are now fully complete. 
Lv1-Lv100 tested thoroughly.

Also fixed certain `Sirensong Sea` bosses' AOE indicators being too big. Gimme my greed.