### PR TITLE
add obstacle map ipcs and fate util los checks

### DIFF
--- a/BossMod/Autorotation/MiscAI/FateUtils.cs
+++ b/BossMod/Autorotation/MiscAI/FateUtils.cs
@@ -1,4 +1,4 @@
-﻿namespace BossMod.Autorotation.MiscAI;
+namespace BossMod.Autorotation.MiscAI;
 
 public sealed class FateUtils(RotationModuleManager manager, Actor player) : RotationModule(manager, player)
 {
@@ -41,10 +41,12 @@ public sealed class FateUtils(RotationModuleManager manager, Actor player) : Rot
         if (strategy.Option(Track.Chocobo).As<Flag>() == Flag.Enabled && World.Client.GetInventoryItemQuantity(ActionDefinitions.IDMiscItemGreens.ID) > 0 && World.Client.ActiveCompanion is { TimeLeft: < 60, Stabled: false })
             Hints.ActionsToExecute.Push(ActionDefinitions.IDMiscItemGreens, Player, ActionQueue.Priority.VeryHigh);
 
+        var fateID = World.Client.ActiveFate.ID;
+        if (primaryTarget is { FateID: > 0 } target && target.FateID == fateID)
+            AddLOSGoalForTarget(target);
+
         if (strategy.Option(Track.Handin).As<Flag>() != Flag.Enabled)
             return;
-
-        var fateID = World.Client.ActiveFate.ID;
 
         var item = Utils.GetFateItem(fateID);
         if (item == 0)
@@ -64,5 +66,71 @@ public sealed class FateUtils(RotationModuleManager manager, Actor player) : Rot
         // otherwise, pick up stuff
         if (strategy.Option(Track.Collect).As<Flag>() == Flag.Enabled && !Player.InCombat)
             Hints.InteractWithTarget = World.Actors.Where(a => a.FateID == fateID && a.IsTargetable && a.Type == ActorType.EventObj).MinBy(Player.DistanceToHitbox);
+
+    }
+
+    private void AddLOSGoalForTarget(Actor target)
+    {
+        if (Hints.PathfindMapObstacles.Bitmap is not { } bitmap)
+            return;
+
+        var rect = Hints.PathfindMapObstacles.Rect;
+        var mapCenter = Hints.PathfindMapCenter;
+        var targetPos = target.Position;
+        var targetRange = (Player.Role is Role.Melee or Role.Tank ? 3.5f : 24.5f) + target.HitboxRadius;
+
+        // blacklist current tile if no LoS
+        Hints.GoalZones.Add(p => HasLineOfSight(bitmap, rect, mapCenter, p, targetPos) ? 0 : -100);
+        Hints.GoalZones.Add(p =>
+        {
+            if (!HasLineOfSight(bitmap, rect, mapCenter, p, targetPos))
+                return 0;
+            return (p - targetPos).LengthSq() <= targetRange * targetRange ? 20 : 8;
+        });
+    }
+
+    private static bool HasLineOfSight(Bitmap map, Bitmap.Rect rect, WPos mapCenter, WPos from, WPos to)
+    {
+        if (!TryWorldToBitmapCell(map, rect, mapCenter, from, out var x0, out var y0) || !TryWorldToBitmapCell(map, rect, mapCenter, to, out var x1, out var y1))
+            return true; // if mapping fails, don't block movement
+
+        var dx = Math.Abs(x1 - x0);
+        var sx = x0 < x1 ? 1 : -1;
+        var dy = -Math.Abs(y1 - y0);
+        var sy = y0 < y1 ? 1 : -1;
+        var err = dx + dy;
+        var x = x0;
+        var y = y0;
+
+        while (true)
+        {
+            if ((uint)x < map.Width && (uint)y < map.Height && map[x, y])
+                return false;
+            if (x == x1 && y == y1)
+                return true;
+            var e2 = 2 * err;
+            if (e2 >= dy)
+            {
+                err += dy;
+                x += sx;
+            }
+            if (e2 <= dx)
+            {
+                err += dx;
+                y += sy;
+            }
+        }
+    }
+
+    private static bool TryWorldToBitmapCell(Bitmap map, Bitmap.Rect rect, WPos mapCenter, WPos pos, out int x, out int y)
+    {
+        var centerCellX = (rect.Left + rect.Right) * 0.5f;
+        var centerCellY = (rect.Top + rect.Bottom) * 0.5f;
+        var invRes = 1.0f / map.PixelSize;
+        var delta = (pos - mapCenter) * invRes;
+
+        x = (int)MathF.Round(centerCellX + delta.X);
+        y = (int)MathF.Round(centerCellY + delta.Z);
+        return (uint)x < map.Width && (uint)y < map.Height;
     }
 }

