### PR TITLE
Fix debug UI error with no player (e.g. main menu)

### DIFF
--- a/BossMod/Debug/MainDebugWindow.cs
+++ b/BossMod/Debug/MainDebugWindow.cs
@@ -43,7 +43,7 @@ class MainDebugWindow(WorldState ws, RotationModuleManager autorot, ZoneModuleMa
         var player = Service.ClientState.LocalPlayer;
         ImGui.TextUnformatted($"Current zone: {ws.CurrentZone}, player=0x{(ulong)Utils.GameObjectInternal(player):X}, playerCID={playerCID:X}, pos = {Utils.Vec3String(player?.Position ?? new Vector3())}");
         // ImGui.TextUnformatted($"ID scramble: {Network.IDScramble.Delta} = {*Network.IDScramble.OffsetAdjusted} - {*Network.IDScramble.OffsetBaseFixed} - {*Network.IDScramble.OffsetBaseChanging}");
-        ImGui.TextUnformatted($"Player mode: {Utils.CharacterInternal(player)->Mode}");
+        ImGui.TextUnformatted($"Player mode: {(player is null ? "No player found" : Utils.CharacterInternal(player)->Mode)}");
 
         var eventFwk = FFXIVClientStructs.FFXIV.Client.Game.Event.EventFramework.Instance();
         var instanceDirector = eventFwk != null ? eventFwk->GetInstanceContentDirector() : null;
@@ -189,13 +189,15 @@ class MainDebugWindow(WorldState ws, RotationModuleManager autorot, ZoneModuleMa
         if (ImGui.Button("Add misdirection"))
         {
             var player = (Character*)GameObjectManager.Instance()->Objects.IndexSorted[0].Value;
-            player->GetStatusManager()->SetStatus(20, 3909, 20.0f, 100, (GameObjectId)0xE0000000, true);
+            if (player is not null)
+                player->GetStatusManager()->SetStatus(20, 3909, 20.0f, 100, (GameObjectId)0xE0000000, true);
         }
         ImGui.SameLine();
         if (ImGui.Button("Add thin ice"))
         {
             var player = (Character*)GameObjectManager.Instance()->Objects.IndexSorted[0].Value;
-            player->GetStatusManager()->SetStatus(20, 911, 20.0f, 50, (GameObjectId)0xE0000000, true); // param = distance * 10
+            if (player is not null)
+                player->GetStatusManager()->SetStatus(20, 911, 20.0f, 50, (GameObjectId)0xE0000000, true); // param = distance * 10
         }
 
         ImGui.TextUnformatted($"Player move speed: {ws.Client.MoveSpeed:f2}");


### PR DESCRIPTION
The mode string would cause an error every UI update while not logged in

```
16:30:49.089 | ERR | [WindowSystem] Error during Draw(): "Boss mod debug UI"
	System.NullReferenceException: Object reference not set to an instance of an object.
	   at BossMod.MainDebugWindow.Draw() in D:\Documents\GitHub\ffxiv_bossmod\BossMod\Debug\MainDebugWindow.cs:line 46
	   at Dalamud.Interface.Windowing.Window.DrawInternal(WindowDrawFlags internalDrawFlags, WindowSystemPersistence persistence) in /_/Dalamud/Interface/Windowing/Window.cs:line 451
```

The add status buttons would error if clicked while not logged in (minor but I was looking at the file anyway so I fixed it)
```
16:41:24.710 | ERR | [WindowSystem] Error during Draw(): "Boss mod debug UI"
	System.NullReferenceException: Object reference not set to an instance of an object.
	   at BossMod.MainDebugWindow.DrawStatuses() in D:\Documents\GitHub\ffxiv_bossmod\BossMod\Debug\MainDebugWindow.cs:line 191
	   at BossMod.MainDebugWindow.Draw() in D:\Documents\GitHub\ffxiv_bossmod\BossMod\Debug\MainDebugWindow.cs:line 72
	   at Dalamud.Interface.Windowing.Window.DrawInternal(WindowDrawFlags internalDrawFlags, WindowSystemPersistence persistence) in /_/Dalamud/Interface/Windowing/Window.cs:line 451
```