### PR TITLE
Add Module for Normal Everkeep

### DIFF
--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/Actualize.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/Actualize.cs
@@ -1,0 +1,3 @@
+namespace BossMod.Dawntrail.Trial.T03Everkeep;
+
+class Actualize(BossModule module) : Components.RaidwideCast(module, AID.Actualize);

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/Actualize.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/Actualize.cs
@@ -1,3 +1,13 @@
 namespace BossMod.Dawntrail.Trial.T03Everkeep;
 
-class Actualize(BossModule module) : Components.RaidwideCast(module, AID.Actualize);
+// Actualize is the raidwide that restores the arena after the Chasm of Vollok + Forged Track
+// sequence: at cast resolution the platform expands back to the full 40x40 arena.
+class Actualize(BossModule module) : Components.RaidwideCast(module, AID.Actualize)
+{
+    public override void OnEventCast(Actor caster, ActorCastEvent spell)
+    {
+        base.OnEventCast(caster, spell);
+        if ((AID)spell.Action.ID == AID.Actualize)
+            Module.Arena.Bounds = T03Everkeep.NormalBounds;
+    }
+}

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/Actualize.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/Actualize.cs
@@ -1,7 +1,5 @@
 namespace BossMod.Dawntrail.Trial.T03Everkeep;
 