--- a/BossMod/Debug/DebugObstacles.cs
+++ b/BossMod/Debug/DebugObstacles.cs
@@ -1,8 +1,9 @@
-﻿using BossMod.Pathfinding;
+using BossMod.Pathfinding;
 using Dalamud.Interface.Utility.Raii;
 using Dalamud.Plugin;
 using Dalamud.Bindings.ImGui;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace BossMod;
 
@@ -129,6 +130,56 @@ sealed class DebugObstacles(ObstacleMapManager obstacles, IDalamudPluginInterfac
         }
     }
 
+    sealed class TempMapViewer : UIBitmapEditor
+    {
+        private readonly DebugObstacles _owner;
+        private readonly ObstacleMapDatabase.Entry _e;
+
+        public TempMapViewer(DebugObstacles owner, Bitmap bm, ObstacleMapDatabase.Entry e) : base(bm)
+        {
+            _owner = owner;
+            _e = e;
+            CurrentMode = PanModeId;
+        }
+
+        protected override void DrawSidebar()
+        {
+            var player = _owner.Obstacles.World.Party.Player();
+            ImGui.TextUnformatted("IPC temp map");
+            ImGui.TextUnformatted($"Generation task: {_owner.Obstacles.GetGenerationStatus()}");
+            ImGui.TextUnformatted($"Key: {_e.Filename}");
+            ImGui.TextUnformatted($"Bounds min {_e.MinBounds}  max {_e.MaxBounds}");
+            ImGui.TextUnformatted($"Origin {_e.Origin}  grid {Bitmap.Width}x{Bitmap.Height}  cell {Bitmap.PixelSize:F3} yalms");
+
+            if (player != null)
+            {
+                var playerOffset = ((player.Position - _e.Origin) / Bitmap.PixelSize).Floor();
+                ImGui.TextUnformatted($"Player cell: {playerOffset.X}x/{playerOffset.Z}z");
+            }
+
+            if (HoveredPixel.x >= 0 && HoveredPixel.y >= 0)
+            {
+                ImGui.TextUnformatted($"Hovered cell: {HoveredPixel.x}x{HoveredPixel.y}");
+                var y = player?.PosRot.Y ?? 0;
+                var tl = _e.Origin + new WDir(HoveredPixel.x, HoveredPixel.y) * Bitmap.PixelSize;
+                var br = tl + new WDir(Bitmap.PixelSize, Bitmap.PixelSize);
+                Camera.Instance?.DrawWorldLine(new(tl.X, y, tl.Z), new(tl.X, y, br.Z), 0xff00ffff);
+                Camera.Instance?.DrawWorldLine(new(tl.X, y, br.Z), new(br.X, y, br.Z), 0xff00ffff);
+                Camera.Instance?.DrawWorldLine(new(br.X, y, br.Z), new(br.X, y, tl.Z), 0xff00ffff);
+                Camera.Instance?.DrawWorldLine(new(br.X, y, tl.Z), new(tl.X, y, tl.Z), 0xff00ffff);
+            }
+        }
+
+        protected override IEnumerable<(int x, int y, Color c)> HighlighedCells()
+        {
+            if (_owner.Obstacles.World.Party.Player() is { } player)
+            {
+                var playerOffset = ((player.Position - _e.Origin) / Bitmap.PixelSize).Floor();
+                yield return ((int)playerOffset.X, (int)playerOffset.Z, new(0xff00ff00));
+            }
+        }
+    }
+
     internal readonly ObstacleMapManager Obstacles = obstacles;
     private readonly UITree _tree = new();
     private readonly Func<Vector3, string, float, Vector3, Vector3, (Vector3, Vector3)> _createMap = (startingPos, filename, pixelSize, minBounds, maxBounds) => dalamud.GetIpcSubscriber<Vector3, string, float, Vector3, Vector3, (Vector3, Vector3)>("vnavmesh.Nav.BuildBitmapBounded").InvokeFunc(startingPos, filename, pixelSize, minBounds, maxBounds);
