### PR TITLE
fateutils los fixes/additions

### DIFF
--- a/BossMod/Autorotation/MiscAI/FateUtils.cs
+++ b/BossMod/Autorotation/MiscAI/FateUtils.cs
@@ -41,96 +41,66 @@ public sealed class FateUtils(RotationModuleManager manager, Actor player) : Rot
         if (strategy.Option(Track.Chocobo).As<Flag>() == Flag.Enabled && World.Client.GetInventoryItemQuantity(ActionDefinitions.IDMiscItemGreens.ID) > 0 && World.Client.ActiveCompanion is { TimeLeft: < 60, Stabled: false })
             Hints.ActionsToExecute.Push(ActionDefinitions.IDMiscItemGreens, Player, ActionQueue.Priority.VeryHigh);
 
-        var fateID = World.Client.ActiveFate.ID;
-        if (primaryTarget is { FateID: > 0 } target && target.FateID == fateID)
-            AddLOSGoalForTarget(target);
-
-        if (strategy.Option(Track.Handin).As<Flag>() != Flag.Enabled)
-            return;
-
-        var item = Utils.GetFateItem(fateID);
-        if (item == 0)
-            return;
-
-        // already turned in enough, fate is ending, do nothing
-        if (World.Client.ActiveFate.HandInCount >= TurnInGoldReq && World.Client.ActiveFate.Progress >= 100)
-            return;
-
-        // until fate is completed, hand in batches of 10; if other people complete the fate, we stop doing stuff
-        if (World.Client.GetInventoryItemQuantity(item) >= TurnInGoldReq)
+        var goal = GetGoal(strategy);
+        if (goal is CollectFateGoal.HandIn)
         {
             Hints.InteractWithTarget = World.Actors.Find(World.Client.ActiveFate.ObjectiveNpc);
             return;
         }
-
-        // otherwise, pick up stuff
-        if (strategy.Option(Track.Collect).As<Flag>() == Flag.Enabled && !Player.InCombat)
-            Hints.InteractWithTarget = World.Actors.Where(a => a.FateID == fateID && a.IsTargetable && a.Type == ActorType.EventObj).MinBy(Player.DistanceToHitbox);
-
-    }
-
-    private void AddLOSGoalForTarget(Actor target)
-    {
-        if (Hints.PathfindMapObstacles.Bitmap is not { } bitmap)
+        else if (goal is CollectFateGoal.Pickup)
+        {
+            Hints.InteractWithTarget = World.Actors.Where(a => a.FateID == World.Client.ActiveFate.ID && a.IsTargetable && a.Type == ActorType.EventObj).MinBy(Player.DistanceToHitbox);
             return;
+        }
 
-        var rect = Hints.PathfindMapObstacles.Rect;
-        var mapCenter = Hints.PathfindMapCenter;
-        var targetPos = target.Position;
-        var targetRange = (Player.Role is Role.Melee or Role.Tank ? 3.5f : 24.5f) + target.HitboxRadius;
-
-        // blacklist current tile if no LoS
-        Hints.GoalZones.Add(p => HasLineOfSight(bitmap, rect, mapCenter, p, targetPos) ? 0 : -100);
-        Hints.GoalZones.Add(p =>
+        if (Manager.LoSFix is { } los)
         {
-            if (!HasLineOfSight(bitmap, rect, mapCenter, p, targetPos))
-                return 0;
-            return (p - targetPos).LengthSq() <= targetRange * targetRange ? 20 : 8;
-        });
-    }
+            var losDelta = los.Destination - los.Origin;
+            var losDist = losDelta.Length();
+            var losDir = losDist > 1e-3f ? losDelta / losDist : default;
 