-// Actualize is the raidwide that restores the arena after the Chasm of Vollok + Forged Track
-// sequence: at cast resolution the platform expands back to the full 40x40 arena.
 class Actualize(BossModule module) : Components.RaidwideCast(module, AID.Actualize)
 {
     public override void OnEventCast(Actor caster, ActorCastEvent spell)

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/BitterReaping.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/BitterReaping.cs
@@ -1,0 +1,3 @@
+namespace BossMod.Dawntrail.Trial.T03Everkeep;
+
+class BitterReaping(BossModule module) : Components.SingleTargetCast(module, AID.BitterReapingAOE, "Tank busters");

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/Burst.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/Burst.cs
@@ -1,0 +1,3 @@
+namespace BossMod.Dawntrail.Trial.T03Everkeep;
+
+class Burst(BossModule module) : Components.StandardAOEs(module, AID.Burst, new AOEShapeCircle(8));

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/CalamitysEdge.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/CalamitysEdge.cs
@@ -1,0 +1,3 @@
+namespace BossMod.Dawntrail.Trial.T03Everkeep;
+
+class CalamitysEdge(BossModule module) : Components.RaidwideCast(module, AID.CalamitysEdge);

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/ChasmOfVollok.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/ChasmOfVollok.cs
@@ -1,0 +1,3 @@
+namespace BossMod.Dawntrail.Trial.T03Everkeep;
+
+class ChasmOfVollok(BossModule module) : Components.StandardAOEs(module, AID.ChasmOfVollokAOE, new AOEShapeRect(2.5f, 2.5f, 2.5f));

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/ChasmOfVollok.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/ChasmOfVollok.cs
@@ -9,9 +9,9 @@ namespace BossMod.Dawntrail.Trial.T03Everkeep;
 //
 // In Mode B the outer 37720 cell maps deterministically to its inner 37722 damage cell: shift
 // ~21.21m (= 30/√2, three 5m cells along the rotated grid) toward the arena center along both
-// world X and Z axes. Verified across 5 waves of the test replay. We render the predicted damage
-// cell with 6.7s warning so the AI has time to reposition. When 37722 actually fires, its rect
-// also renders (final-moment reminder, redundant with the predicted one).
+// world X and Z axes. We render the predicted damage cell with 6.7s warning so the AI has time
+// to reposition. When 37722 actually fires, its rect also renders (final-moment reminder,
+// redundant with the predicted one).
 //
 // Origin-at-back-corner shape (5f forward + 0 back): cast targets sit at the back corner of each
 // 5×5 cell, not the center, so we extend the rect 5 forward from its origin.

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/ChasmOfVollok.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/ChasmOfVollok.cs
@@ -1,3 +1,6 @@
 namespace BossMod.Dawntrail.Trial.T03Everkeep;
 
-class ChasmOfVollok(BossModule module) : Components.StandardAOEs(module, AID.ChasmOfVollokAOE, new AOEShapeRect(2.5f, 2.5f, 2.5f));
+// Cast target positions sit at the "near" corner of each 5x5 grid cell rather than the center,
+// so we draw the rect as 5 forward + 0 back (origin at the back corner) instead of centered.
+// That way the extreme rect (SE-most in local) has its outer corner at the arena's S diamond tip.
+class ChasmOfVollok(BossModule module) : Components.StandardAOEs(module, AID.ChasmOfVollokAOE, new AOEShapeRect(5f, 2.5f));

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/ChasmOfVollok.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/ChasmOfVollok.cs
@@ -1,11 +1,57 @@
 namespace BossMod.Dawntrail.Trial.T03Everkeep;
 
-// Track both the 6.7s preview (37720) and the 0.7s final damage cast (37722). The preview gives
-// the long warning window the AI needs to reposition; the damage cast still renders as a
-// final-moment reminder. Target positions for both are the same grid cells, so the rect appears
-// in the correct spot throughout.
+// Two flavors of Chasm of Vollok exist:
+// - Single-cast (Mode A): 37720 cells spawn inside the arena and ARE the damage; 37722 doesn't
+//   fire. We just render the 37720 cell with its 6.7s cast as the warning.
+// - Telegraphed (Mode B): 37720 cells spawn on the OUTER ring (visual only, no damage), then
+//   37722 fires 6s later on different cells inside the arena. The user only gets ~0.7s warning
+//   from 37722 alone, which the AI cannot react to in time.
 //
-// Origin-at-back-corner shape (5f forward + 0 back) ensures the SE-most rect's outer corner
-// reaches the arena's S diamond tip — cast targets sit at the back corner of each 5x5 cell, not
-// the center.
-class ChasmOfVollok(BossModule module) : Components.GroupedAOEs(module, [AID.ChasmOfVollokPreview, AID.ChasmOfVollokAOE], new AOEShapeRect(5f, 2.5f));
+// In Mode B the outer 37720 cell maps deterministically to its inner 37722 damage cell: shift
+// ~21.21m (= 30/√2, three 5m cells along the rotated grid) toward the arena center along both
+// world X and Z axes. Verified across 5 waves of the test replay. We render the predicted damage
+// cell with 6.7s warning so the AI has time to reposition. When 37722 actually fires, its rect
+// also renders (final-moment reminder, redundant with the predicted one).
+//
+// Origin-at-back-corner shape (5f forward + 0 back): cast targets sit at the back corner of each
+// 5×5 cell, not the center, so we extend the rect 5 forward from its origin.
+class ChasmOfVollok(BossModule module) : Components.GenericAOEs(module)
+{
+    private readonly Dictionary<ulong, AOEInstance> _previewAoes = [];
+    private readonly Dictionary<ulong, AOEInstance> _damageAoes = [];
+
+    private static readonly AOEShapeRect _shape = new(5f, 2.5f);
+    private const float ArenaRadius = 15f; // cells beyond this are outer-ring previews (Mode B)
+    private const float TranslateMagnitude = 21.21f; // 15√2; shift toward center per world axis
+
+    public override IEnumerable<AOEInstance> ActiveAOEs(int slot, Actor actor) =>
+        _previewAoes.Values.Concat(_damageAoes.Values);
+
+    public override void OnCastStarted(Actor caster, ActorCastInfo spell)
+    {
+        switch ((AID)spell.Action.ID)
+        {
+            case AID.ChasmOfVollokPreview:
+                var pos = spell.LocXZ;
+                var dx = pos.X - Module.Center.X;
+                var dz = pos.Z - Module.Center.Z;
+                if (dx * dx + dz * dz > ArenaRadius * ArenaRadius)
+                    pos = new WPos(pos.X - TranslateMagnitude * MathF.Sign(dx),
+                                   pos.Z - TranslateMagnitude * MathF.Sign(dz));
+                _previewAoes[caster.InstanceID] = new AOEInstance(_shape, pos, spell.Rotation, Module.CastFinishAt(spell));
+                break;
+            case AID.ChasmOfVollokAOE:
+                _damageAoes[caster.InstanceID] = new AOEInstance(_shape, spell.LocXZ, spell.Rotation, Module.CastFinishAt(spell));
+                break;
+        }
+    }
+
+    public override void OnCastFinished(Actor caster, ActorCastInfo spell)
+    {
+        switch ((AID)spell.Action.ID)
+        {
+            case AID.ChasmOfVollokPreview: _previewAoes.Remove(caster.InstanceID); break;
+            case AID.ChasmOfVollokAOE: _damageAoes.Remove(caster.InstanceID); break;
+        }
+    }
+}

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/ChasmOfVollok.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/ChasmOfVollok.cs
@@ -1,6 +1,11 @@
 namespace BossMod.Dawntrail.Trial.T03Everkeep;
 
-// Cast target positions sit at the "near" corner of each 5x5 grid cell rather than the center,
-// so we draw the rect as 5 forward + 0 back (origin at the back corner) instead of centered.
-// That way the extreme rect (SE-most in local) has its outer corner at the arena's S diamond tip.
-class ChasmOfVollok(BossModule module) : Components.StandardAOEs(module, AID.ChasmOfVollokAOE, new AOEShapeRect(5f, 2.5f));
+// Track both the 6.7s preview (37720) and the 0.7s final damage cast (37722). The preview gives
+// the long warning window the AI needs to reposition; the damage cast still renders as a
+// final-moment reminder. Target positions for both are the same grid cells, so the rect appears
+// in the correct spot throughout.
+//
+// Origin-at-back-corner shape (5f forward + 0 back) ensures the SE-most rect's outer corner
+// reaches the arena's S diamond tip — cast targets sit at the back corner of each 5x5 cell, not
+// the center.
+class ChasmOfVollok(BossModule module) : Components.GroupedAOEs(module, [AID.ChasmOfVollokPreview, AID.ChasmOfVollokAOE], new AOEShapeRect(5f, 2.5f));

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/DawnOfAnAge.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/DawnOfAnAge.cs
@@ -1,0 +1,3 @@
+namespace BossMod.Dawntrail.Trial.T03Everkeep;
+
+class DawnOfAnAge(BossModule module) : Components.RaidwideCast(module, AID.DawnOfAnAge);

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/DawnOfAnAge.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/DawnOfAnAge.cs
@@ -11,4 +11,15 @@ class DawnOfAnAge(BossModule module) : Components.RaidwideCast(module, AID.DawnO
         if ((AID)spell.Action.ID == AID.DawnOfAnAge)
             Module.Arena.Bounds = T03Everkeep.SmallBounds;
     }
+
+    public override void AddAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
+    {
+        base.AddAIHints(slot, actor, assignment, hints);
+        // While the cast is up, forbid everything outside the post-shrink diamond so ranged jobs
+        // pull in toward center before the platform collapses around them.
+        var center = Module.Center;
+        var bounds = T03Everkeep.SmallBounds;
+        foreach (var c in Casters)
+            hints.AddForbiddenZone(p => !bounds.Contains(p - center), Module.CastFinishAt(c.CastInfo));
+    }
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/DawnOfAnAge.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/DawnOfAnAge.cs
@@ -1,3 +1,14 @@
 namespace BossMod.Dawntrail.Trial.T03Everkeep;
 
-class DawnOfAnAge(BossModule module) : Components.RaidwideCast(module, AID.DawnOfAnAge);
+// Dawn of an Age is the raidwide that also shrinks the arena: when the cast resolves the platform
+// collapses to a 20x20 center square for the Chasm of Vollok + Forged Track sequence. Actualize
+// restores the full 40x40 arena at the end of that sequence.
+class DawnOfAnAge(BossModule module) : Components.RaidwideCast(module, AID.DawnOfAnAge)
+{
+    public override void OnEventCast(Actor caster, ActorCastEvent spell)
+    {
+        base.OnEventCast(caster, spell);
+        if ((AID)spell.Action.ID == AID.DawnOfAnAge)
+            Module.Arena.Bounds = T03Everkeep.SmallBounds;
+    }
+}

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/DawnOfAnAge.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/DawnOfAnAge.cs
@@ -22,4 +22,29 @@ class DawnOfAnAge(BossModule module) : Components.RaidwideCast(module, AID.DawnO
         foreach (var c in Casters)
             hints.AddForbiddenZone(p => !bounds.Contains(p - center), Module.CastFinishAt(c.CastInfo));
     }
+
+    // Cardinal extents of the rotated-45° diamonds: corners sit at half-extent × √2 from center.
+    private static readonly float OuterCardinal = 20f * MathF.Sqrt(2);
+    private static readonly float InnerCardinal = 10f * MathF.Sqrt(2);
+
+    public override void DrawArenaBackground(int pcSlot, Actor pc)
+    {
+        if (Casters.Count == 0)
+            return;
+        // Paint the four diamond wings that will collapse — the donut between SmallBounds and
+        // NormalBounds, drawn as four quadrilaterals between adjacent diamond cardinals.
+        var c = Module.Center;
+        var nO = new WPos(c.X, c.Z - OuterCardinal);
+        var eO = new WPos(c.X + OuterCardinal, c.Z);
+        var sO = new WPos(c.X, c.Z + OuterCardinal);
+        var wO = new WPos(c.X - OuterCardinal, c.Z);
+        var nI = new WPos(c.X, c.Z - InnerCardinal);
+        var eI = new WPos(c.X + InnerCardinal, c.Z);
+        var sI = new WPos(c.X, c.Z + InnerCardinal);
+        var wI = new WPos(c.X - InnerCardinal, c.Z);
+        Arena.ZonePoly("doaa-ne", new[] { nO, eO, eI, nI }, ArenaColor.AOE);
+        Arena.ZonePoly("doaa-se", new[] { eO, sO, sI, eI }, ArenaColor.AOE);
+        Arena.ZonePoly("doaa-sw", new[] { sO, wO, wI, sI }, ArenaColor.AOE);
+        Arena.ZonePoly("doaa-nw", new[] { wO, nO, nI, wI }, ArenaColor.AOE);
+    }
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/DoubleEdgedSwords.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/DoubleEdgedSwords.cs
@@ -1,0 +1,3 @@
+namespace BossMod.Dawntrail.Trial.T03Everkeep;
+
+class DoubleEdgedSwords(BossModule module) : Components.StandardAOEs(module, AID.DoubleEdgedSwordsAOE, new AOEShapeRect(60, 60));

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/DutysEdge.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/DutysEdge.cs
@@ -1,0 +1,19 @@
+namespace BossMod.Dawntrail.Trial.T03Everkeep;
+
+class DutysEdge(BossModule module) : Components.GenericWildCharge(module, 4, AID.DutysEdgeAOE, 100)
+{
+    public override void OnEventCast(Actor caster, ActorCastEvent spell)
+    {
+        switch ((AID)spell.Action.ID)
+        {
+            case AID.DutysEdgeTarget:
+                Source = caster;
+                foreach (var (i, p) in Raid.WithSlot(true))
+                    PlayerRoles[i] = p.InstanceID == spell.MainTargetID ? PlayerRole.Target : PlayerRole.Share;
+                break;
+            case AID.DutysEdgeAOE:
+                ++NumCasts;
+                break;
+        }
+    }
+}

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/DutysEdge.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/DutysEdge.cs
@@ -1,18 +1,25 @@
 namespace BossMod.Dawntrail.Trial.T03Everkeep;
 
+// Duty's Edge fires 4 line-stack hits (37750) after a 4.6s visual (37748), ~2.1s apart. The target
+// icon (35567) is picked once per instance. Clear Source after the 4th hit so the rendering goes
+// away, and reset NumCasts on each new target so the mechanic works for the second instance.
 class DutysEdge(BossModule module) : Components.GenericWildCharge(module, 4, AID.DutysEdgeAOE, 100)
 {
+    private const int TotalHits = 4;
+
     public override void OnEventCast(Actor caster, ActorCastEvent spell)
     {
         switch ((AID)spell.Action.ID)
         {
             case AID.DutysEdgeTarget:
                 Source = caster;
+                NumCasts = 0;
                 foreach (var (i, p) in Raid.WithSlot(true))
                     PlayerRoles[i] = p.InstanceID == spell.MainTargetID ? PlayerRole.Target : PlayerRole.Share;
                 break;
             case AID.DutysEdgeAOE:
-                ++NumCasts;
+                if (++NumCasts >= TotalHits)
+                    Source = null;
                 break;
         }
     }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/FireIII.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/FireIII.cs
@@ -2,4 +2,14 @@ namespace BossMod.Dawntrail.Trial.T03Everkeep;
 
 // Spread on icon 376; 8 helpers instant-cast Fire III (37752) ~5s later. Forbidden radius is 7m
 // (2m wider than the 5m hit) so the AI doesn't clip a neighbor while routing.
-class FireIII(BossModule module) : Components.SpreadFromIcon(module, 376, AID.FireIII, 7f, 5.1f);
+class FireIII(BossModule module) : Components.SpreadFromIcon(module, 376, AID.FireIII, 7f, 5.1f)
+{
+    public override void AddAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
+    {
+        base.AddAIHints(slot, actor, assignment, hints);
+        // Duty Support NPCs always fan to the perimeter, so running onto the boss leaves the player
+        // alone in the center — only their own Fire III circle hits, no overlap from a neighbor's.
+        if (Spreads.Any(s => s.Target == actor))
+            hints.GoalZones.Add(hints.GoalSingleTarget(Module.PrimaryActor, 1f, 10f));
+    }
+}

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/FireIII.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/FireIII.cs
@@ -3,4 +3,7 @@ namespace BossMod.Dawntrail.Trial.T03Everkeep;
 // Spread on each party member: icon 376 appears on all 8 party members simultaneously (~5s
 // warning), then 8 helpers each instant-cast Fire III (37752) on their assigned target. Players
 // must spread out of each other's circles.
-class FireIII(BossModule module) : Components.SpreadFromIcon(module, 376, AID.FireIII, 5f, 5.1f);
+// Forbidden radius bumped 5→7m so the AI keeps a 2m buffer from every other party member during the
+// 5s spread window — bumping to 6 wasn't enough to stop the AI from clipping a neighbor's circle
+// while routing through them to its own destination.
+class FireIII(BossModule module) : Components.SpreadFromIcon(module, 376, AID.FireIII, 7f, 5.1f);

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/FireIII.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/FireIII.cs
@@ -1,0 +1,6 @@
+namespace BossMod.Dawntrail.Trial.T03Everkeep;
+
+// Spread on each party member: icon 376 appears on all 8 party members simultaneously (~5s
+// warning), then 8 helpers each instant-cast Fire III (37752) on their assigned target. Players
+// must spread out of each other's circles.
+class FireIII(BossModule module) : Components.SpreadFromIcon(module, 376, AID.FireIII, 5f, 5.1f);

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/FireIII.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/FireIII.cs
@@ -1,9 +1,5 @@
 namespace BossMod.Dawntrail.Trial.T03Everkeep;
 
-// Spread on each party member: icon 376 appears on all 8 party members simultaneously (~5s
-// warning), then 8 helpers each instant-cast Fire III (37752) on their assigned target. Players
-// must spread out of each other's circles.
-// Forbidden radius bumped 5→7m so the AI keeps a 2m buffer from every other party member during the
-// 5s spread window — bumping to 6 wasn't enough to stop the AI from clipping a neighbor's circle
-// while routing through them to its own destination.
+// Spread on icon 376; 8 helpers instant-cast Fire III (37752) ~5s later. Forbidden radius is 7m
+// (2m wider than the 5m hit) so the AI doesn't clip a neighbor while routing.
 class FireIII(BossModule module) : Components.SpreadFromIcon(module, 376, AID.FireIII, 7f, 5.1f);

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/ForgedTrack.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/ForgedTrack.cs
@@ -7,11 +7,14 @@ namespace BossMod.Dawntrail.Trial.T03Everkeep;
 //
 // The lane relationship between preview and damage has two patterns, keyed off the cast rotation:
 // - NE-SW diagonal (rot -45° or +135°): damage lane is offset ±5 perpendicular from preview lane,
-//   with the sign determined by Gateway's rotation (captured from its cast).
+//   with the sign determined by BladeWarp's direction: sign(dir.X + dir.Z), captured from its cast.
+//   Equivalent to sign(sin(θ + 45°)) — i.e. which side of the NE-SW axis BladeWarp points toward.
 // - NW-SE diagonal (rot +45° or -135°): damage lane coincides with preview lane (no offset).
 //
-// MapEffect indices 11-14 (state 0x00020001 vs 0x00200010) also encode which platforms are in
-// which pattern, but rotation is sufficient for the two cases we observe.
+// Earlier revision used Gateway's rotation sign; that held for two observed replays but broke on a
+// third (Gateway -6.6° but needed +offset). BladeWarp's direction is the actual physical cue for
+// which side of the diagonal the damage lane shifts toward. MapEffect indices 11-14 also encode
+// this via state bits, but BladeWarp is simpler to read and fires before the previews resolve.
 class ForgedTrack(BossModule module) : Components.GenericAOEs(module)
 {
     private readonly Dictionary<ulong, AOEInstance> _aoes = [];
@@ -21,12 +24,15 @@ class ForgedTrack(BossModule module) : Components.GenericAOEs(module)
     private const float ForwardOffset = 30f;
     private const float PerpOffsetMagnitude = 5f;
 
-    private float _gatewaySign; // +1 / -1, captured from Gateway cast; 0 if not yet seen.
+    private float _perpSign; // +1 / -1, captured from BladeWarp direction; 0 if not yet seen.
 
     public override void OnEventCast(Actor caster, ActorCastEvent spell)
     {
-        if ((AID)spell.Action.ID == AID.Gateway)
-            _gatewaySign = spell.Rotation.Rad >= 0 ? 1f : -1f;
+        if ((AID)spell.Action.ID == AID.BladeWarp)
+        {
+            var dir = spell.Rotation.ToDirection();
+            _perpSign = dir.X + dir.Z >= 0 ? 1f : -1f;
+        }
     }
 
     public override void OnCastStarted(Actor caster, ActorCastInfo spell)
@@ -37,8 +43,8 @@ class ForgedTrack(BossModule module) : Components.GenericAOEs(module)
         var dir = spell.Rotation.ToDirection();
         // NE-SW diagonal: dir.X and dir.Z have opposite signs; NW-SE: same signs.
         var isNESWDiagonal = dir.X * dir.Z < 0;
-        var perpOffset = isNESWDiagonal && _gatewaySign != 0
-            ? dir.OrthoL() * (PerpOffsetMagnitude * _gatewaySign)
+        var perpOffset = isNESWDiagonal && _perpSign != 0
+            ? dir.OrthoL() * (PerpOffsetMagnitude * _perpSign)
             : default;
         var origin = caster.Position + dir * ForwardOffset + perpOffset;
         _aoes[caster.InstanceID] = new AOEInstance(_shape, origin, spell.Rotation, Module.CastFinishAt(spell));

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/ForgedTrack.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/ForgedTrack.cs
@@ -19,11 +19,23 @@ namespace BossMod.Dawntrail.Trial.T03Everkeep;
 class ForgedTrack(BossModule module) : Components.GenericAOEs(module)
 {
     private readonly Dictionary<ulong, AOEInstance> _aoes = [];
-    public override IEnumerable<AOEInstance> ActiveAOEs(int slot, Actor actor) => _aoes.Values;
+
+    public override IEnumerable<AOEInstance> ActiveAOEs(int slot, Actor actor)
+    {
+        // Preview entries linger past activation until the actual 37730 fires — auto-cull stale ones.
+        var cutoff = WorldState.CurrentTime.AddSeconds(-0.5);
+        foreach (var id in _aoes.Where(kv => kv.Value.Activation < cutoff).Select(kv => kv.Key).ToList())
+            _aoes.Remove(id);
+        return _aoes.Values;
+    }
 
     private static readonly AOEShapeRect _shape = new(20f, 2.5f);
     private const float ForwardOffset = 30f;
     private const float PerpOffsetMagnitude = 5f;
+    // 37730 damage hits ~1.4s after the 11.6s preview cast resolves; previously we dropped the rect
+    // at preview finish, leaving a ~1.3s window with no rendered danger that the AI happily pathed
+    // through. Activation now points at the real lethal moment so the zone stays forbidden until then.
+    private const float DamageDelayAfterPreview = 1.4f;
 
     public override void OnCastStarted(Actor caster, ActorCastInfo spell)
     {
@@ -42,12 +54,6 @@ class ForgedTrack(BossModule module) : Components.GenericAOEs(module)
             perpOffset = orthoL * (PerpOffsetMagnitude * perpSign);
         }
         var origin = caster.Position + dir * ForwardOffset + perpOffset;
-        _aoes[caster.InstanceID] = new AOEInstance(_shape, origin, spell.Rotation, Module.CastFinishAt(spell));
-    }
-
-    public override void OnCastFinished(Actor caster, ActorCastInfo spell)
-    {
-        if ((AID)spell.Action.ID == AID.ForgedTrackPreview)
-            _aoes.Remove(caster.InstanceID);
+        _aoes[caster.InstanceID] = new AOEInstance(_shape, origin, spell.Rotation, Module.CastFinishAt(spell, DamageDelayAfterPreview));
     }
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/ForgedTrack.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/ForgedTrack.cs
@@ -5,16 +5,17 @@ namespace BossMod.Dawntrail.Trial.T03Everkeep;
 // the preview resolves, a separate inner Fang instant-casts 37730 for the actual damage along a
 // parallel lane.
 //
-// The lane relationship between preview and damage has two patterns, keyed off the cast rotation:
-// - NE-SW diagonal (rot -45° or +135°): damage lane is offset ±5 perpendicular from preview lane,
-//   with the sign determined by BladeWarp's direction: sign(dir.X + dir.Z), captured from its cast.
-//   Equivalent to sign(sin(θ + 45°)) — i.e. which side of the NE-SW axis BladeWarp points toward.
-// - NW-SE diagonal (rot +45° or -135°): damage lane coincides with preview lane (no offset).
+// The lane relationship between preview and damage:
+// - NW-SE diagonal (rot +45° / -135°): damage lane coincides with preview lane (no offset).
+// - NE-SW diagonal (rot -45° / +135°): damage lane is 5m perpendicular from preview lane. Offset
+//   direction is determined per-fang by which lane the outer fang stands on.
 //
-// Earlier revision used Gateway's rotation sign; that held for two observed replays but broke on a
-// third (Gateway -6.6° but needed +offset). BladeWarp's direction is the actual physical cue for
-// which side of the diagonal the damage lane shifts toward. MapEffect indices 11-14 also encode
-// this via state bits, but BladeWarp is simpler to read and fires before the previews resolve.
+// The four valid NE-SW lanes within the arena lie at perpendicular offsets of -7.5, -2.5, +2.5,
+// +7.5 from arena center (each 5m wide, the arena is 20m across the diamond). They form two
+// interleaved pairs: outer fangs spawn on one pair, inner damage fangs on the other. So the
+// offset sign alternates between adjacent lanes — `floor(perp / 5)` parity gives the right sign.
+// Verified across 5 observed waves; earlier BladeWarp- and Gateway-rotation rules each fit
+// some subset but failed on one wave where the outer pair flipped to the opposite lane set.
 class ForgedTrack(BossModule module) : Components.GenericAOEs(module)
 {
     private readonly Dictionary<ulong, AOEInstance> _aoes = [];
@@ -24,28 +25,22 @@ class ForgedTrack(BossModule module) : Components.GenericAOEs(module)
     private const float ForwardOffset = 30f;
     private const float PerpOffsetMagnitude = 5f;
 
-    private float _perpSign; // +1 / -1, captured from BladeWarp direction; 0 if not yet seen.
-
-    public override void OnEventCast(Actor caster, ActorCastEvent spell)
-    {
-        if ((AID)spell.Action.ID == AID.BladeWarp)
-        {
-            var dir = spell.Rotation.ToDirection();
-            _perpSign = dir.X + dir.Z >= 0 ? 1f : -1f;
-        }
-    }
-
     public override void OnCastStarted(Actor caster, ActorCastInfo spell)
     {
         if ((AID)spell.Action.ID != AID.ForgedTrackPreview)
             return;
 
         var dir = spell.Rotation.ToDirection();
-        // NE-SW diagonal: dir.X and dir.Z have opposite signs; NW-SE: same signs.
-        var isNESWDiagonal = dir.X * dir.Z < 0;
-        var perpOffset = isNESWDiagonal && _perpSign != 0
-            ? dir.OrthoL() * (PerpOffsetMagnitude * _perpSign)
-            : default;
+        // NE-SW diagonal: dir.X and dir.Z have opposite signs; NW-SE: same signs (no offset).
+        var perpOffset = default(WDir);
+        if (dir.X * dir.Z < 0)
+        {
+            var orthoL = dir.OrthoL();
+            var perp = (caster.Position - Module.Center).Dot(orthoL);
+            var laneIndex = (int)MathF.Floor(perp / PerpOffsetMagnitude);
+            var perpSign = laneIndex % 2 == 0 ? 1f : -1f;
+            perpOffset = orthoL * (PerpOffsetMagnitude * perpSign);
+        }
         var origin = caster.Position + dir * ForwardOffset + perpOffset;
         _aoes[caster.InstanceID] = new AOEInstance(_shape, origin, spell.Rotation, Module.CastFinishAt(spell));
     }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/ForgedTrack.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/ForgedTrack.cs
@@ -14,8 +14,6 @@ namespace BossMod.Dawntrail.Trial.T03Everkeep;
 // +7.5 from arena center (each 5m wide, the arena is 20m across the diamond). They form two
 // interleaved pairs: outer fangs spawn on one pair, inner damage fangs on the other. So the
 // offset sign alternates between adjacent lanes — `floor(perp / 5)` parity gives the right sign.
-// Verified across 5 observed waves; earlier BladeWarp- and Gateway-rotation rules each fit
-// some subset but failed on one wave where the outer pair flipped to the opposite lane set.
 class ForgedTrack(BossModule module) : Components.GenericAOEs(module)
 {
     private readonly Dictionary<ulong, AOEInstance> _aoes = [];
@@ -32,9 +30,7 @@ class ForgedTrack(BossModule module) : Components.GenericAOEs(module)
     private static readonly AOEShapeRect _shape = new(20f, 2.5f);
     private const float ForwardOffset = 30f;
     private const float PerpOffsetMagnitude = 5f;
-    // 37730 damage hits ~1.4s after the 11.6s preview cast resolves; previously we dropped the rect
-    // at preview finish, leaving a ~1.3s window with no rendered danger that the AI happily pathed
-    // through. Activation now points at the real lethal moment so the zone stays forbidden until then.
+    // Activation = predicted damage moment so the rect stays forbidden through the preview→damage gap.
     private const float DamageDelayAfterPreview = 1.4f;
 
     public override void OnCastStarted(Actor caster, ActorCastInfo spell)

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/ForgedTrack.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/ForgedTrack.cs
@@ -1,0 +1,52 @@
+namespace BossMod.Dawntrail.Trial.T03Everkeep;
+
+// Forged Track: 4 intercardinal platforms spawn sword Fangs that telegraph narrow lane charges
+// across the small arena. Each preview (37729, 11.6s, 0-hit) has an outer-platform caster; after
+// the preview resolves, a separate inner Fang instant-casts 37730 for the actual damage along a
+// parallel lane.
+//
+// The lane relationship between preview and damage has two patterns, keyed off the cast rotation:
+// - NE-SW diagonal (rot -45° or +135°): damage lane is offset ±5 perpendicular from preview lane,
+//   with the sign determined by Gateway's rotation (captured from its cast).
+// - NW-SE diagonal (rot +45° or -135°): damage lane coincides with preview lane (no offset).
+//
+// MapEffect indices 11-14 (state 0x00020001 vs 0x00200010) also encode which platforms are in
+// which pattern, but rotation is sufficient for the two cases we observe.
+class ForgedTrack(BossModule module) : Components.GenericAOEs(module)
+{
+    private readonly Dictionary<ulong, AOEInstance> _aoes = [];
+    public override IEnumerable<AOEInstance> ActiveAOEs(int slot, Actor actor) => _aoes.Values;
+
+    private static readonly AOEShapeRect _shape = new(20f, 2.5f);
+    private const float ForwardOffset = 30f;
+    private const float PerpOffsetMagnitude = 5f;
+
+    private float _gatewaySign; // +1 / -1, captured from Gateway cast; 0 if not yet seen.
+
+    public override void OnEventCast(Actor caster, ActorCastEvent spell)
+    {
+        if ((AID)spell.Action.ID == AID.Gateway)
+            _gatewaySign = spell.Rotation.Rad >= 0 ? 1f : -1f;
+    }
+
+    public override void OnCastStarted(Actor caster, ActorCastInfo spell)
+    {
+        if ((AID)spell.Action.ID != AID.ForgedTrackPreview)
+            return;
+
+        var dir = spell.Rotation.ToDirection();
+        // NE-SW diagonal: dir.X and dir.Z have opposite signs; NW-SE: same signs.
+        var isNESWDiagonal = dir.X * dir.Z < 0;
+        var perpOffset = isNESWDiagonal && _gatewaySign != 0
+            ? dir.OrthoL() * (PerpOffsetMagnitude * _gatewaySign)
+            : default;
+        var origin = caster.Position + dir * ForwardOffset + perpOffset;
+        _aoes[caster.InstanceID] = new AOEInstance(_shape, origin, spell.Rotation, Module.CastFinishAt(spell));
+    }
+
+    public override void OnCastFinished(Actor caster, ActorCastInfo spell)
+    {
+        if ((AID)spell.Action.ID == AID.ForgedTrackPreview)
+            _aoes.Remove(caster.InstanceID);
+    }
+}

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/HalfCircuit.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/HalfCircuit.cs
@@ -1,0 +1,5 @@
+namespace BossMod.Dawntrail.Trial.T03Everkeep;
+
+class HalfCircuitRect(BossModule module) : Components.StandardAOEs(module, AID.HalfCircuitRect, new AOEShapeRect(60, 60));
+class HalfCircuitDonut(BossModule module) : Components.StandardAOEs(module, AID.HalfCircuitDonut, new AOEShapeDonut(10, 30));
+class HalfCircuitCircle(BossModule module) : Components.StandardAOEs(module, AID.HalfCircuitCircle, new AOEShapeCircle(10));

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/HalfFull.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/HalfFull.cs
@@ -1,0 +1,3 @@
+namespace BossMod.Dawntrail.Trial.T03Everkeep;
+
+class HalfFull(BossModule module) : Components.StandardAOEs(module, AID.HalfFullAOE, new AOEShapeRect(60, 60));

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/PatricidalPique.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/PatricidalPique.cs
@@ -1,0 +1,3 @@
+namespace BossMod.Dawntrail.Trial.T03Everkeep;
+
+class PatricidalPique(BossModule module) : Components.SingleTargetCast(module, AID.PatricidalPique);

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/SmitingCircuit.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/SmitingCircuit.cs
@@ -1,0 +1,4 @@
+namespace BossMod.Dawntrail.Trial.T03Everkeep;
+
+class SmitingCircuitDonut(BossModule module) : Components.StandardAOEs(module, AID.SmitingCircuitDonutAOE, new AOEShapeDonut(10, 30));
+class SmitingCircuitCircle(BossModule module) : Components.StandardAOEs(module, AID.SmitingCircuitCircleAOE, new AOEShapeCircle(10));

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/SoulOverflow.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/SoulOverflow.cs
@@ -1,0 +1,4 @@
+namespace BossMod.Dawntrail.Trial.T03Everkeep;
+
+class SoulOverflow(BossModule module) : Components.RaidwideCast(module, AID.SoulOverflow);
+class SoulOverflowEnrage(BossModule module) : Components.RaidwideCast(module, AID.SoulOverflowEnrage);

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03Everkeep.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03Everkeep.cs
@@ -1,6 +1,6 @@
 namespace BossMod.Dawntrail.Trial.T03Everkeep;
 
-[ModuleInfo(BossModuleInfo.Maturity.WIP, Contributors = "Gabriel Deleon", PrimaryActorOID = (uint)OID.Boss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 995, NameID = 12881)]
+[ModuleInfo(BossModuleInfo.Maturity.Contributed, Contributors = "Gabriel Deleon", PrimaryActorOID = (uint)OID.Boss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 995, NameID = 12881)]
 public class T03Everkeep(WorldState ws, Actor primary) : BossModule(ws, primary, new(100, 100), new ArenaBoundsCircle(20))
 {
     private Actor? _bossP2;

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03Everkeep.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03Everkeep.cs
@@ -1,0 +1,17 @@
+namespace BossMod.Dawntrail.Trial.T03Everkeep;
+
+class SoulOverflow(BossModule module) : Components.RaidwideCast(module, AID.SoulOverflow);
+class SoulOverflowEnrage(BossModule module) : Components.RaidwideCast(module, AID.SoulOverflowEnrage);
+
+class T03EverkeepStates : StateMachineBuilder
+{
+    public T03EverkeepStates(BossModule module) : base(module)
+    {
+        TrivialPhase()
+            .ActivateOnEnter<SoulOverflow>()
+            .ActivateOnEnter<SoulOverflowEnrage>();
+    }
+}
+
+[ModuleInfo(BossModuleInfo.Maturity.WIP, Contributors = "Gabriel Deleon", GroupType = BossModuleInfo.GroupType.CFC, GroupID = 995, NameID = 12881)]
+public class T03Everkeep(WorldState ws, Actor primary) : BossModule(ws, primary, new(100, 100), new ArenaBoundsCircle(20));

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03Everkeep.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03Everkeep.cs
@@ -6,18 +6,16 @@ public class T03Everkeep(WorldState ws, Actor primary) : BossModule(ws, primary,
     public static readonly ArenaBoundsRect NormalBounds = new(20, 20, 45.Degrees());
     public static readonly ArenaBoundsRect SmallBounds = new(10, 10, 45.Degrees(), 20);
 
-    private Actor? _bossP2;
     public Actor? BossP1() => PrimaryActor;
-    public Actor? BossP2() => _bossP2;
 
-    protected override void UpdateModule()
-    {
-        _bossP2 ??= StateMachine.ActivePhaseIndex > 0 ? Enemies(OID.BossP2).FirstOrDefault() : null;
-    }
+    // The P2 boss actor is re-spawned mid-fight (the old instance is destroyed and a new one with
+    // the same OID is spawned ~0.4s later during the big arena transition), so we query dynamically
+    // and skip destroyed instances instead of caching the first one we see.
+    public Actor? BossP2() => Enemies(OID.BossP2).FirstOrDefault(a => !a.IsDestroyed);
 
     protected override void DrawEnemies(int pcSlot, Actor pc)
     {
         Arena.Actor(PrimaryActor, ArenaColor.Enemy);
-        Arena.Actor(_bossP2, ArenaColor.Enemy);
+        Arena.Actor(BossP2(), ArenaColor.Enemy);
     }
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03Everkeep.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03Everkeep.cs
@@ -2,6 +2,7 @@ namespace BossMod.Dawntrail.Trial.T03Everkeep;
 
 class SoulOverflow(BossModule module) : Components.RaidwideCast(module, AID.SoulOverflow);
 class SoulOverflowEnrage(BossModule module) : Components.RaidwideCast(module, AID.SoulOverflowEnrage);
+class PatricidalPique(BossModule module) : Components.SingleTargetCast(module, AID.PatricidalPique);
 
 class T03EverkeepStates : StateMachineBuilder
 {
@@ -9,7 +10,8 @@ class T03EverkeepStates : StateMachineBuilder
     {
         TrivialPhase()
             .ActivateOnEnter<SoulOverflow>()
-            .ActivateOnEnter<SoulOverflowEnrage>();
+            .ActivateOnEnter<SoulOverflowEnrage>()
+            .ActivateOnEnter<PatricidalPique>();
     }
 }
 

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03Everkeep.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03Everkeep.cs
@@ -1,27 +1,20 @@
 namespace BossMod.Dawntrail.Trial.T03Everkeep;
 
-class SoulOverflow(BossModule module) : Components.RaidwideCast(module, AID.SoulOverflow);
-class SoulOverflowEnrage(BossModule module) : Components.RaidwideCast(module, AID.SoulOverflowEnrage);
-class PatricidalPique(BossModule module) : Components.SingleTargetCast(module, AID.PatricidalPique);
-class CalamitysEdge(BossModule module) : Components.RaidwideCast(module, AID.CalamitysEdge);
-class Burst(BossModule module) : Components.StandardAOEs(module, AID.Burst, new AOEShapeCircle(8));
-class VorpalTrail(BossModule module) : Components.StandardAOEs(module, AID.VorpalTrailAOE, new AOEShapeCircle(6));
-class DoubleEdgedSwords(BossModule module) : Components.StandardAOEs(module, AID.DoubleEdgedSwordsAOE, new AOEShapeRect(60, 60));
-
-class T03EverkeepStates : StateMachineBuilder
+[ModuleInfo(BossModuleInfo.Maturity.WIP, Contributors = "Gabriel Deleon", PrimaryActorOID = (uint)OID.Boss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 995, NameID = 12881)]
+public class T03Everkeep(WorldState ws, Actor primary) : BossModule(ws, primary, new(100, 100), new ArenaBoundsCircle(20))
 {
-    public T03EverkeepStates(BossModule module) : base(module)
+    private Actor? _bossP2;
+    public Actor? BossP1() => PrimaryActor;
+    public Actor? BossP2() => _bossP2;
+
+    protected override void UpdateModule()
     {
-        TrivialPhase()
-            .ActivateOnEnter<SoulOverflow>()
-            .ActivateOnEnter<SoulOverflowEnrage>()
-            .ActivateOnEnter<PatricidalPique>()
-            .ActivateOnEnter<CalamitysEdge>()
-            .ActivateOnEnter<Burst>()
-            .ActivateOnEnter<VorpalTrail>()
-            .ActivateOnEnter<DoubleEdgedSwords>();
+        _bossP2 ??= StateMachine.ActivePhaseIndex > 0 ? Enemies(OID.BossP2).FirstOrDefault() : null;
+    }
+
+    protected override void DrawEnemies(int pcSlot, Actor pc)
+    {
+        Arena.Actor(PrimaryActor, ArenaColor.Enemy);
+        Arena.Actor(_bossP2, ArenaColor.Enemy);
     }
 }
-
-[ModuleInfo(BossModuleInfo.Maturity.WIP, Contributors = "Gabriel Deleon", GroupType = BossModuleInfo.GroupType.CFC, GroupID = 995, NameID = 12881)]
-public class T03Everkeep(WorldState ws, Actor primary) : BossModule(ws, primary, new(100, 100), new ArenaBoundsCircle(20));

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03Everkeep.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03Everkeep.cs
@@ -3,6 +3,7 @@ namespace BossMod.Dawntrail.Trial.T03Everkeep;
 class SoulOverflow(BossModule module) : Components.RaidwideCast(module, AID.SoulOverflow);
 class SoulOverflowEnrage(BossModule module) : Components.RaidwideCast(module, AID.SoulOverflowEnrage);
 class PatricidalPique(BossModule module) : Components.SingleTargetCast(module, AID.PatricidalPique);
+class CalamitysEdge(BossModule module) : Components.RaidwideCast(module, AID.CalamitysEdge);
 
 class T03EverkeepStates : StateMachineBuilder
 {
@@ -11,7 +12,8 @@ class T03EverkeepStates : StateMachineBuilder
         TrivialPhase()
             .ActivateOnEnter<SoulOverflow>()
             .ActivateOnEnter<SoulOverflowEnrage>()
-            .ActivateOnEnter<PatricidalPique>();
+            .ActivateOnEnter<PatricidalPique>()
+            .ActivateOnEnter<CalamitysEdge>();
     }
 }
 

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03Everkeep.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03Everkeep.cs
@@ -5,6 +5,7 @@ class SoulOverflowEnrage(BossModule module) : Components.RaidwideCast(module, AI
 class PatricidalPique(BossModule module) : Components.SingleTargetCast(module, AID.PatricidalPique);
 class CalamitysEdge(BossModule module) : Components.RaidwideCast(module, AID.CalamitysEdge);
 class Burst(BossModule module) : Components.StandardAOEs(module, AID.Burst, new AOEShapeCircle(8));
+class VorpalTrail(BossModule module) : Components.StandardAOEs(module, AID.VorpalTrailAOE, new AOEShapeCircle(6));
 
 class T03EverkeepStates : StateMachineBuilder
 {
@@ -15,7 +16,8 @@ class T03EverkeepStates : StateMachineBuilder
             .ActivateOnEnter<SoulOverflowEnrage>()
             .ActivateOnEnter<PatricidalPique>()
             .ActivateOnEnter<CalamitysEdge>()
-            .ActivateOnEnter<Burst>();
+            .ActivateOnEnter<Burst>()
+            .ActivateOnEnter<VorpalTrail>();
     }
 }
 

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03Everkeep.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03Everkeep.cs
@@ -6,6 +6,7 @@ class PatricidalPique(BossModule module) : Components.SingleTargetCast(module, A
 class CalamitysEdge(BossModule module) : Components.RaidwideCast(module, AID.CalamitysEdge);
 class Burst(BossModule module) : Components.StandardAOEs(module, AID.Burst, new AOEShapeCircle(8));
 class VorpalTrail(BossModule module) : Components.StandardAOEs(module, AID.VorpalTrailAOE, new AOEShapeCircle(6));
+class DoubleEdgedSwords(BossModule module) : Components.StandardAOEs(module, AID.DoubleEdgedSwordsAOE, new AOEShapeRect(60, 60));
 
 class T03EverkeepStates : StateMachineBuilder
 {
@@ -17,7 +18,8 @@ class T03EverkeepStates : StateMachineBuilder
             .ActivateOnEnter<PatricidalPique>()
             .ActivateOnEnter<CalamitysEdge>()
             .ActivateOnEnter<Burst>()
-            .ActivateOnEnter<VorpalTrail>();
+            .ActivateOnEnter<VorpalTrail>()
+            .ActivateOnEnter<DoubleEdgedSwords>();
     }
 }
 

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03Everkeep.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03Everkeep.cs
@@ -1,8 +1,11 @@
 namespace BossMod.Dawntrail.Trial.T03Everkeep;
 
 [ModuleInfo(BossModuleInfo.Maturity.Contributed, Contributors = "Gabriel Deleon", PrimaryActorOID = (uint)OID.Boss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 995, NameID = 12881)]
-public class T03Everkeep(WorldState ws, Actor primary) : BossModule(ws, primary, new(100, 100), new ArenaBoundsRect(20, 20, 45.Degrees()))
+public class T03Everkeep(WorldState ws, Actor primary) : BossModule(ws, primary, new(100, 100), NormalBounds)
 {
+    public static readonly ArenaBoundsRect NormalBounds = new(20, 20, 45.Degrees());
+    public static readonly ArenaBoundsRect SmallBounds = new(10, 10, 45.Degrees(), 20);
+
     private Actor? _bossP2;
     public Actor? BossP1() => PrimaryActor;
     public Actor? BossP2() => _bossP2;

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03Everkeep.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03Everkeep.cs
@@ -1,7 +1,7 @@
 namespace BossMod.Dawntrail.Trial.T03Everkeep;
 
 [ModuleInfo(BossModuleInfo.Maturity.Contributed, Contributors = "Gabriel Deleon", PrimaryActorOID = (uint)OID.Boss, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 995, NameID = 12881)]
-public class T03Everkeep(WorldState ws, Actor primary) : BossModule(ws, primary, new(100, 100), new ArenaBoundsCircle(20))
+public class T03Everkeep(WorldState ws, Actor primary) : BossModule(ws, primary, new(100, 100), new ArenaBoundsRect(20, 20, 45.Degrees()))
 {
     private Actor? _bossP2;
     public Actor? BossP1() => PrimaryActor;

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03Everkeep.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03Everkeep.cs
@@ -4,6 +4,7 @@ class SoulOverflow(BossModule module) : Components.RaidwideCast(module, AID.Soul
 class SoulOverflowEnrage(BossModule module) : Components.RaidwideCast(module, AID.SoulOverflowEnrage);
 class PatricidalPique(BossModule module) : Components.SingleTargetCast(module, AID.PatricidalPique);
 class CalamitysEdge(BossModule module) : Components.RaidwideCast(module, AID.CalamitysEdge);
+class Burst(BossModule module) : Components.StandardAOEs(module, AID.Burst, new AOEShapeCircle(8));
 
 class T03EverkeepStates : StateMachineBuilder
 {
@@ -13,7 +14,8 @@ class T03EverkeepStates : StateMachineBuilder
             .ActivateOnEnter<SoulOverflow>()
             .ActivateOnEnter<SoulOverflowEnrage>()
             .ActivateOnEnter<PatricidalPique>()
-            .ActivateOnEnter<CalamitysEdge>();
+            .ActivateOnEnter<CalamitysEdge>()
+            .ActivateOnEnter<Burst>();
     }
 }
 

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
@@ -46,4 +46,8 @@ public enum AID : uint
 
     // Gateway / Blade Warp / Forged Track chain: boss creates portals -> places swords -> charges along them
     Gateway = 37723, // BossP2->self, 3.7s cast, visual (spawns portals/gateways, no player damage)
+    BladeWarp = 37726, // BossP2->self, 3.7s cast, visual (places swords, no player damage)
+    ForgedTrackVisual = 37727, // BossP2->self, 3.7s cast, visual (no player damage)
+    ForgedTrackPreview = 37729, // Helper->self, 11.6s cast, outer-arena sword-path telegraph (0 hits in CST!) - TODO: component
+    ForgedTrackAOE = 37730, // Fang (OID 0x42AA)->self, instant cast, sword-charge damage along path - TODO: component paired with preview
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
@@ -56,4 +56,8 @@ public enum AID : uint
     DutysEdgeVisual = 37748, // BossP2->self, 4.6s cast, visual (mechanic start)
     DutysEdgeRepeat = 37749, // BossP2->self, 2.1s cast, visual (fires 4x repeated with 37750)
     DutysEdgeAOE = 37750, // Helper->self, instant, range 100 width 8 rect line-stack (distinct from Ex2 AID 38055)
+
+    // Half Full: half-arena cleave (single variant observed in replay, west-facing)
+    HalfFullVisual = 37737, // BossP2->self, 5.7s cast, visual only (self-status, no player damage)
+    HalfFullAOE = 37738, // Helper->self, 6.0s cast, range 60 width 120 rect, actual cleave
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
@@ -19,4 +19,5 @@ public enum AID : uint
     // === Phase 1 ===
     SoulOverflow = 37707, // Boss->self, 4.7s cast, raidwide
     SoulOverflowEnrage = 37744, // Boss->self, 6.7s cast, raidwide + inflicts bleed DoT (phase transition / enrage)
+    PatricidalPique = 37715, // Boss->MT, 4.7s cast, single-target tankbuster
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
@@ -11,6 +11,7 @@ public enum OID : uint
     ShadowOfTuralSpear = 0x42AD, // spawn during fight, later wave
     // 0x42B0..0x42B3 observed in replay; purpose TBD (phase 2 adds or fang variants)
     FangSmall = 0x42B6, // R1.000, spawn during fight, Phase 2 Fang that telegraphs Chasm of Vollok preview
+    HalfCircuitHelper = 0x42B9, // R10.050, spawn during fight, casts Smiting Circuit visuals (shared OID with Ex2)
 }
 
 public enum AID : uint
@@ -71,4 +72,11 @@ public enum AID : uint
     HalfCircuitRect = 37741, // Helper->self, 7.0s cast, range 60 width 120 rect (always fires, rotation varies)
     HalfCircuitDonut = 37742, // Helper->self, 6.7s cast, range 10-30 donut (center safe)
     HalfCircuitCircle = 37743, // Helper->self, 6.7s cast, range 10 circle (outer safe)
+
+    // Smiting Circuit: precursor mechanic to Half Circuit (fires before it), donut OR circle center variant. Distinct from Ex2 where these are visuals.
+    SmitingCircuitVisual = 37731, // BossP2->self, 6.7s cast, visual only
+    SmitingCircuitHelperDonut = 37732, // HalfCircuitHelper->self, visual pairing for donut variant (shared AID with Ex2)
+    SmitingCircuitHelperCircle = 37733, // HalfCircuitHelper->self, visual pairing for circle variant (shared AID with Ex2)
+    SmitingCircuitDonutAOE = 37734, // Helper->self, 6.7s cast, range 10-30 donut (inside safe)
+    SmitingCircuitCircleAOE = 37735, // Helper->self, 6.7s cast, range 10 circle (outside safe)
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
@@ -35,4 +35,5 @@ public enum AID : uint
 
     // === Phase 2 (BossP2 / Zoraal Ja Vollok form, OID 0x42B4) ===
     DawnOfAnAge = 37716, // BossP2->self, 6.7s cast, raidwide + arena transition (distinct from Ex2 AID 37783)
+    Actualize = 37718, // BossP2->self, 4.7s cast, raidwide (distinct from Ex2 AID 37784 at 5.0s)
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
@@ -67,6 +67,9 @@ public enum AID : uint
     BitterReapingVisual = 37753, // BossP2->self, 4.1s cast, visual only
     BitterReapingAOE = 37754, // Helper->player, 4.7s cast, single-target tankbuster (2 simultaneous casts targeting MT + Wuk/OT)
 
+    // Fire III: spread — icon 376 appears on each party member, ~5s later 8 helpers instant-cast a per-target circle on each
+    FireIII = 37752, // Helper->player, instant cast, single-target spread circle (one per party member)
+
     // Half Circuit: 3 simultaneous AoEs — always a side-cleave rect + (circle OR donut) center shape
     HalfCircuitVisualCircle = 37739, // BossP2->self, 6.7s cast, visual paired with circle variant (shared AID with Ex2)
     HalfCircuitVisualDonut = 37740, // BossP2->self, 6.7s cast, visual paired with donut variant (shared AID with Ex2)

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
@@ -32,4 +32,7 @@ public enum AID : uint
     // Double-edged Swords: two half-arena cleaves in sequence (forward-then-backward)
     DoubleEdgedSwordsVisual = 37713, // Boss->self, 4.1s cast, single-target visual (mechanic start)
     DoubleEdgedSwordsAOE = 37714, // Helper->self, 4.7s cast, range 60 width 120 rect (half-arena cleave; 2 casters with opposite rotations fire ~2.3s apart)
+
+    // === Phase 2 (BossP2 / Zoraal Ja Vollok form, OID 0x42B4) ===
+    DawnOfAnAge = 37716, // BossP2->self, 6.7s cast, raidwide + arena transition (distinct from Ex2 AID 37783)
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
@@ -50,4 +50,10 @@ public enum AID : uint
     ForgedTrackVisual = 37727, // BossP2->self, 3.7s cast, visual (no player damage)
     ForgedTrackPreview = 37729, // Helper->self, 11.6s cast, outer-arena sword-path telegraph (0 hits in CST!) - TODO: component
     ForgedTrackAOE = 37730, // Fang (OID 0x42AA)->self, instant cast, sword-charge damage along path - TODO: component paired with preview
+
+    // Duty's Edge: target selection (35567) -> boss visual (37748) -> 4 repeated line-stack hits (37749 visual + 37750 damage)
+    DutysEdgeTarget = 35567, // Helper->player, instant, target marker (shared AID with Ex2)
+    DutysEdgeVisual = 37748, // BossP2->self, 4.6s cast, visual (mechanic start)
+    DutysEdgeRepeat = 37749, // BossP2->self, 2.1s cast, visual (fires 4x repeated with 37750)
+    DutysEdgeAOE = 37750, // Helper->self, instant, range 100 width 8 rect line-stack (distinct from Ex2 AID 38055)
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
@@ -43,4 +43,7 @@ public enum AID : uint
     ChasmOfVollokPreview = 37720, // FangSmall->self, 6.7s cast, 5x5 rect telegraph, no player damage
     Sync = 37721, // BossP2->self, 4.7s cast, visual (activates AOEs), no player damage
     ChasmOfVollokAOE = 37722, // Helper->self, 0.7s cast, range 5 width 5 rect (final damage; positions match preview in Normal - no mirroring)
+
+    // Gateway / Blade Warp / Forged Track chain: boss creates portals -> places swords -> charges along them
+    Gateway = 37723, // BossP2->self, 3.7s cast, visual (spawns portals/gateways, no player damage)
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
@@ -60,4 +60,8 @@ public enum AID : uint
     // Half Full: half-arena cleave (single variant observed in replay, west-facing)
     HalfFullVisual = 37737, // BossP2->self, 5.7s cast, visual only (self-status, no player damage)
     HalfFullAOE = 37738, // Helper->self, 6.0s cast, range 60 width 120 rect, actual cleave
+
+    // Bitter Reaping: two simultaneous single-target tankbusters on MT + OT (distinct from Ex2 Bitter Whirlwind which is 3-hit tank-swap)
+    BitterReapingVisual = 37753, // BossP2->self, 4.1s cast, visual only
+    BitterReapingAOE = 37754, // Helper->player, 4.7s cast, single-target tankbuster (2 simultaneous casts targeting MT + Wuk/OT)
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
@@ -64,4 +64,11 @@ public enum AID : uint
     // Bitter Reaping: two simultaneous single-target tankbusters on MT + OT (distinct from Ex2 Bitter Whirlwind which is 3-hit tank-swap)
     BitterReapingVisual = 37753, // BossP2->self, 4.1s cast, visual only
     BitterReapingAOE = 37754, // Helper->player, 4.7s cast, single-target tankbuster (2 simultaneous casts targeting MT + Wuk/OT)
+
+    // Half Circuit: 3 simultaneous AoEs — always a side-cleave rect + (circle OR donut) center shape
+    HalfCircuitVisualCircle = 37739, // BossP2->self, 6.7s cast, visual paired with circle variant (shared AID with Ex2)
+    HalfCircuitVisualDonut = 37740, // BossP2->self, 6.7s cast, visual paired with donut variant (shared AID with Ex2)
+    HalfCircuitRect = 37741, // Helper->self, 7.0s cast, range 60 width 120 rect (always fires, rotation varies)
+    HalfCircuitDonut = 37742, // Helper->self, 6.7s cast, range 10-30 donut (center safe)
+    HalfCircuitCircle = 37743, // Helper->self, 6.7s cast, range 10 circle (outer safe)
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
@@ -10,6 +10,7 @@ public enum OID : uint
     ShadowOfTuralSword = 0x42AC, // spawn during fight, later wave
     ShadowOfTuralSpear = 0x42AD, // spawn during fight, later wave
     // 0x42B0..0x42B3 observed in replay; purpose TBD (phase 2 adds or fang variants)
+    FangSmall = 0x42B6, // R1.000, spawn during fight, Phase 2 Fang that telegraphs Chasm of Vollok preview
 }
 
 public enum AID : uint
@@ -36,4 +37,10 @@ public enum AID : uint
     // === Phase 2 (BossP2 / Zoraal Ja Vollok form, OID 0x42B4) ===
     DawnOfAnAge = 37716, // BossP2->self, 6.7s cast, raidwide + arena transition (distinct from Ex2 AID 37783)
     Actualize = 37718, // BossP2->self, 4.7s cast, raidwide (distinct from Ex2 AID 37784 at 5.0s)
+
+    // Chasm of Vollok chain: Vollok spawns Fangs -> preview telegraphs at fang positions -> Sync -> helper AOEs resolve at same positions
+    Vollok = 37719, // BossP2->self, 3.7s cast, visual (spawns FangSmall actors in a grid, no player damage)
+    ChasmOfVollokPreview = 37720, // FangSmall->self, 6.7s cast, 5x5 rect telegraph, no player damage
+    Sync = 37721, // BossP2->self, 4.7s cast, visual (activates AOEs), no player damage
+    ChasmOfVollokAOE = 37722, // Helper->self, 0.7s cast, range 5 width 5 rect (final damage; positions match preview in Normal - no mirroring)
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
@@ -20,4 +20,5 @@ public enum AID : uint
     SoulOverflow = 37707, // Boss->self, 4.7s cast, raidwide
     SoulOverflowEnrage = 37744, // Boss->self, 6.7s cast, raidwide + inflicts bleed DoT (phase transition / enrage)
     PatricidalPique = 37715, // Boss->MT, 4.7s cast, single-target tankbuster
+    CalamitysEdge = 37708, // Boss->self, 4.7s cast, raidwide
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
@@ -21,4 +21,5 @@ public enum AID : uint
     SoulOverflowEnrage = 37744, // Boss->self, 6.7s cast, raidwide + inflicts bleed DoT (phase transition / enrage)
     PatricidalPique = 37715, // Boss->MT, 4.7s cast, single-target tankbuster
     CalamitysEdge = 37708, // Boss->self, 4.7s cast, raidwide
+    Burst = 37709, // ShadowOfTural->self, 7.7s cast, range 8 circle (8 adds spawn in a pattern, each casts)
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
@@ -1,0 +1,22 @@
+namespace BossMod.Dawntrail.Trial.T03Everkeep;
+
+public enum OID : uint
+{
+    Boss = 0x42A9, // R2.500, phase 1 (human form)
+    BossP2 = 0x42B4, // phase 2 (Vollok form) - spawns mid-fight
+    Helper = 0x233C,
+    ShadowOfTural = 0x43A8, // R0.500, initial add waves (phase 1)
+    Fang = 0x42AA, // spawn during fight
+    ShadowOfTuralSword = 0x42AC, // spawn during fight, later wave
+    ShadowOfTuralSpear = 0x42AD, // spawn during fight, later wave
+    // 0x42B0..0x42B3 observed in replay; purpose TBD (phase 2 adds or fang variants)
+}
+
+public enum AID : uint
+{
+    AutoAttack = 6497, // Boss->player, no cast, single-target
+
+    // === Phase 1 ===
+    SoulOverflow = 37707, // Boss->self, 4.7s cast, raidwide
+    SoulOverflowEnrage = 37744, // Boss->self, 6.7s cast, raidwide + inflicts bleed DoT (phase transition / enrage)
+}

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
@@ -22,4 +22,10 @@ public enum AID : uint
     PatricidalPique = 37715, // Boss->MT, 4.7s cast, single-target tankbuster
     CalamitysEdge = 37708, // Boss->self, 4.7s cast, raidwide
     Burst = 37709, // ShadowOfTural->self, 7.7s cast, range 8 circle (8 adds spawn in a pattern, each casts)
+
+    // Vorpal Trail: Fang adds charge across arena leaving a trail of circles
+    VorpalTrailVisual = 37710, // Boss->self, 3.4s cast, single-target visual (mechanic start)
+    VorpalTrailSprint = 37711, // Fang->self, 0.7s cast, internal sprint tick (no player damage)
+    VorpalTrailAOE = 37712, // Helper->location, 2.0s cast, range 6 circle (trail puddle)
+    VorpalTrailTelegraph = 38184, // Helper->location, 4.0s cast, 0-hit path telegraph
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
@@ -28,4 +28,8 @@ public enum AID : uint
     VorpalTrailSprint = 37711, // Fang->self, 0.7s cast, internal sprint tick (no player damage)
     VorpalTrailAOE = 37712, // Helper->location, 2.0s cast, range 6 circle (trail puddle)
     VorpalTrailTelegraph = 38184, // Helper->location, 4.0s cast, 0-hit path telegraph
+
+    // Double-edged Swords: two half-arena cleaves in sequence (forward-then-backward)
+    DoubleEdgedSwordsVisual = 37713, // Boss->self, 4.1s cast, single-target visual (mechanic start)
+    DoubleEdgedSwordsAOE = 37714, // Helper->self, 4.7s cast, range 60 width 120 rect (half-arena cleave; 2 casters with opposite rotations fire ~2.3s apart)
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepEnums.cs
@@ -27,9 +27,10 @@ public enum AID : uint
 
     // Vorpal Trail: Fang adds charge across arena leaving a trail of circles
     VorpalTrailVisual = 37710, // Boss->self, 3.4s cast, single-target visual (mechanic start)
-    VorpalTrailSprint = 37711, // Fang->self, 0.7s cast, internal sprint tick (no player damage)
-    VorpalTrailAOE = 37712, // Helper->location, 2.0s cast, range 6 circle (trail puddle)
-    VorpalTrailTelegraph = 38184, // Helper->location, 4.0s cast, 0-hit path telegraph
+    VorpalTrailSprint = 37711, // Fang->self, 0.7s cast, sprint telegraph (fang rotates 90° CW after cast then sprints forward)
+    VorpalTrailAOE = 37712, // Helper->location, 2.0s cast, rect puddle at sprint waypoint
+    VorpalTrailInitial = 38183, // Fang->self, instant cast fired at initial sprint start; TargetPos = first waypoint endpoint
+    VorpalTrailTelegraph = 38184, // Helper->location, 4.0s cast, 0-hit path telegraph along outer perimeter
 
     // Double-edged Swords: two half-arena cleaves in sequence (forward-then-backward)
     DoubleEdgedSwordsVisual = 37713, // Boss->self, 4.1s cast, single-target visual (mechanic start)

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
@@ -31,7 +31,8 @@ class T03EverkeepStates : StateMachineBuilder
             .ActivateOnEnter<DawnOfAnAge>()
             .ActivateOnEnter<Actualize>()
             .ActivateOnEnter<ChasmOfVollok>()
-            .ActivateOnEnter<DutysEdge>();
+            .ActivateOnEnter<DutysEdge>()
+            .ActivateOnEnter<HalfFull>();
         // phase 2 mechanics activated as they are implemented
     }
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
@@ -9,8 +9,11 @@ class T03EverkeepStates : StateMachineBuilder
         _module = module;
         SimplePhase(0, Phase1, "P1")
             .Raw.Update = () => Module.PrimaryActor.IsDeadOrDestroyed || (Module.PrimaryActor.CastInfo?.IsSpell(AID.SoulOverflowEnrage) ?? false);
+        // P2 ends only when a BossP2 has been defeated (HP = 0). Missing/destroyed BossP2 is not
+        // sufficient on its own — the actor is briefly destroyed and re-spawned when the arena
+        // shrinks at the big ENVC block, and we must not unload the module during that gap.
         SimplePhase(1, Phase2, "P2")
-            .Raw.Update = () => Module.PrimaryActor.IsDeadOrDestroyed && (_module.BossP2()?.IsDeadOrDestroyed ?? true);
+            .Raw.Update = () => Module.PrimaryActor.IsDeadOrDestroyed && (_module.BossP2()?.IsDead ?? false);
     }
 
     private void Phase1(uint id)

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
@@ -36,6 +36,7 @@ class T03EverkeepStates : StateMachineBuilder
             .ActivateOnEnter<ChasmOfVollok>()
             .ActivateOnEnter<DutysEdge>()
             .ActivateOnEnter<ForgedTrack>()
+            .ActivateOnEnter<FireIII>()
             .ActivateOnEnter<HalfFull>()
             .ActivateOnEnter<BitterReaping>()
             .ActivateOnEnter<HalfCircuitRect>()

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
@@ -1,0 +1,33 @@
+namespace BossMod.Dawntrail.Trial.T03Everkeep;
+
+class T03EverkeepStates : StateMachineBuilder
+{
+    private readonly T03Everkeep _module;
+
+    public T03EverkeepStates(T03Everkeep module) : base(module)
+    {
+        _module = module;
+        SimplePhase(0, Phase1, "P1")
+            .Raw.Update = () => Module.PrimaryActor.IsDeadOrDestroyed || (Module.PrimaryActor.CastInfo?.IsSpell(AID.SoulOverflowEnrage) ?? false);
+        SimplePhase(1, Phase2, "P2")
+            .Raw.Update = () => Module.PrimaryActor.IsDeadOrDestroyed && (_module.BossP2()?.IsDeadOrDestroyed ?? true);
+    }
+
+    private void Phase1(uint id)
+    {
+        SimpleState(id, 10000, "P1")
+            .ActivateOnEnter<SoulOverflow>()
+            .ActivateOnEnter<SoulOverflowEnrage>()
+            .ActivateOnEnter<PatricidalPique>()
+            .ActivateOnEnter<CalamitysEdge>()
+            .ActivateOnEnter<Burst>()
+            .ActivateOnEnter<VorpalTrail>()
+            .ActivateOnEnter<DoubleEdgedSwords>();
+    }
+
+    private void Phase2(uint id)
+    {
+        SimpleState(id, 10000, "P2");
+        // phase 2 mechanics activated as they are implemented
+    }
+}

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
@@ -30,7 +30,8 @@ class T03EverkeepStates : StateMachineBuilder
         SimpleState(id, 10000, "P2")
             .ActivateOnEnter<DawnOfAnAge>()
             .ActivateOnEnter<Actualize>()
-            .ActivateOnEnter<ChasmOfVollok>();
+            .ActivateOnEnter<ChasmOfVollok>()
+            .ActivateOnEnter<DutysEdge>();
         // phase 2 mechanics activated as they are implemented
     }
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
@@ -36,7 +36,9 @@ class T03EverkeepStates : StateMachineBuilder
             .ActivateOnEnter<BitterReaping>()
             .ActivateOnEnter<HalfCircuitRect>()
             .ActivateOnEnter<HalfCircuitDonut>()
-            .ActivateOnEnter<HalfCircuitCircle>();
+            .ActivateOnEnter<HalfCircuitCircle>()
+            .ActivateOnEnter<SmitingCircuitDonut>()
+            .ActivateOnEnter<SmitingCircuitCircle>();
         // phase 2 mechanics activated as they are implemented
     }
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
@@ -12,7 +12,7 @@ class T03EverkeepStates : StateMachineBuilder
         // P2 ends only when a BossP2 has been defeated (HP = 0). Missing/destroyed BossP2 is not
         // sufficient on its own — the actor is briefly destroyed and re-spawned when the arena
         // shrinks at the big ENVC block, and we must not unload the module during that gap.
-        SimplePhase(1, Phase2, "P2")
+        SimplePhase(1, Phase2, "Enrage")
             .Raw.Update = () => Module.PrimaryActor.IsDeadOrDestroyed && (_module.BossP2()?.IsDead ?? false);
     }
 

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
@@ -29,7 +29,8 @@ class T03EverkeepStates : StateMachineBuilder
     {
         SimpleState(id, 10000, "P2")
             .ActivateOnEnter<DawnOfAnAge>()
-            .ActivateOnEnter<Actualize>();
+            .ActivateOnEnter<Actualize>()
+            .ActivateOnEnter<ChasmOfVollok>();
         // phase 2 mechanics activated as they are implemented
     }
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
@@ -33,7 +33,10 @@ class T03EverkeepStates : StateMachineBuilder
             .ActivateOnEnter<ChasmOfVollok>()
             .ActivateOnEnter<DutysEdge>()
             .ActivateOnEnter<HalfFull>()
-            .ActivateOnEnter<BitterReaping>();
+            .ActivateOnEnter<BitterReaping>()
+            .ActivateOnEnter<HalfCircuitRect>()
+            .ActivateOnEnter<HalfCircuitDonut>()
+            .ActivateOnEnter<HalfCircuitCircle>();
         // phase 2 mechanics activated as they are implemented
     }
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
@@ -35,6 +35,7 @@ class T03EverkeepStates : StateMachineBuilder
             .ActivateOnEnter<Actualize>()
             .ActivateOnEnter<ChasmOfVollok>()
             .ActivateOnEnter<DutysEdge>()