@@ -143,6 +194,22 @@ sealed class DebugObstacles(ObstacleMapManager obstacles, IDalamudPluginInterfac
     public void Draw()
     {
         ImGui.TextUnformatted($"Database root: {Obstacles.RootPath}");
+
+        ImGui.Separator();
+        ImGui.TextUnformatted("Temp map (IPC / memory)");
+        var gen = Obstacles.GetGenerationStatus();
+        if (gen is not TaskStatus.RanToCompletion)
+            ImGui.TextUnformatted($"Build task: {gen}");
+        if (Obstacles.GetTempMapMeta() is not { } meta)
+        {
+            ImGui.TextDisabled("No temp map loaded.");
+        }
+        else
+        {
+            ImGui.TextUnformatted($"{meta.Filename}  {meta.Width}x{meta.Height} cells");
+            if (ImGui.Button("Open viewer##tempObstacle") && Obstacles.TryCloneTempMap(out var ent, out var bmp))
+                _ = new UISimpleWindow($"Temp obstacle map: {ent.Filename}", new TempMapViewer(this, bmp, ent).Draw, true, new(1000, 1000));
+        }
 
         var curZoneEntries = Obstacles.Database.Entries.GetValueOrDefault(Obstacles.CurrentKey());
         using (ImRaii.Disabled(!Obstacles.CanEditDatabase()))

--- a/BossMod/Debug/DebugObstacles.cs
+++ b/BossMod/Debug/DebugObstacles.cs
@@ -146,7 +146,7 @@ sealed class DebugObstacles(ObstacleMapManager obstacles, IDalamudPluginInterfac
         {
             var player = _owner.Obstacles.World.Party.Player();
             ImGui.TextUnformatted("IPC temp map");
-            ImGui.TextUnformatted($"Generation task: {_owner.Obstacles.GetGenerationStatus()}");
+            ImGui.TextUnformatted($"Generation task: {_owner.Obstacles.GenerationStatus}");
             ImGui.TextUnformatted($"Key: {_e.Filename}");
             ImGui.TextUnformatted($"Bounds min {_e.MinBounds}  max {_e.MaxBounds}");
             ImGui.TextUnformatted($"Origin {_e.Origin}  grid {Bitmap.Width}x{Bitmap.Height}  cell {Bitmap.PixelSize:F3} yalms");
@@ -197,10 +197,10 @@ sealed class DebugObstacles(ObstacleMapManager obstacles, IDalamudPluginInterfac
 
         ImGui.Separator();
         ImGui.TextUnformatted("Temp map (IPC / memory)");
-        var gen = Obstacles.GetGenerationStatus();
+        var gen = Obstacles.GenerationStatus;
         if (gen is not TaskStatus.RanToCompletion)
             ImGui.TextUnformatted($"Build task: {gen}");
-        if (Obstacles.GetTempMapMeta() is not { } meta)
+        if (Obstacles.TempMapMeta is not { } meta)
         {
             ImGui.TextDisabled("No temp map loaded.");
         }

--- a/BossMod/Framework/IPCProvider.cs
+++ b/BossMod/Framework/IPCProvider.cs
@@ -206,7 +206,7 @@ sealed class IPCProvider : IDisposable
         });
 
         Register("ObstacleMap.Generate", (Vector3 centerWorld, float radius, float margin, bool writeToFile) => obstacles.GenerateMap(centerWorld, radius, margin, writeToFile));
-        Register("ObstacleMap.GetGenerationStatus", obstacles.GetGenerationStatus);
+        Register("ObstacleMap.GetGenerationStatus", () => obstacles.GenerationStatus);
         Register("ObstacleMap.HasTempMap", obstacles.HasTempMap);
     }
 

--- a/BossMod/Framework/IPCProvider.cs
+++ b/BossMod/Framework/IPCProvider.cs
@@ -205,7 +205,7 @@ sealed class IPCProvider : IDisposable
             return true;
         });
 
-        Register("ObstacleMap.Generate", (Vector3 centerWorld, float radius, float margin, bool writeToFile) => obstacles.GenerateMap(centerWorld, radius, margin, writeToFile));
+        Register("ObstacleMap.Generate", (Vector3 centerWorld, float radius, bool writeToFile) => obstacles.GenerateMap(centerWorld, radius, writeToFile));
         Register("ObstacleMap.GetGenerationStatus", () => obstacles.GenerationStatus);
         Register("ObstacleMap.HasTempMap", obstacles.HasTempMap);
     }

