### PR TITLE
Fix: CFC ID/Enforce Snap Punch for first phase of Return of the Holyfist.

### DIFF
--- a/BossMod/QuestBattle/ARealmReborn/ClassJobQuests/MNK/ReturnoftheHolyfist.cs
+++ b/BossMod/QuestBattle/ARealmReborn/ClassJobQuests/MNK/ReturnoftheHolyfist.cs
@@ -1,7 +1,47 @@
-﻿namespace BossMod.QuestBattle.ARealmReborn.ClassJobQuests.MNK;
+namespace BossMod.QuestBattle.ARealmReborn.ClassJobQuests.MNK;
 
-[ZoneModuleInfo(BossModuleInfo.Maturity.Contributed, 323)]
+[ZoneModuleInfo(BossModuleInfo.Maturity.Contributed, 322, 261)]
 internal class ReturnOfTheHolyfist(WorldState ws) : QuestBattle(ws)
 {
-    public override void AddQuestAIHints(Actor player, AIHints hints) => hints.PrioritizeAll();
+    private int _snapPunchCount;
+    private int _comboStep; // 0=Bootshine, 1=TrueStrike, 2=SnapPunch
+
+    public override List<QuestObjective> DefineObjectives(WorldState ws) => [
+        new QuestObjective(ws)
+            .With(obj => {
+                obj.OnEventCast += (act, spell) => {
+                    if (act.OID != 0) return;
+                    var id = spell.Action;
+                    if (_comboStep == 0 && id == ActionID.MakeSpell(BossMod.MNK.AID.Bootshine))
+                        _comboStep = 1;
+                    else if (_comboStep == 1 && id == ActionID.MakeSpell(BossMod.MNK.AID.TrueStrike))
+                        _comboStep = 2;
+                    else if (_comboStep == 2 && id == ActionID.MakeSpell(BossMod.MNK.AID.SnapPunch))
+                    {
+                        _snapPunchCount++;
+                        _comboStep = 0;
+                    }
+                };
+                // no completion condition — objective stays active so Hints and OnEventCast keep firing
+            })
+            .Hints((player, hints) => {
+                if (_snapPunchCount >= 3) return;
+                var target = hints.PotentialTargets.FirstOrDefault()?.Actor;
+                if (target == null) return;
+                hints.ForcedTarget = target;
+                var next = _comboStep switch {
+                    0 => BossMod.MNK.AID.Bootshine,
+                    1 => BossMod.MNK.AID.TrueStrike,
+                    _ => BossMod.MNK.AID.SnapPunch,
+                };
+                hints.ActionsToExecute.Push(ActionID.MakeSpell(next), target, ActionQueue.Priority.VeryHigh);
+            })
+    ];
+
+    public override void AddQuestAIHints(Actor player, AIHints hints)
+    {
+        // ForcePriority bypasses the PriorityPointless setter guard so the mob appears in PotentialTargets
+        foreach (var e in hints.PotentialTargets)
+            e.ForcePriority(0);
+    }
 }


### PR DESCRIPTION
I was having trouble with this QuestBattle and noticed the CFC was off by 1.

```
15:11:22.262 | DBG | [ClientState] ZoneInit: ZoneInitEventArgs { TerritoryTypeId = 261, Instance = 0, ContentFinderCondition = 322, Weather = 14, ActiveFestivals = [0|0, 0|0, 0|0, 0|0, 0|0, 0|0, 0|0, 0|0],  }
```
On top of that, I was overlevelled/overgeared and kept reducing Holyfist's health to 1 which made the auto rotation stop/no actions getting cast so Snap Punch never executed 3 times.

This forces the use of the combo (without demolition) to complete the first phase.