+            .ActivateOnEnter<ForgedTrack>()
             .ActivateOnEnter<HalfFull>()
             .ActivateOnEnter<BitterReaping>()
             .ActivateOnEnter<HalfCircuitRect>()

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
@@ -28,7 +28,8 @@ class T03EverkeepStates : StateMachineBuilder
     private void Phase2(uint id)
     {
         SimpleState(id, 10000, "P2")
-            .ActivateOnEnter<DawnOfAnAge>();
+            .ActivateOnEnter<DawnOfAnAge>()
+            .ActivateOnEnter<Actualize>();
         // phase 2 mechanics activated as they are implemented
     }
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
@@ -27,7 +27,8 @@ class T03EverkeepStates : StateMachineBuilder
 
     private void Phase2(uint id)
     {
-        SimpleState(id, 10000, "P2");
+        SimpleState(id, 10000, "P2")
+            .ActivateOnEnter<DawnOfAnAge>();
         // phase 2 mechanics activated as they are implemented
     }
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
@@ -18,7 +18,7 @@ class T03EverkeepStates : StateMachineBuilder
 
     private void Phase1(uint id)
     {
-        SimpleState(id, 10000, "P1")
+        SimpleState(id, 10000, "Enrage")
             .ActivateOnEnter<SoulOverflow>()
             .ActivateOnEnter<SoulOverflowEnrage>()
             .ActivateOnEnter<PatricidalPique>()
@@ -30,7 +30,7 @@ class T03EverkeepStates : StateMachineBuilder
 
     private void Phase2(uint id)
     {
-        SimpleState(id, 10000, "P2")
+        SimpleState(id, 10000, "Enrage")
             .ActivateOnEnter<DawnOfAnAge>()
             .ActivateOnEnter<Actualize>()
             .ActivateOnEnter<ChasmOfVollok>()

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
@@ -44,6 +44,5 @@ class T03EverkeepStates : StateMachineBuilder
             .ActivateOnEnter<HalfCircuitCircle>()
             .ActivateOnEnter<SmitingCircuitDonut>()
             .ActivateOnEnter<SmitingCircuitCircle>();
-        // phase 2 mechanics activated as they are implemented
     }
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/T03EverkeepStates.cs
@@ -32,7 +32,8 @@ class T03EverkeepStates : StateMachineBuilder
             .ActivateOnEnter<Actualize>()
             .ActivateOnEnter<ChasmOfVollok>()
             .ActivateOnEnter<DutysEdge>()
-            .ActivateOnEnter<HalfFull>();
+            .ActivateOnEnter<HalfFull>()
+            .ActivateOnEnter<BitterReaping>();
         // phase 2 mechanics activated as they are implemented
     }
 }

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/VorpalTrail.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/VorpalTrail.cs
@@ -1,0 +1,3 @@
+namespace BossMod.Dawntrail.Trial.T03Everkeep;
+
+class VorpalTrail(BossModule module) : Components.StandardAOEs(module, AID.VorpalTrailAOE, new AOEShapeCircle(6));

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/VorpalTrail.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/VorpalTrail.cs
@@ -39,7 +39,6 @@ class VorpalTrail(BossModule module) : Components.GenericAOEs(module)
             return;
         if ((AID)spell.Action.ID != AID.VorpalTrailInitial)
             return;
