### PR TITLE
IPC: Add `Configuration`, and `ActionQueue` methods

### DIFF
--- a/BossMod/ActionQueue/ActionQueue.cs
+++ b/BossMod/ActionQueue/ActionQueue.cs
@@ -8,7 +8,10 @@
 // - repeat the process until no more actions can be found
 public sealed class ActionQueue
 {
-    public readonly record struct Entry(ActionID Action, Actor? Target, float Priority, float Expire, float Delay, float CastTime, Vector3 TargetPos, Angle? FacingAngle);
+    public readonly record struct Entry(ActionID Action, Actor? Target, float Priority, float Expire, float Delay, float CastTime, Vector3 TargetPos, Angle? FacingAngle)
+    {
+        public readonly bool IsManualAction = Priority is (ActionQueue.Priority.ManualEmergency or ActionQueue.Priority.ManualOGCD or ActionQueue.Priority.ManualGCD);
+    }
 
     // reference priority guidelines
     // values divisible by 1000 are reserved for standard cooldown planner priorities

--- a/BossMod/Framework/IPCProvider.cs
+++ b/BossMod/Framework/IPCProvider.cs
@@ -17,9 +17,7 @@ sealed class IPCProvider : IDisposable
         Service.Config.Modified.Subscribe(() => lastModified = DateTime.Now);
         Register("Configuration.LastModified", () => lastModified);
 
-        Register("Rotation.ActionQueue.Entries", () => autorotation.Hints.ActionsToExecute.Entries);
-        Register("Rotation.ActionQueue.NonManualEntries", () => autorotation.Hints.ActionsToExecute.Entries
-            .Where(x => x.Priority is not (ActionQueue.Priority.ManualEmergency or ActionQueue.Priority.ManualOGCD or ActionQueue.Priority.ManualGCD)));
+        Register("Rotation.ActionQueue.HasEntries", () => autorotation.Hints.ActionsToExecute.Entries.Any(x => !x.IsManualAction));
 
         Register("Presets.Get", (string name) =>
         {

--- a/BossMod/Framework/IPCProvider.cs
+++ b/BossMod/Framework/IPCProvider.cs
@@ -13,6 +13,14 @@ sealed class IPCProvider : IDisposable
         Register("HasModuleByDataId", (uint dataId) => BossModuleRegistry.FindByOID(dataId) != null);
         Register("Configuration", (IReadOnlyList<string> args, bool save) => Service.Config.ConsoleCommand(string.Join(' ', args), save));
 
+        DateTime lastModified = DateTime.Now;
+        Service.Config.Modified.Subscribe(() => lastModified = DateTime.Now);
+        Register("Configuration.LastModified", () => lastModified);
+
+        Register("Rotation.ActionQueue.Entries", () => autorotation.Hints.ActionsToExecute.Entries);
+        Register("Rotation.ActionQueue.NonManualEntries", () => autorotation.Hints.ActionsToExecute.Entries
+            .Where(x => x.Priority is not (ActionQueue.Priority.ManualEmergency or ActionQueue.Priority.ManualOGCD or ActionQueue.Priority.ManualGCD)));
+
         Register("Presets.Get", (string name) =>
         {
             var preset = autorotation.Database.Presets.FindPresetByName(name);


### PR DESCRIPTION
This PR adds a few IPC methods to make it possible to check the `ActionQueue` entries, as well as when BossMod's configuration was last modified.

> The use-case here is for Wrath to be able to poll BossMod for queued actions, regardless of preset, and if actions are consistently going out, that itself can be marked as a preset (as opposed to the whole plugin).

- [X] Adds `Configuration.LastModified`, updated with the `Service.Config.Modified` `Event`.
- [X] Adds `Rotation.ActionQueue.HasEntries`, a `bool` indicating if there are any `Entry`s that are automatic actions.