--- a/BossMod/Framework/IPCProvider.cs
+++ b/BossMod/Framework/IPCProvider.cs
@@ -1,5 +1,6 @@
-﻿using BossMod.AI;
+using BossMod.AI;
 using BossMod.Autorotation;
+using BossMod.Pathfinding;
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -10,7 +11,7 @@ sealed class IPCProvider : IDisposable
 {
     private Action? _disposeActions;
 
-    public IPCProvider(RotationModuleManager autorotation, ActionManagerEx amex, MovementOverride movement, AIManager ai)
+    public IPCProvider(RotationModuleManager autorotation, ActionManagerEx amex, MovementOverride movement, AIManager ai, ObstacleMapManager obstacles)
     {
         Register("HasModuleByDataId", (uint dataId) => BossModuleRegistry.FindByOID(dataId) != null);
         Register("Configuration", (IReadOnlyList<string> args, bool save) => Service.Config.ConsoleCommand(string.Join(' ', args), save));
@@ -203,6 +204,10 @@ sealed class IPCProvider : IDisposable
                 ms.TransientSettings.Clear();
             return true;
         });
+
+        Register("ObstacleMap.Generate", (Vector3 centerWorld, float radius, float margin, bool writeToFile) => obstacles.GenerateMap(centerWorld, radius, margin, writeToFile));
+        Register("ObstacleMap.GetGenerationStatus", obstacles.GetGenerationStatus);
+        Register("ObstacleMap.HasTempMap", obstacles.HasTempMap);
     }
 
     public void Dispose() => _disposeActions?.Invoke();

--- a/BossMod/Framework/Plugin.cs
+++ b/BossMod/Framework/Plugin.cs
@@ -96,7 +96,7 @@ public sealed class Plugin : IDalamudPlugin
         _wsSync = new(_ws, _amex);
         _rotation = new(_rotationDB, _bossmod, _hints);
         _ai = new(_rotation, _amex, _movementOverride);
-        _ipc = new(_rotation, _amex, _movementOverride, _ai);
+        _ipc = new(_rotation, _amex, _movementOverride, _ai, _hintsBuilder.Obstacles);
         _dtr = new(_rotation, _ai);
         _slashCmd = new(commandManager, "/vbm");
         _mbox = new(_rotation, _ws);

--- a/BossMod/Pathfinding/ObstacleMapManager.cs
+++ b/BossMod/Pathfinding/ObstacleMapManager.cs
@@ -128,7 +128,7 @@ public sealed class ObstacleMapManager : IDisposable
         }
     }
 