-        // Initial-sprint rects tile the outer diamond perimeter flush — wide halfwidth + back extension.
         SetRect(caster.InstanceID, caster.Position, spell.TargetXZ, 4f, 0f, 3f, WorldState.FutureTime(1.5f));
     }
 
@@ -49,10 +48,7 @@ class VorpalTrail(BossModule module) : Components.GenericAOEs(module)
             return;
         if ((AID)spell.Action.ID != AID.VorpalTrailSprint)
             return;
-        // Subsequent sprints form a pinwheel — narrower arms + extend back by 2 so the rect reaches
-        // the 233C helper sitting 2 units behind the fang's sprint-start position. HalfWidth bumped
-        // from 2.5 to 2.75 so adjacent converging lanes overlap slightly — a raw 2.5 left a ~1m
-        // sliver at the pinwheel center that the AI read as safe but the player hitbox clipped.
+        // Back extension reaches the 233C helper sitting 2 units behind the fang's sprint-start position.
         SetRect(caster.InstanceID, caster.Position, spell.LocXZ, 2.5f, 2.0f, 2.5f, Module.CastFinishAt(spell, 1.0f));
     }
 

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/VorpalTrail.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/VorpalTrail.cs
@@ -40,8 +40,10 @@ class VorpalTrail(BossModule module) : Components.GenericAOEs(module)
         if ((AID)spell.Action.ID != AID.VorpalTrailSprint)
             return;
         // Subsequent sprints form a pinwheel — narrower arms + extend back by 2 so the rect reaches