-    private static bool HasLineOfSight(Bitmap map, Bitmap.Rect rect, WPos mapCenter, WPos from, WPos to)
-    {
-        if (!TryWorldToBitmapCell(map, rect, mapCenter, from, out var x0, out var y0) || !TryWorldToBitmapCell(map, rect, mapCenter, to, out var x1, out var y1))
-            return true; // if mapping fails, don't block movement
-
-        var dx = Math.Abs(x1 - x0);
-        var sx = x0 < x1 ? 1 : -1;
-        var dy = -Math.Abs(y1 - y0);
-        var sy = y0 < y1 ? 1 : -1;
-        var err = dx + dy;
-        var x = x0;
-        var y = y0;
-
-        while (true)
-        {
-            if ((uint)x < map.Width && (uint)y < map.Height && map[x, y])
-                return false;
-            if (x == x1 && y == y1)
-                return true;
-            var e2 = 2 * err;
-            if (e2 >= dy)
+            // tight spot with high reward to get out of where we're at
+            Hints.GoalZones.Add(Hints.GoalSingleTarget(los.Destination, 0.3f, 120));
+            // add a penalty to current position to actually encourage moving out of it
+            Hints.GoalZones.Add(p => p.InCircle(los.Origin, 1.0f) ? -25 : 0);
+            // more encouragement for going towards the destination, but need to cap it or else it'll just keep going
+            Hints.GoalZones.Add(p =>
             {
-                err += dy;
-                x += sx;
-            }
-            if (e2 <= dx)
-            {
-                err += dx;
-                y += sy;
-            }
+                var progress = WDir.Dot(p - los.Origin, losDir);
+                if (progress <= 0)
+                    return 0;
+
+                var cappedProgress = MathF.Min(progress, losDist);
+                var overshoot = MathF.Max(0, progress - losDist);
+                return cappedProgress * 8 - overshoot * 16;
+            });
         }
     }
 
-    private static bool TryWorldToBitmapCell(Bitmap map, Bitmap.Rect rect, WPos mapCenter, WPos pos, out int x, out int y)
+    private CollectFateGoal GetGoal(StrategyValues strategy)
     {
-        var centerCellX = (rect.Left + rect.Right) * 0.5f;
-        var centerCellY = (rect.Top + rect.Bottom) * 0.5f;
-        var invRes = 1.0f / map.PixelSize;
-        var delta = (pos - mapCenter) * invRes;
+        if (strategy.Option(Track.Handin).As<Flag>() != Flag.Enabled)
+            return CollectFateGoal.None;
 
-        x = (int)MathF.Round(centerCellX + delta.X);
-        y = (int)MathF.Round(centerCellY + delta.Z);
-        return (uint)x < map.Width && (uint)y < map.Height;
+        if (Utils.GetFateItem(World.Client.ActiveFate.ID) is not (not 0 and var itemId))
+            return CollectFateGoal.None;
+
+        // already turned in enough, fate is ending, do nothing
+        if (World.Client.ActiveFate.HandInCount >= TurnInGoldReq && World.Client.ActiveFate.Progress >= 100)
+            return CollectFateGoal.None;
+
+        // until fate is completed, hand in batches of 10; if other people complete the fate, we stop doing stuff
+        if (World.Client.GetInventoryItemQuantity(itemId) >= TurnInGoldReq)
+            return CollectFateGoal.HandIn;
+
+        // pick up stuff
+        return strategy.Option(Track.Collect).As<Flag>() == Flag.Enabled && !Player.InCombat ? CollectFateGoal.Pickup : CollectFateGoal.None;
+    }
+
+    private enum CollectFateGoal
+    {
+        None,
+        HandIn,
+        Pickup,
     }
 }