-    public bool GenerateMap(Vector3 centerWorld, float radius, float margin, bool writeToFile)
+    public bool GenerateMap(Vector3 centerWorld, float radius, bool writeToFile)
     {
         if (_generationTask is { IsCompleted: false })
             return false;
@@ -137,9 +137,8 @@ public sealed class ObstacleMapManager : IDisposable
 
         _generationTask = Service.Framework.RunOnTick(() =>
         {
-            var effectiveRadius = MathF.Max(1, radius + margin);
-            var minBounds = new Vector3(centerWorld.X - effectiveRadius, -1024, centerWorld.Z - effectiveRadius);
-            var maxBounds = new Vector3(centerWorld.X + effectiveRadius, 1024, centerWorld.Z + effectiveRadius);
+            var minBounds = new Vector3(centerWorld.X - radius, -1024, centerWorld.Z - radius);
+            var maxBounds = new Vector3(centerWorld.X + radius, 1024, centerWorld.Z + radius);
             var pixelSize = 0.5f;
             var filename = writeToFile ? GeneratePersistentMapName() : Path.GetRandomFileName() + ".bmp";
             var fullPath = writeToFile ? RootPath + filename : Path.Combine(Path.GetTempPath(), filename);

--- a/BossMod/Pathfinding/ObstacleMapManager.cs
+++ b/BossMod/Pathfinding/ObstacleMapManager.cs
@@ -46,17 +46,20 @@ public sealed class ObstacleMapManager : IDisposable
     public bool CanEditDatabase() => _config.MapLoadFromSource;
     public uint ZoneKey(ushort zoneId, ushort cfcId) => ((uint)zoneId << 16) | cfcId;
     public uint CurrentKey() => ZoneKey(World.CurrentZone, World.CurrentCFCID);
-    public TaskStatus GetGenerationStatus() => _generationTask?.Status ?? TaskStatus.RanToCompletion;
+    public TaskStatus GenerationStatus => _generationTask?.Status ?? TaskStatus.RanToCompletion;
     public bool HasTempMap()
     {
         lock (_tempMapLock)
             return _tempMap != null;
     }
 
-    public (string Filename, int Width, int Height)? GetTempMapMeta()
+    public (string Filename, int Width, int Height)? TempMapMeta
     {
-        lock (_tempMapLock)
-            return _tempMap is { } t ? (t.entry.Filename, t.data.Width, t.data.Height) : null;
+        get
+        {
+            lock (_tempMapLock)
+                return _tempMap is { } t ? (t.entry.Filename, t.data.Width, t.data.Height) : null;
+        }
     }
 
     public bool TryCloneTempMap(out ObstacleMapDatabase.Entry entry, out Bitmap bitmap)

--- a/BossMod/Pathfinding/ObstacleMapManager.cs
+++ b/BossMod/Pathfinding/ObstacleMapManager.cs
@@ -1,5 +1,6 @@
-﻿using System.IO;
+using System.IO;
 using System.Reflection;
+using System.Threading.Tasks;
 
 namespace BossMod.Pathfinding;
 
@@ -11,6 +12,9 @@ public sealed class ObstacleMapManager : IDisposable
     private readonly DeveloperConfig _config = Service.Config.Get<DeveloperConfig>();
     private readonly EventSubscriptions _subscriptions;
     private readonly List<(ObstacleMapDatabase.Entry entry, Bitmap data)> _entries = [];
+    private readonly object _tempMapLock = new();
+    private (ObstacleMapDatabase.Entry entry, Bitmap data)? _tempMap;
+    private Task? _generationTask;
 
     public bool LoadFromSource => _config.MapLoadFromSource;
 
@@ -26,13 +30,51 @@ public sealed class ObstacleMapManager : IDisposable
 
     public void Dispose()
     {
+        ClearTempMap();
         _subscriptions.Dispose();
     }
 
-    public (ObstacleMapDatabase.Entry? entry, Bitmap? data) Find(Vector3 pos) => _entries.FirstOrDefault(e => e.entry.Contains(pos));
+    public (ObstacleMapDatabase.Entry? entry, Bitmap? data) Find(Vector3 pos)
+    {
+        lock (_tempMapLock)
+        {
+            if (_tempMap is { } temp && temp.entry.Contains(pos))
+                return temp;
+        }
+        return _entries.FirstOrDefault(e => e.entry.Contains(pos));
+    }
     public bool CanEditDatabase() => _config.MapLoadFromSource;
     public uint ZoneKey(ushort zoneId, ushort cfcId) => ((uint)zoneId << 16) | cfcId;
     public uint CurrentKey() => ZoneKey(World.CurrentZone, World.CurrentCFCID);
+    public TaskStatus GetGenerationStatus() => _generationTask?.Status ?? TaskStatus.RanToCompletion;
+    public bool HasTempMap()
+    {
+        lock (_tempMapLock)
+            return _tempMap != null;
+    }
+
+    public (string Filename, int Width, int Height)? GetTempMapMeta()
+    {
+        lock (_tempMapLock)
+            return _tempMap is { } t ? (t.entry.Filename, t.data.Width, t.data.Height) : null;
+    }
+
+    public bool TryCloneTempMap(out ObstacleMapDatabase.Entry entry, out Bitmap bitmap)
+    {
+        lock (_tempMapLock)
+        {
+            if (_tempMap is not { } t)
+            {
+                entry = null!;
+                bitmap = null!;
+                return false;
+            }
+
+            entry = new ObstacleMapDatabase.Entry(t.entry.MinBounds, t.entry.MaxBounds, t.entry.Origin, t.entry.ViewWidth, t.entry.ViewHeight, t.entry.Filename);
+            bitmap = t.data.Clone();
+            return true;
+        }
+    }
 
     public void ReloadDatabase()
     {
@@ -63,6 +105,7 @@ public sealed class ObstacleMapManager : IDisposable
 
     private void LoadMaps(ushort zoneId, ushort cfcId)
     {
+        ClearTempMap();
         _entries.Clear();
         if (Database.Entries.TryGetValue(ZoneKey(zoneId, cfcId), out var entries))
         {
@@ -79,6 +122,85 @@ public sealed class ObstacleMapManager : IDisposable
                     Service.Log($"Failed to load map {e.Filename} from {(_config.MapLoadFromSource ? RootPath : "<embedded>")} for {zoneId}.{cfcId}: {ex}");
                 }
             }
+        }
+    }
+
+    public bool GenerateMap(Vector3 centerWorld, float radius, float margin, bool writeToFile)
+    {
+        if (_generationTask is { IsCompleted: false })
+            return false;
+        if (writeToFile && !CanEditDatabase())
+            return false;
+
+        _generationTask = Service.Framework.RunOnTick(() =>
+        {
+            var effectiveRadius = MathF.Max(1, radius + margin);
+            var minBounds = new Vector3(centerWorld.X - effectiveRadius, -1024, centerWorld.Z - effectiveRadius);
+            var maxBounds = new Vector3(centerWorld.X + effectiveRadius, 1024, centerWorld.Z + effectiveRadius);
+            var pixelSize = 0.5f;
+            var filename = writeToFile ? GeneratePersistentMapName() : Path.GetRandomFileName() + ".bmp";
+            var fullPath = writeToFile ? RootPath + filename : Path.Combine(Path.GetTempPath(), filename);
+
+            try
+            {
+                var build = Service.PluginInterface.GetIpcSubscriber<Vector3, string, float, Vector3, Vector3, (Vector3, Vector3)>("vnavmesh.Nav.BuildBitmapBounded");
+                var (actualMin, actualMax) = build.InvokeFunc(centerWorld, fullPath, pixelSize, minBounds, maxBounds);
+
+                using var stream = File.OpenRead(fullPath);
+                // keep x/z bounds as-is, but make y bounds permissive
+                var min = new Vector3(actualMin.X, -1024, actualMin.Z);
+                var max = new Vector3(actualMax.X, 1024, actualMax.Z);
+                var entry = new ObstacleMapDatabase.Entry(min, max, new(actualMin.XZ()), 60, 60, filename);
+                var bitmap = new Bitmap(stream);
+                if (writeToFile)
+                {
+                    Database.Entries.GetOrAdd(CurrentKey()).Add(entry);
+                    SaveDatabase();
+                }
+                else
+                {
+                    lock (_tempMapLock)
+                    {
+                        _tempMap = (entry, bitmap);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Service.Log($"Obstacle map generation failed: {ex}");
+                throw;
+            }
+            finally
+            {
+                if (!writeToFile)
+                {
+                    try
+                    {
+                        File.Delete(fullPath);
+                    }
+                    catch (Exception ex)
+                    {
+                        Service.Log($"Failed to delete temporary obstacle map '{fullPath}': {ex}");
+                    }
+                }
+            }
+        }, delayTicks: 1);
+        return true;
+    }
+
+    private void ClearTempMap()
+    {
+        lock (_tempMapLock)
+            _tempMap = null;
+    }
+
+    private string GeneratePersistentMapName()
+    {
+        for (var i = 1; ; ++i)
+        {
+            var name = $"{World.CurrentZone}.{World.CurrentCFCID}.auto.{i}.bmp";
+            if (!new FileInfo(RootPath + name).Exists)
+                return name;
         }
     }
 


### PR DESCRIPTION
added obstacle map ipcs for https://github.com/Jaksuhn/ffxiv-bundleoftweaks/issues/124. So right now what I do in CBT is call it right before moving to the fate with the fate bounds + a few yalms for margin. I wasn't really sure about adding these as normal obstacle maps since they're auto generated/unchecked so it just stores it in memory, which is fine for my use case since these are very tiny areas being generated.

Also for Fate utils, added LoS checks to use the aforementioned maps.  I was testing in north shroud as that has a lot of shit on the map and variable terrain. It worked pretty well in fates like Air Supply that has a lot of LoS checks and has to navigate around the water. One area it still fails is in the west of north shroud where there's a lot of Y elevation changes. It will just walk off cliffs. Not too sure what if anything can be done about that.

Would appreciate a good look over/code review of this one as I've barely touched obstacle maps before.