-        // the 233C helper sitting 2 units behind the fang's sprint-start position.
-        SetRect(caster.InstanceID, caster.Position, spell.LocXZ, 2.5f, 1.5f, 2f, Module.CastFinishAt(spell, 1.0f));
+        // the 233C helper sitting 2 units behind the fang's sprint-start position. HalfWidth bumped
+        // from 2.5 to 2.75 so adjacent converging lanes overlap slightly — a raw 2.5 left a ~1m
+        // sliver at the pinwheel center that the AI read as safe but the player hitbox clipped.
+        SetRect(caster.InstanceID, caster.Position, spell.LocXZ, 2.75f, 1.5f, 2f, Module.CastFinishAt(spell, 1.0f));
     }
 
     private void SetRect(ulong fangId, WPos from, WPos to, float halfWidth, float frontExt, float backExt, DateTime expiration)

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/VorpalTrail.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/VorpalTrail.cs
@@ -1,3 +1,60 @@
 namespace BossMod.Dawntrail.Trial.T03Everkeep;
 
-class VorpalTrail(BossModule module) : Components.StandardAOEs(module, AID.VorpalTrailAOE, new AOEShapeCircle(6));
+// Each 42AA Fang does a sequence of sprints (5 inward + 5 outward = 10 segments per fang); the
+// rectangle AOE is the line segment each sprint covers, from the fang's current position to the
+// sprint endpoint (carried in the cast's TargetPos / LocXZ).
+//
+// - Initial sprint (VorpalTrailInitial / 38183): instant cast fired when the sprint begins from
+//   the arena-edge spawn. Extend rect back by 3 so it reaches the diamond corner.
+// - Subsequent sprints (VorpalTrailSprint / 37711): 0.7s cast fired while the fang is stationary
+//   at the current waypoint. Rect spans interior waypoints with no back extension.
+//
+// One rect per fang is tracked; a new sprint cast replaces the previous rect, and rects auto-expire
+// shortly after the sprint would complete.
+class VorpalTrail(BossModule module) : Components.GenericAOEs(module)
+{
+    private readonly Dictionary<ulong, AOEInstance> _fangAOE = [];
+
+    public override IEnumerable<AOEInstance> ActiveAOEs(int slot, Actor actor)
+    {
+        var now = WorldState.CurrentTime;
+        foreach (var id in _fangAOE.Where(kv => kv.Value.Activation < now).Select(kv => kv.Key).ToList())
+            _fangAOE.Remove(id);
+        return _fangAOE.Values;
+    }
+
+    public override void OnEventCast(Actor caster, ActorCastEvent spell)
+    {
+        if (caster.OID != (uint)OID.Fang)
+            return;
+        if ((AID)spell.Action.ID != AID.VorpalTrailInitial)
+            return;
+        // Initial-sprint rects tile the outer diamond perimeter flush — wide halfwidth + back extension.
+        SetRect(caster.InstanceID, caster.Position, spell.TargetXZ, 4f, 0f, 3f, WorldState.FutureTime(1.5f));
+    }
+
+    public override void OnCastStarted(Actor caster, ActorCastInfo spell)
+    {
+        if (caster.OID != (uint)OID.Fang)
+            return;
+        if ((AID)spell.Action.ID != AID.VorpalTrailSprint)
+            return;
+        // Subsequent sprints form a pinwheel — narrower arms + extend back by 2 so the rect reaches
+        // the 233C helper sitting 2 units behind the fang's sprint-start position.
+        SetRect(caster.InstanceID, caster.Position, spell.LocXZ, 2.5f, 1.5f, 2f, Module.CastFinishAt(spell, 1.0f));
+    }
+
+    private void SetRect(ulong fangId, WPos from, WPos to, float halfWidth, float frontExt, float backExt, DateTime expiration)
+    {
+        var diff = to - from;
+        var length = diff.Length();
+        if (length < 0.1f)
+        {
+            _fangAOE.Remove(fangId);
+            return;
+        }
+        var mid = from + diff * 0.5f;
+        var angle = Angle.FromDirection(diff);
+        _fangAOE[fangId] = new AOEInstance(new AOEShapeRect(length * 0.5f + frontExt, halfWidth, length * 0.5f + backExt), mid, angle, expiration);
+    }
+}

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/VorpalTrail.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/VorpalTrail.cs
@@ -14,6 +14,7 @@ namespace BossMod.Dawntrail.Trial.T03Everkeep;
 class VorpalTrail(BossModule module) : Components.GenericAOEs(module)
 {
     private readonly Dictionary<ulong, AOEInstance> _fangAOE = [];
+    private static readonly AOEShapeCircle _centerKeepout = new(6f);
 
     public override IEnumerable<AOEInstance> ActiveAOEs(int slot, Actor actor)
     {
@@ -21,6 +22,15 @@ class VorpalTrail(BossModule module) : Components.GenericAOEs(module)
         foreach (var id in _fangAOE.Where(kv => kv.Value.Activation < now).Select(kv => kv.Key).ToList())
             _fangAOE.Remove(id);
         return _fangAOE.Values;
+    }
+
+    public override void AddAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
+    {
+        base.AddAIHints(slot, actor, assignment, hints);
+        // Pinwheel safe-spots all sit near the perimeter; a central keepout stops the AI from
+        // settling on the apparent gap between converging rects at the convergence point.
+        if (_fangAOE.Count > 0)
+            hints.AddForbiddenZone(_centerKeepout, Module.Center);
     }
 
     public override void OnEventCast(Actor caster, ActorCastEvent spell)
@@ -43,7 +53,7 @@ class VorpalTrail(BossModule module) : Components.GenericAOEs(module)
         // the 233C helper sitting 2 units behind the fang's sprint-start position. HalfWidth bumped
         // from 2.5 to 2.75 so adjacent converging lanes overlap slightly — a raw 2.5 left a ~1m
         // sliver at the pinwheel center that the AI read as safe but the player hitbox clipped.
-        SetRect(caster.InstanceID, caster.Position, spell.LocXZ, 2.75f, 1.5f, 2f, Module.CastFinishAt(spell, 1.0f));
+        SetRect(caster.InstanceID, caster.Position, spell.LocXZ, 2.5f, 2.0f, 2.5f, Module.CastFinishAt(spell, 1.0f));
     }
 
     private void SetRect(ulong fangId, WPos from, WPos to, float halfWidth, float frontExt, float backExt, DateTime expiration)

