### PR TITLE
Add a buffer hint to over dodge AOEs

### DIFF
--- a/BossMod/Pathfinding/Map.cs
+++ b/BossMod/Pathfinding/Map.cs
@@ -94,6 +94,7 @@ public class Map
     }
 
     public int GridToIndex(int x, int y) => y * Width + x;
+    public int GridToIndex((int x, int y) p) => GridToIndex(p.x, p.y);
     public (int x, int y) IndexToGrid(int index) => (index % Width, index / Width);
     public (int x, int y) FracToGrid(Vector2 frac) => ((int)MathF.Floor(frac.X), (int)MathF.Floor(frac.Y));
     public (int x, int y) WorldToGrid(WPos world) => FracToGrid(WorldToGridFrac(world));

--- a/BossMod/Pathfinding/NavigationDecision.cs
+++ b/BossMod/Pathfinding/NavigationDecision.cs
@@ -22,10 +22,10 @@ public struct NavigationDecision
     public float LeewaySeconds; // can be used for finishing casts / slidecasting etc.
     public float TimeToGoal;
 
-    public const float ForbiddenZoneCushion = 1.5f; // increase to fatten forbidden zones
+    public const float ForbiddenZoneCushion = 0; // increase to fatten forbidden zones
     public const float ActivationTimeCushion = 1; // reduce time between now and activation by this value in seconds; increase for more conservativeness
 
-    public static NavigationDecision Build(Context ctx, WorldState ws, AIHints hints, Actor player, float playerSpeed = 6)
+    public static NavigationDecision Build(Context ctx, WorldState ws, AIHints hints, Actor player, float playerSpeed = 6, float forbiddenZoneCushion = ForbiddenZoneCushion)
     {
         // build a pathfinding map: rasterize all forbidden zones and goals
         hints.InitPathfindMap(ctx.Map);
@@ -34,8 +34,8 @@ public struct NavigationDecision
         if (hints.GoalZones.Count > 0)
             RasterizeGoalZones(ctx.Map, hints.GoalZones);
 
-        if (ForbiddenZoneCushion > 0)
-            AvoidForbiddenZone(ctx.Map);
+        if (forbiddenZoneCushion > 0)
+            AvoidForbiddenZone(ctx.Map, forbiddenZoneCushion);
 
         // execute pathfinding
         ctx.ThetaStar.Start(ctx.Map, player.Position, 1.0f / playerSpeed);
@@ -45,9 +45,9 @@ public struct NavigationDecision
         return new() { Destination = waypoints.first, NextWaypoint = waypoints.second, LeewaySeconds = bestNode.PathLeeway, TimeToGoal = bestNode.GScore };
     }
 
-    public static void AvoidForbiddenZone(Map map)
+    public static void AvoidForbiddenZone(Map map, float forbiddenZoneCushion)
     {
-        int d = (int)(ForbiddenZoneCushion / map.Resolution);
+        int d = (int)(forbiddenZoneCushion / map.Resolution);
         map.MaxPriority = -1;
         foreach (var (x, y, _) in map.EnumeratePixels())
         {


### PR DESCRIPTION
Adds a configurable 0/.5/1.5/3 yalm buffer in the form of a small priority reduction near forbidden zones.

When set to none this should behave identically to without this change. 

In my testing I did not notice any frame loss from the extra pass. 30 fps with or without