--- a/BossMod/Autorotation/MiscAI/FateUtils.cs
+++ b/BossMod/Autorotation/MiscAI/FateUtils.cs
@@ -2,6 +2,8 @@ namespace BossMod.Autorotation.MiscAI;
 
 public sealed class FateUtils(RotationModuleManager manager, Actor player) : RotationModule(manager, player)
 {
+    public override bool WantsLoSFix => true;
+
     public enum Track { Handin, Collect, Sync, Chocobo }
     public enum Flag { Enabled, Disabled }
 

--- a/BossMod/Autorotation/RotationModule.cs
+++ b/BossMod/Autorotation/RotationModule.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 
 namespace BossMod.Autorotation;
 
@@ -193,6 +193,8 @@ public abstract class RotationModule(RotationModuleManager manager, Actor player
 
     // the main entry point of the module - given a set of strategy values, fill the queue with a set of actions to execute
     public abstract void Execute(StrategyValues strategy, ref Actor? primaryTarget, float estimatedAnimLockDelay, bool isMoving);
+
+    public virtual bool WantsLoSFix => false;
 
     public virtual string DescribeState() => "";
 

--- a/BossMod/Autorotation/RotationModuleManager.cs
+++ b/BossMod/Autorotation/RotationModuleManager.cs
@@ -1,4 +1,6 @@
-﻿namespace BossMod.Autorotation;
+using FFXIVClientStructs.FFXIV.Common.Component.BGCollision;
+
+namespace BossMod.Autorotation;
 
 public interface IRotationModuleData
 {
@@ -11,6 +13,7 @@ public interface IRotationModuleData
 public sealed class RotationModuleManager : IDisposable
 {
     private readonly record struct ActiveModule(int DataIndex, RotationModuleDefinition Definition, RotationModule Module);
+    public readonly record struct LineOfSightFix(ulong TargetID, WPos Origin, WPos Destination);
 
     public readonly List<Preset> Presets = [];
 
@@ -38,6 +41,7 @@ public sealed class RotationModuleManager : IDisposable
     // historic data for recent events that could be interesting for modules
     public DateTime CombatStart { get; private set; } // default value when player is not in combat, otherwise timestamp when player entered combat
     public (DateTime Time, ActorCastEvent? Data) LastCast { get; private set; }
+    public LineOfSightFix? LoSFix { get; private set; }
 
     public volatile float LastRasterizeMs;
     public volatile float LastPathfindMs;
@@ -86,6 +90,7 @@ public sealed class RotationModuleManager : IDisposable
             WorldState.Party.Modified.Subscribe(op => DirtyActiveModules(op.Slot == PlayerSlot)),
             WorldState.Client.ActionRequested.Subscribe(OnActionRequested),
             WorldState.Client.CountdownChanged.Subscribe(OnCountdownChanged),
+            WorldState.Client.ActionFailedLoS.Subscribe(OnLoSFailed),
             Database.Presets.PresetModified.Subscribe(OnPresetModified)
         );
     }
@@ -358,5 +363,196 @@ public sealed class RotationModuleManager : IDisposable
             Service.Log($"[RMM] Luring Trap triggered, force-disabling from '{PresetNames}'");
             SetForceDisabled();
         }
+
+        if (actor.InstanceID == PlayerInstanceId)
+        {
+            LoSFix = null; // successful cast means we're not stuck anymore
+        }
+    }
+
+    private void OnLoSFailed(ClientState.OpActionFailedLoS op)
+    {
+        if (Hints.PathfindMapObstacles.Bitmap is null)
+            return;
+
+        // don't reevaluate if there's one fix for current target. Performance cost is huge
+        if (LoSFix?.TargetID == op.TargetId)
+            return;
+
+        if (Player is null || WorldState.Actors.Find(op.TargetId) is not { } target)
+        {
+            LoSFix = null;
+            return;
+        }
+
+        var dest = FindLosDestination(Hints.PathfindMapObstacles, Hints.PathfindMapCenter, Player, target, out var debug);
+        if (Service.IsDev)
+        {
+            Service.Log($"[RMM] LoS failed for action {op.ActionId} on target {target.Name}#{op.TargetId:X}, setting LoS destination to {dest}");
+            Service.Log($"[RMM] {debug}");
+        }
+        LoSFix = dest != null ? new(op.TargetId, Player.Position, dest.Value) : null;
+    }
+
+    private static WPos? FindLosDestination(Bitmap.Region obstacleRegion, WPos mapCenter, Actor player, Actor target, out string debug)
+    {
+        var map = obstacleRegion.Bitmap!;
+        var w = map.Width;
+        var h = map.Height;
+        if (w <= 0 || h <= 0)
+        {
+            debug = $"invalid-map-size={w}x{h}";
+            return null;
+        }
+
+        // clamp to nearest in-bounds cell
+        var centerCellX = (obstacleRegion.Rect.Left + obstacleRegion.Rect.Right) * 0.5f;
+        var centerCellY = (obstacleRegion.Rect.Top + obstacleRegion.Rect.Bottom) * 0.5f;
+        var invRes = 1.0f / map.PixelSize;
+        var delta = (player.Position - mapCenter) * invRes;
+        var sx = (int)MathF.Round(centerCellX + delta.X);
+        var sy = (int)MathF.Round(centerCellY + delta.Z);
+        sx = Math.Clamp(sx, 0, w - 1);
+        sy = Math.Clamp(sy, 0, h - 1);
+
+        var visited = new bool[w * h];
+        var q = new Queue<(int x, int y)>();
+        var pass1Visited = 0;
+        var pass1BitmapReject = 0;
+        var pass1RayReject = 0;
+        var pass2Visited = 0;
+        var pass2RayReject = 0;
+        var startPos = obstacleRegion.CellCenterToWorld(mapCenter, sx, sy);
+        var startRayLoS = HasLineOfSightFrom(startPos, player.PosRot.Y, target);
+        var startBitmapLoS = obstacleRegion.HasObstacleMapLineOfSight(mapCenter, startPos, target.Position);
+        bool Passable(int x, int y) => (uint)x < (uint)w && (uint)y < (uint)h && !map[x, y];
+
+        void Enqueue(int x, int y)
+        {
+            if (!Passable(x, y))
+                return;
+            ref var slot = ref visited[y * w + x];
+            if (slot)
+                return;
+            slot = true;
+            q.Enqueue((x, y));
+        }
+
+        bool SeedFromNearestPassable(out int seededCount)
+        {
+            seededCount = 0;
+            Enqueue(sx, sy);
+            if (q.Count > 0)
+            {
+                seededCount = q.Count;
+                return true;
+            }
+
+            // start can be blocked, grow until passable seed found
+            var maxR = Math.Max(w, h);
+            for (var r = 1; r < maxR; ++r)
+            {
+                var any = false;
+                var xmin = sx - r;
+                var xmax = sx + r;
+                var ymin = sy - r;
+                var ymax = sy + r;
+
+                for (var x = xmin; x <= xmax; ++x)
+                {
+                    var before = q.Count;
+                    Enqueue(x, ymin);
+                    Enqueue(x, ymax);
+                    any |= q.Count != before;
+                }
+                for (var y = ymin + 1; y < ymax; ++y)
+                {
+                    var before = q.Count;
+                    Enqueue(xmin, y);
+                    Enqueue(xmax, y);
+                    any |= q.Count != before;
+                }
+                if (any)
+                {
+                    seededCount = q.Count;
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        if (!SeedFromNearestPassable(out var seededPass1))
+        {
+            debug = $"seed-failed start=({sx},{sy}) start-passable={Passable(sx, sy)} start-ray={startRayLoS} start-bitmap={startBitmapLoS}";
+            return null;
+        }
+
+        // check bitmap los + raycast los
+        while (q.Count > 0)
+        {
+            var (x, y) = q.Dequeue();
+            ++pass1Visited;
+            var wpos = obstacleRegion.CellCenterToWorld(mapCenter, x, y);
+            var bitmapOK = obstacleRegion.HasObstacleMapLineOfSight(mapCenter, wpos, target.Position);
+            var rayOK = HasLineOfSightFrom(wpos, player.PosRot.Y, target);
+            if (!bitmapOK)
+                ++pass1BitmapReject;
+            if (!rayOK)
+                ++pass1RayReject;
+            if ((x != sx || y != sy) && bitmapOK && rayOK)
+            {
+                debug = $"ok-pass1 start=({sx},{sy}) seed1={seededPass1} p1v={pass1Visited} p1b-rej={pass1BitmapReject} p1r-rej={pass1RayReject}";
+                return obstacleRegion.CellCenterToWorld(mapCenter, x, y);
+            }
+
+            Enqueue(x + 1, y);
+            Enqueue(x - 1, y);
+            Enqueue(x, y + 1);
+            Enqueue(x, y - 1);
+        }
+
+        Array.Clear(visited, 0, visited.Length);
+        q.Clear();
+        if (!SeedFromNearestPassable(out var seededPass2))
+        {
+            debug = $"seed2-failed start=({sx},{sy}) pass1-visited={pass1Visited} b-reject={pass1BitmapReject} r-reject={pass1RayReject}";
+            return null;
+        }
+
+        // in case the bitmap is shit, just do raycast only
+        while (q.Count > 0)
+        {
+            var (x, y) = q.Dequeue();
+            ++pass2Visited;
+            var wpos = obstacleRegion.CellCenterToWorld(mapCenter, x, y);
+            var rayOK = HasLineOfSightFrom(wpos, player.PosRot.Y, target);
+            if (!rayOK)
+                ++pass2RayReject;
+            if ((x != sx || y != sy) && rayOK)
+            {
+                debug = $"ok-pass2 start=({sx},{sy}) seed1={seededPass1} p1v={pass1Visited} p1b-rej={pass1BitmapReject} p1r-rej={pass1RayReject} seed2={seededPass2} p2v={pass2Visited} p2r-rej={pass2RayReject}";
+                return obstacleRegion.CellCenterToWorld(mapCenter, x, y);
+            }
+
+            Enqueue(x + 1, y);
+            Enqueue(x - 1, y);
+            Enqueue(x, y + 1);
+            Enqueue(x, y - 1);
+        }
+
+        debug = $"null start=({sx},{sy}) passable={Passable(sx, sy)} start-ray={startRayLoS} start-bitmap={startBitmapLoS} seed1={seededPass1} p1v={pass1Visited} p1b-rej={pass1BitmapReject} p1r-rej={pass1RayReject} seed2={seededPass2} p2v={pass2Visited} p2r-rej={pass2RayReject}";
+        return null;
+    }
+
+    private static bool HasLineOfSightFrom(WPos from, float sourceY, Actor target)
+    {
+        var sourcePos = from.ToVec3(sourceY + 2);
+        var targetPos = target.Position.ToVec3(target.PosRot.Y + 2);
+        var offset = targetPos - sourcePos;
+        var maxDist = offset.Length();
+        if (maxDist <= 1e-3f)
+            return true;
+        var direction = offset / maxDist;
+        return !BGCollisionModule.RaycastMaterialFilter(sourcePos, direction, out _, maxDist);
     }
 }

--- a/BossMod/Autorotation/RotationModuleManager.cs
+++ b/BossMod/Autorotation/RotationModuleManager.cs
@@ -27,6 +27,7 @@ public sealed class RotationModuleManager : IDisposable
     private readonly EventSubscriptions _subscriptions;
     private List<(int index, ActiveModule module)>? _activeModules;
     private IEnumerable<ActiveModule> ActiveModulesFlat => _activeModules?.Select(m => m.module) ?? [];
+    private bool WantsLoSFix => ActiveModulesFlat.Any(m => m.Module.WantsLoSFix);
 
     public static readonly Preset ForceDisable = new(""); // empty preset, so if it's activated, rotation is force disabled
 
@@ -372,6 +373,12 @@ public sealed class RotationModuleManager : IDisposable
 
     private void OnLoSFailed(ClientState.OpActionFailedLoS op)
     {
+        if (!WantsLoSFix)
+        {
+            LoSFix = null;
+            return;
+        }
+
         if (Hints.PathfindMapObstacles.Bitmap is null)
             return;
 

--- a/BossMod/Data/ClientState.cs
+++ b/BossMod/Data/ClientState.cs
@@ -513,4 +513,11 @@ public sealed class ClientState
             output.EmitFourCC("INVT"u8).Emit(ItemId).Emit(Quantity);
         }
     }
+
+    public Event<OpActionFailedLoS> ActionFailedLoS = new();
+    public sealed record class OpActionFailedLoS(uint ActionId, ulong TargetId) : WorldState.Operation
+    {
+        protected override void Exec(WorldState ws) => ws.Client.ActionFailedLoS.Fire(this);
+        public override void Write(ReplayRecorder.Output output) => output.EmitFourCC("FLOS"u8).Emit(ActionId).EmitActor(TargetId);
+    }
 }