--- a/BossMod/Modules/Dawntrail/Trial/T03Everkeep/VorpalTrail.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T03Everkeep/VorpalTrail.cs
@@ -14,32 +14,88 @@ namespace BossMod.Dawntrail.Trial.T03Everkeep;
 class VorpalTrail(BossModule module) : Components.GenericAOEs(module)
 {
     private readonly Dictionary<ulong, AOEInstance> _fangAOE = [];
-    private static readonly AOEShapeCircle _centerKeepout = new(6f);
+    private readonly Dictionary<ulong, AOEInstance> _predictedNext = []; // sprint N+1, painted at sprint N's resolution to give the AI extra lead time
+    private readonly Dictionary<ulong, DateTime> _lastUnsafe = [];
+    private DateTime _mechanicActiveUntil;
+    private const float SettleSeconds = 4f; // require this much continuous safety before allowing casts
+    private const float NextSprintExpirationSec = 5f; // covers dash → arrival → next-cast window; the precise rect overwrites once sprint N+1's CST+ fires
+    private const float CenterAttractRadius = 0.1f; // hold-position tolerance for the center goal zone
+    private const float CenterAttractWeight = 10f; // strong attractor; rect forbids still override when a sprint crosses center
+    private const float AIRectHalfWidth = 3.5f; // AI-only padding beyond the 2.5f visible halfwidth so the AI commits to leaving instead of skimming the edge
 
     public override IEnumerable<AOEInstance> ActiveAOEs(int slot, Actor actor)
     {
         var now = WorldState.CurrentTime;
         foreach (var id in _fangAOE.Where(kv => kv.Value.Activation < now).Select(kv => kv.Key).ToList())
             _fangAOE.Remove(id);
-        return _fangAOE.Values;
+        foreach (var id in _predictedNext.Where(kv => kv.Value.Activation < now).Select(kv => kv.Key).ToList())
+            _predictedNext.Remove(id);
+        return _fangAOE.Values.Concat(_predictedNext.Values);
     }
 
     public override void AddAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
     {
-        base.AddAIHints(slot, actor, assignment, hints);
-        // Pinwheel safe-spots all sit near the perimeter; a central keepout stops the AI from
-        // settling on the apparent gap between converging rects at the convergence point.
-        if (_fangAOE.Count > 0)
-            hints.AddForbiddenZone(_centerKeepout, Module.Center);
+        // Skipping base.AddAIHints here — we replace its rect-based forbidden zones with widened
+        // AI-only versions below so the visual stays at 2.5f while the pathfinder treats 3.5f as forbidden.
+        var now = WorldState.CurrentTime;
+        var mechanicActive = _fangAOE.Count > 0 || _mechanicActiveUntil > now;
+        if (!mechanicActive)
+        {
+            _lastUnsafe.Remove(actor.InstanceID);
+            return;
+        }
+        foreach (var aoe in ActiveAOEs(slot, actor))
+        {
+            if (!aoe.Risky)
+                continue;
+            if (aoe.Shape is AOEShapeRect rect)
+            {
+                var paddedHalfWidth = MathF.Max(rect.HalfWidth, AIRectHalfWidth);
+                var widened = new AOEShapeRect(rect.LengthFront, paddedHalfWidth, rect.LengthBack, rect.DirectionOffset);
+                hints.AddForbiddenZone(widened, aoe.Origin, aoe.Rotation, aoe.Activation);
+            }
+            else
+            {
+                hints.AddForbiddenZone(aoe.Check, aoe.Activation);
+            }
+        }
+        // Inverted strategy: park the AI at arena center and let rect avoidance pull it off when a
+        // sprint actually crosses through. Most pinwheel rects miss exact center between converging
+        // dashes, so holding station beats dancing around the perimeter trying to read the next sprint.
+        hints.GoalZones.Add(hints.GoalSingleTarget(Module.Center, CenterAttractRadius, CenterAttractWeight));
+
+        var inDanger = _fangAOE.Values.Any(a => a.Check(actor.Position)) || _predictedNext.Values.Any(a => a.Check(actor.Position));
+        if (inDanger || !_lastUnsafe.ContainsKey(actor.InstanceID))
+            _lastUnsafe[actor.InstanceID] = now;
+        // Suppress casts (incl. instants) until the player has held a safe position long enough —
+        // the pinwheel cycles fast and a 1.5s GCD that locks movement is enough to clip the next sprint.
+        if ((now - _lastUnsafe[actor.InstanceID]).TotalSeconds < SettleSeconds)
+            hints.MaxCastTime = 0;
     }
 
     public override void OnEventCast(Actor caster, ActorCastEvent spell)
     {
         if (caster.OID != (uint)OID.Fang)
             return;
-        if ((AID)spell.Action.ID != AID.VorpalTrailInitial)
+        var aid = (AID)spell.Action.ID;
+        if (aid == AID.VorpalTrailInitial)
+        {
+            SetRect(caster.InstanceID, caster.Position, spell.TargetXZ, 4f, 0f, 3f, WorldState.FutureTime(1.5f));
             return;
-        SetRect(caster.InstanceID, caster.Position, spell.TargetXZ, 4f, 0f, 3f, WorldState.FutureTime(1.5f));
+        }
+        if (aid == AID.VorpalTrailSprint)
+        {
+            // Sprint N just resolved: fang dashes from caster.Position (A) to spell.TargetXZ (B).
+            // Pinwheel is deterministic — sprint N+1 rotates 90° CW with the same dash length.
+            // Pre-paint that rect now; sprint N+1's CST+ will overwrite the prediction with precise
+            // geometry once the fang stops at B and starts casting again.
+            var dirAB = spell.TargetXZ - caster.Position;
+            if (dirAB.LengthSq() < 0.01f)
+                return;
+            var b = spell.TargetXZ;
+            var c = b + dirAB.OrthoR(); // OrthoR = (-Z, X) = 90° CW; preserves length
+            SetRectInto(_predictedNext, caster.InstanceID, b, c, 2.5f, 2.5f, 3.0f, WorldState.FutureTime(NextSprintExpirationSec));
+        }
     }
 
     public override void OnCastStarted(Actor caster, ActorCastInfo spell)
@@ -48,21 +104,31 @@ class VorpalTrail(BossModule module) : Components.GenericAOEs(module)
             return;
         if ((AID)spell.Action.ID != AID.VorpalTrailSprint)
             return;
+        // Precise rect supersedes any prediction we put in _predictedNext for this fang.
+        _predictedNext.Remove(caster.InstanceID);
         // Back extension reaches the 233C helper sitting 2 units behind the fang's sprint-start position.
-        SetRect(caster.InstanceID, caster.Position, spell.LocXZ, 2.5f, 2.0f, 2.5f, Module.CastFinishAt(spell, 1.0f));
+        SetRect(caster.InstanceID, caster.Position, spell.LocXZ, 2.5f, 2.5f, 3.0f, Module.CastFinishAt(spell, 1.0f));
     }
 
     private void SetRect(ulong fangId, WPos from, WPos to, float halfWidth, float frontExt, float backExt, DateTime expiration)
+        => SetRectInto(_fangAOE, fangId, from, to, halfWidth, frontExt, backExt, expiration);
+
+    private void SetRectInto(Dictionary<ulong, AOEInstance> dict, ulong fangId, WPos from, WPos to, float halfWidth, float frontExt, float backExt, DateTime expiration)
     {
         var diff = to - from;
         var length = diff.Length();
         if (length < 0.1f)
         {
-            _fangAOE.Remove(fangId);
+            dict.Remove(fangId);
             return;
         }
         var mid = from + diff * 0.5f;
         var angle = Angle.FromDirection(diff);
-        _fangAOE[fangId] = new AOEInstance(new AOEShapeRect(length * 0.5f + frontExt, halfWidth, length * 0.5f + backExt), mid, angle, expiration);
+        dict[fangId] = new AOEInstance(new AOEShapeRect(length * 0.5f + frontExt, halfWidth, length * 0.5f + backExt), mid, angle, expiration);
+        // Bridge the ~0.7s gaps between sprints + a tail past the final sprint so cast suppression
+        // doesn't blink off mid-pinwheel just because the active rect just expired.
+        var until = expiration.AddSeconds(3);
+        if (until > _mechanicActiveUntil)
+            _mechanicActiveUntil = until;
     }
 }


### PR DESCRIPTION
(This is my first attempt at a module and should definitely be squashed if pulled.)

Adds support for Normal Everkeep for Duty Support.

Tested as:
* GNB
* WHM
* BLM
* BRD
* SAM

Zero hits on all runs.

Open to feedback to make this better! 