--- a/BossMod/Framework/WorldStateGameSync.cs
+++ b/BossMod/Framework/WorldStateGameSync.cs
@@ -212,6 +212,7 @@ sealed class WorldStateGameSync : IDisposable
         _processPacketOpenTreasureHook.Dispose();
         _processPacketFateTradeHook.Dispose();
         _processPacketFateInfoHook.Dispose();
+        _getActionInRangeOrLoSHook.Dispose();
         _subscriptions.Dispose();
         _netConfig.Dispose();
         _interceptor.Dispose();

--- a/BossMod/Framework/WorldStateGameSync.cs
+++ b/BossMod/Framework/WorldStateGameSync.cs
@@ -94,6 +94,8 @@ sealed class WorldStateGameSync : IDisposable
     private unsafe delegate void ProcessPacketPlayActionTimelineSync(Network.ServerIPC.PlayActionTimelineSync* data);
     private readonly Hook<ProcessPacketPlayActionTimelineSync> _processPlayActionTimelineSyncHook;
 
+    private readonly Hook<ActionManager.Delegates.GetActionInRangeOrLoS> _getActionInRangeOrLoSHook;
+
     public unsafe WorldStateGameSync(WorldState ws, ActionManagerEx amex)
     {
         _ws = ws;
@@ -185,6 +187,10 @@ sealed class WorldStateGameSync : IDisposable
         _processPlayActionTimelineSyncHook = Service.Hook.HookFromSignature<ProcessPacketPlayActionTimelineSync>("E8 ?? ?? ?? ?? E9 ?? ?? ?? ?? B9 ?? ?? ?? ?? 48 8B D7 45 33 C0 E8 ?? ?? ?? ?? E9 ?? ?? ?? ?? B9 ?? ?? ?? ??", ProcessPlayActionTimelineSyncDetour);
         _processPlayActionTimelineSyncHook.Enable();
         Service.Log($"[WSG] ProcessPlayActionTimelineSync address = {_processPlayActionTimelineSyncHook.Address:X}");
+
+        _getActionInRangeOrLoSHook = Service.Hook.HookFromAddress<ActionManager.Delegates.GetActionInRangeOrLoS>((nint)ActionManager.MemberFunctionPointers.GetActionInRangeOrLoS, GetActionInRangeOrLoSDetour);
+        _getActionInRangeOrLoSHook.Enable();
+        Service.Log($"[WSG] GetActionInRangeOrLoS address = 0x{_getActionInRangeOrLoSHook.Address:X}");
     }
 
     public void Dispose()
@@ -1158,5 +1164,13 @@ sealed class WorldStateGameSync : IDisposable
 
         if (owner > 0)
             _actorOps.GetOrAdd(owner).Add(new ActorState.OpPlayActionTimelineSync(owner, actions));
+    }
+
+    private unsafe uint GetActionInRangeOrLoSDetour(uint actionId, GameObject* sourceObject, GameObject* targetObject)
+    {
+        var res = _getActionInRangeOrLoSHook.Original(actionId, sourceObject, targetObject);
+        if (res is 562 && sourceObject->EntityId == UIState.Instance()->PlayerState.EntityId)
+            _globalOps.Add(new ClientState.OpActionFailedLoS(actionId, SanitizedObjectID(targetObject->EntityId)));
+        return res;
     }
 }

--- a/BossMod/Util/BitmapPathfindExtensions.cs
+++ b/BossMod/Util/BitmapPathfindExtensions.cs
@@ -1,0 +1,67 @@
+namespace BossMod;
+
+public static class BitmapPathfindExtensions
+{
+    public static bool TryWorldToBitmapCell(this Bitmap map, Bitmap.Rect rect, WPos mapCenter, WPos pos, out int x, out int y)
+    {
+        var centerCellX = (rect.Left + rect.Right) * 0.5f;
+        var centerCellY = (rect.Top + rect.Bottom) * 0.5f;
+        var invRes = 1.0f / map.PixelSize;
+        var delta = (pos - mapCenter) * invRes;
+        x = (int)MathF.Round(centerCellX + delta.X);
+        y = (int)MathF.Round(centerCellY + delta.Z);
+        return (uint)x < map.Width && (uint)y < map.Height;
+    }
+
+    public static WPos CellCenterToWorld(this Bitmap map, Bitmap.Rect rect, WPos mapCenter, int x, int y)
+    {
+        var centerCellX = (rect.Left + rect.Right) * 0.5f;
+        var centerCellY = (rect.Top + rect.Bottom) * 0.5f;
+        var ps = map.PixelSize;
+        return new WPos(
+            mapCenter.X + (x - centerCellX) * ps,
+            mapCenter.Z + (y - centerCellY) * ps);
+    }
+
+    public static bool HasObstacleMapLineOfSight(this Bitmap map, Bitmap.Rect rect, WPos mapCenter, WPos from, WPos to)
+    {
+        if (!map.TryWorldToBitmapCell(rect, mapCenter, from, out var x0, out var y0) || !map.TryWorldToBitmapCell(rect, mapCenter, to, out var x1, out var y1))
+            return true;
+
+        var dx = Math.Abs(x1 - x0);
+        var sx = x0 < x1 ? 1 : -1;
+        var dy = -Math.Abs(y1 - y0);
+        var sy = y0 < y1 ? 1 : -1;
+        var err = dx + dy;
+        var x = x0;
+        var y = y0;
+
+        while (true)
+        {
+            if ((uint)x < map.Width && (uint)y < map.Height && map[x, y])
+                return false;
+            if (x == x1 && y == y1)
+                return true;
+            var e2 = 2 * err;
+            if (e2 >= dy)
+            {
+                err += dy;
+                x += sx;
+            }
+            if (e2 <= dx)
+            {
+                err += dx;
+                y += sy;
+            }
+        }
+    }
+
+    public static bool TryWorldToBitmapCell(this Bitmap.Region region, WPos mapCenter, WPos pos, out int x, out int y)
+        => region.Bitmap.TryWorldToBitmapCell(region.Rect, mapCenter, pos, out x, out y);
+
+    public static WPos CellCenterToWorld(this Bitmap.Region region, WPos mapCenter, int x, int y)
+        => region.Bitmap.CellCenterToWorld(region.Rect, mapCenter, x, y);
+
+    public static bool HasObstacleMapLineOfSight(this Bitmap.Region region, WPos mapCenter, WPos from, WPos to)
+        => region.Bitmap.HasObstacleMapLineOfSight(region.Rect, mapCenter, from, to);
+}


### PR DESCRIPTION
last go at this was obstacle map los only, but now I added a raycast los check

it's in rmm because I was having some persistence issues when it was solely in fateutils (and also rot mods aren't capable of subscribing to events and I didn't want to add that functionality)

there's an opt-in WantsLoSFix virtual for rot mods if they want to use it, otherwise it won't run the los checks so other mods shouldn't have a (minor) performance loss because of this