### PR TITLE
AkechiPLD improvements

### DIFF
--- a/BossMod/Autorotation/Standard/akechi/AkechiTools.cs
+++ b/BossMod/Autorotation/Standard/akechi/AkechiTools.cs
@@ -128,6 +128,7 @@ public abstract class AkechiTools<AID, TraitID>(RotationModuleManager manager, A
     protected bool Unlocked(AID aid) => ActionUnlocked(ActionID.MakeSpell(aid));
     protected bool Unlocked(TraitID tid) => TraitUnlocked((uint)(object)tid);
     protected AID ComboLastMove => (AID)(object)World.Client.ComboState.Action;
+    protected unsafe AID LastComboAction => (AID)(object)Instance()->Combo.Action;
     protected float SkSGCDLength => ActionSpeed.GCDRounded(World.Client.PlayerStats.SkillSpeed, World.Client.PlayerStats.Haste, Player.Level);
     protected float SpSGCDLength => ActionSpeed.GCDRounded(World.Client.PlayerStats.SpellSpeed, World.Client.PlayerStats.Haste, Player.Level);
     protected bool CanFitSkSGCD(float duration, int extraGCDs = 0) => GCD + SkSGCDLength * extraGCDs < duration;

--- a/BossMod/Autorotation/Standard/akechi/Tank/AkechiPLD.cs
+++ b/BossMod/Autorotation/Standard/akechi/Tank/AkechiPLD.cs
@@ -12,9 +12,9 @@ public sealed class AkechiPLD(RotationModuleManager manager, Actor player) : Ake
     public enum BladeComboStrategy { Automatic, ForceConfiteor, ForceFaith, ForceTruth, ForceValor, Delay }
     public enum GoringBladeStrategy { Automatic, Late, Force, Delay }
     public enum HolyStrategy { Automatic, Early, Late, VeryLate, OnlySpirit, OnlyCircle, ForceSpirit, ForceCircle, Delay }
-    public enum DashStrategy { Automatic, GapClose, GapClose5, GapClose10, GapCloseOpener, Opener, Force, Delay }
+    public enum DashStrategy { Automatic, GapClose, GapClose5, GapClose10, GapCloseOpener, Opener, OvercapSafe, OvercapUnsafe, Force, Delay }
     public enum BuffsStrategy { Automatic, Together, RaidBuffsOnly, Force, ForceWeave, Delay }
-    public enum RangedStrategy { Automatic, OpenerRangedCast, OpenerCast, ForceCast, RangedCast, RangedCastStationary, OpenerRanged, Opener, Force, Ranged, Forbid }
+    public enum RangedStrategy { Automatic, OpenerRangedCast, OpenerCast, RangedCast, RangedCastStationary, OpenerRanged, Opener, Ranged, Force, Forbid }
 
     public static RotationModuleDefinition Definition()
     {
@@ -35,27 +35,27 @@ public sealed class AkechiPLD(RotationModuleManager manager, Actor player) : Ake
 
         res.Define(Track.Atonement).As<AtonementStrategy>("Atones", "Atonement Combo", 155)
             .AddOption(AtonementStrategy.Automatic, "Automatically use full Atonement combo - will hold if Fight or Flight is imminent (unless Fight or Flight is user disabled)")
-            .AddOption(AtonementStrategy.ForceAtonement, "Force use of Atonement (if available)", 0, 30, ActionTargets.Hostile, 76)
-            .AddOption(AtonementStrategy.ForceSupplication, "Force use of Supplication (if available)", 0, 30, ActionTargets.Hostile, 76)
-            .AddOption(AtonementStrategy.ForceSepulchre, "Force use of Sepulchre (if available)", 0, 0, ActionTargets.Hostile, 76)
-            .AddOption(AtonementStrategy.Delay, "Do not use full Atonement combo", 0, 0, ActionTargets.None, 60)
+            .AddOption(AtonementStrategy.ForceAtonement, "Force Atonement (if available)", 0, 30, ActionTargets.Hostile, 76)
+            .AddOption(AtonementStrategy.ForceSupplication, "Force Supplication (if available)", 0, 30, ActionTargets.Hostile, 76)
+            .AddOption(AtonementStrategy.ForceSepulchre, "Force Sepulchre (if available)", 0, 0, ActionTargets.Hostile, 76)
+            .AddOption(AtonementStrategy.Delay, "Do not use Atonement combo", 0, 0, ActionTargets.None, 60)
             .AddAssociatedActions(AID.Atonement, AID.Supplication, AID.Sepulchre);
 
         res.Define(Track.BladeCombo).As<BladeComboStrategy>("Blades", "Confiteor + Blade Combo", 160)
             .AddOption(BladeComboStrategy.Automatic, "Automatically use full Blades combo - if no blades, will use best Holy action")
-            .AddOption(BladeComboStrategy.ForceConfiteor, "Force use of Confiteor (if available)", 0, 0, ActionTargets.Hostile, 80)
-            .AddOption(BladeComboStrategy.ForceFaith, "Force use of Blade of Faith (if available)", 0, 0, ActionTargets.Hostile, 90)
-            .AddOption(BladeComboStrategy.ForceTruth, "Force use of Blade of Truth (if available)", 0, 0, ActionTargets.Hostile, 90)
-            .AddOption(BladeComboStrategy.ForceValor, "Force use of Blade of Valor (if available)", 0, 0, ActionTargets.Hostile, 90)
-            .AddOption(BladeComboStrategy.Delay, "Do not use full Blades combo", 0, 0, ActionTargets.None, 80)
+            .AddOption(BladeComboStrategy.ForceConfiteor, "Force Confiteor (if available)", 0, 0, ActionTargets.Hostile, 80)
+            .AddOption(BladeComboStrategy.ForceFaith, "Force Blade of Faith (if available)", 0, 0, ActionTargets.Hostile, 90)
+            .AddOption(BladeComboStrategy.ForceTruth, "Force Blade of Truth (if available)", 0, 0, ActionTargets.Hostile, 90)
+            .AddOption(BladeComboStrategy.ForceValor, "Force Blade of Valor (if available)", 0, 0, ActionTargets.Hostile, 90)
+            .AddOption(BladeComboStrategy.Delay, "Do not use Confiteor or any Blades", 0, 0, ActionTargets.None, 80)
             .AddAssociatedActions(AID.Confiteor, AID.BladeOfFaith, AID.BladeOfTruth, AID.BladeOfValor);
 
         res.Define(Track.FightOrFlight).As<BuffsStrategy>("FoF", "Fight or Flight", 170)
             .AddOption(BuffsStrategy.Automatic, "Automatically use Fight or Flight on cooldown")
             .AddOption(BuffsStrategy.Together, "Automatically use Fight or Flight only with Requiescat - will delay in attempt to align itself with Requiescat if misaligned", 60, 20, ActionTargets.Self, 2)
             .AddOption(BuffsStrategy.RaidBuffsOnly, "Automatically use Fight or Flight only with raid buffs - will delay in attempt to align itself with raid buffs", 60, 20, ActionTargets.Self, 2)
-            .AddOption(BuffsStrategy.Force, "Force use of Fight or Flight (if available)", 60, 20, ActionTargets.Self, 2)
-            .AddOption(BuffsStrategy.ForceWeave, "Force use of Fight or Flight inside the next possible weave window (if available)", 60, 20, ActionTargets.Self, 2)
+            .AddOption(BuffsStrategy.Force, "Force Fight or Flight (if available)", 60, 20, ActionTargets.Self, 2)
+            .AddOption(BuffsStrategy.ForceWeave, "Force Fight or Flight inside the next possible weave window (if available)", 60, 20, ActionTargets.Self, 2)
             .AddOption(BuffsStrategy.Delay, "Do not use Fight or Flight", 0, 0, ActionTargets.None, 2)
             .AddAssociatedActions(AID.FightOrFlight);
 
@@ -63,53 +63,54 @@ public sealed class AkechiPLD(RotationModuleManager manager, Actor player) : Ake
             .AddOption(BuffsStrategy.Automatic, "Automatically use Requiescat on cooldown")
             .AddOption(BuffsStrategy.Together, "Automatically use Requiescat only with Fight or Flight - will delay in attempt to align itself with Fight or Flight", 60, 20, ActionTargets.Self, 68)
             .AddOption(BuffsStrategy.RaidBuffsOnly, "Automatically use Requiescat only with raid buffs - will delay in attempt to align itself with raid buffs", 60, 20, ActionTargets.Self, 68)
-            .AddOption(BuffsStrategy.Force, "Force use of Requiescat (if available)", 60, 20, ActionTargets.Self, 68)
-            .AddOption(BuffsStrategy.ForceWeave, "Force use of Requiescat inside the next possible weave window (if available)", 60, 20, ActionTargets.Self, 68)
+            .AddOption(BuffsStrategy.Force, "Force Requiescat (if available)", 60, 20, ActionTargets.Self, 68)
+            .AddOption(BuffsStrategy.ForceWeave, "Force Requiescat inside the next possible weave window (if available)", 60, 20, ActionTargets.Self, 68)
             .AddOption(BuffsStrategy.Delay, "Do not use Requiescat", 0, 0, ActionTargets.None, 68)
             .AddAssociatedActions(AID.Requiescat, AID.Imperator);
 
         res.Define(Track.GoringBlade).As<GoringBladeStrategy>("GB", "Goring Blade", 135)
             .AddOption(GoringBladeStrategy.Automatic, "Automatically use Goring Blade as soon as possible when in burst")
             .AddOption(GoringBladeStrategy.Late, "Automatically use Goring Blade after spending Requiescat stacks in burst (or if status is expiring)", 0, 0, ActionTargets.Hostile, 68)
-            .AddOption(GoringBladeStrategy.Force, "Force use of Goring Blade (if available)", 0, 0, ActionTargets.Hostile, 54)
+            .AddOption(GoringBladeStrategy.Force, "Force Goring Blade (if available)", 0, 0, ActionTargets.Hostile, 54)
             .AddOption(GoringBladeStrategy.Delay, "Do not use Goring Blade", 0, 0, ActionTargets.None, 54)
             .AddAssociatedActions(AID.GoringBlade);
 
         res.Define(Track.Holy).As<HolyStrategy>("Holy", "(Divine Might) Holy Spirit/Circle", 150)
-            .AddOption(HolyStrategy.Automatic, "Automatically choose best Divine Might Holy action based on targets")
-            .AddOption(HolyStrategy.Early, "Automatically choose best Divine Might Holy action as soon as possible", 0, 0, ActionTargets.Hostile, 68)
-            .AddOption(HolyStrategy.Late, "Automatically choose best Divine Might Holy action after Atonement combo (or if nothing else left to use)", 0, 0, ActionTargets.Hostile, 68)
-            .AddOption(HolyStrategy.VeryLate, "Automatically choose best Divine Might Holy action at the very last possible moment (right before next Atonement)", 0, 0, ActionTargets.Hostile, 68)
-            .AddOption(HolyStrategy.OnlySpirit, "Only use Holy Spirit as best Divine Might Holy action", 0, 0, ActionTargets.Hostile, 64)
-            .AddOption(HolyStrategy.OnlyCircle, "Only use Holy Circle as best Divine Might Holy action", 0, 0, ActionTargets.Hostile, 72)
-            .AddOption(HolyStrategy.ForceSpirit, "Force use of raw or buffed Holy Spirit (if available)", 0, 0, ActionTargets.Hostile, 64)
-            .AddOption(HolyStrategy.ForceCircle, "Force use of raw or buffed Holy Circle (if available)", 0, 0, ActionTargets.Hostile, 72)
-            .AddOption(HolyStrategy.Delay, "Do not use any Holy actions under Divine Might", 0, 0, ActionTargets.None, 64)
+            .AddOption(HolyStrategy.Automatic, "Automatically use best Holy action based on targets")
+            .AddOption(HolyStrategy.Early, "Automatically use best Holy action as soon as possible", 0, 0, ActionTargets.Hostile, 68)
+            .AddOption(HolyStrategy.Late, "Automatically use best Holy action after Atonement combo (or if nothing else left to use)", 0, 0, ActionTargets.Hostile, 68)
+            .AddOption(HolyStrategy.VeryLate, "Automatically use best Holy action at the very last possible moment (right before next Atonement)", 0, 0, ActionTargets.Hostile, 68)
+            .AddOption(HolyStrategy.OnlySpirit, "Only use Holy Spirit as best Holy action", 0, 0, ActionTargets.Hostile, 64)
+            .AddOption(HolyStrategy.OnlyCircle, "Only use Holy Circle as best Holy action", 0, 0, ActionTargets.Hostile, 72)
+            .AddOption(HolyStrategy.ForceSpirit, "Force raw or buffed Holy Spirit (if available)", 0, 0, ActionTargets.Hostile, 64)
+            .AddOption(HolyStrategy.ForceCircle, "Force raw or buffed Holy Circle (if available)", 0, 0, ActionTargets.Hostile, 72)
+            .AddOption(HolyStrategy.Delay, "Do not use any Holy actions", 0, 0, ActionTargets.None, 64)
             .AddAssociatedActions(AID.HolySpirit, AID.HolyCircle);
 
         res.Define(Track.Dash).As<DashStrategy>("Dash", "Intervene", 95)
-            .AddOption(DashStrategy.Automatic, "Automatically use both Intervene charges when in burst, not moving, & safely inside melee range")
+            .AddOption(DashStrategy.Automatic, "Automatically use both Intervene charges when in burst - will only use if in melee range and not moving")
             .AddOption(DashStrategy.GapClose, "Automatically use Intervene as gap closer if outside melee range", 30, 0, ActionTargets.Hostile, 66)
             .AddOption(DashStrategy.GapClose5, "Automatically use Intervene as gap closer if further than five yalms", 30, 0, ActionTargets.Hostile, 66)
             .AddOption(DashStrategy.GapClose10, "Automatically use Intervene as gap closer if further than ten yalms", 30, 0, ActionTargets.Hostile, 66)
             .AddOption(DashStrategy.GapCloseOpener, "Automatically use Intervene as gap closer at the start of combat if out of melee range", 30, 0, ActionTargets.Hostile, 66)
             .AddOption(DashStrategy.Opener, "Automatically use Intervene at the start of combat, regardless of range", 30, 0, ActionTargets.Hostile, 66)
-            .AddOption(DashStrategy.Force, "Force use of Intervene", 30, 0, ActionTargets.Hostile, 66)
+            .AddOption(DashStrategy.OvercapSafe, "Automatically use Intervene if close to overcapping on charges - will only use if in melee range and not moving", 30, 0, ActionTargets.Hostile, 66)
+            .AddOption(DashStrategy.OvercapUnsafe, "Automatically use Intervene if close to overcapping on charges, regardless of any conditions (UNSAFE)", 30, 0, ActionTargets.Hostile, 66)
+            .AddOption(DashStrategy.Force, "Force Intervene", 30, 0, ActionTargets.Hostile, 66)
             .AddOption(DashStrategy.Delay, "Do not use Intervene", 0, 0, ActionTargets.None, 66)
             .AddAssociatedActions(AID.Intervene);
 
-        res.Define(Track.Ranged).As<RangedStrategy>("Ranged", "Shield Lob / Holy Spirit", 100)
-            .AddOption(RangedStrategy.Automatic, "Automatically use Holy Spirit if stationary or use Shield Lob if moving")
+        res.Define(Track.Ranged).As<RangedStrategy>("Ranged", "Ranged Options", 100)
+            .AddOption(RangedStrategy.Automatic, "Automatically use best ranged attack if outside of melee range - Holy Spirit if stationary; Shield Lob if moving")
             .AddOption(RangedStrategy.OpenerRangedCast, "Automatically use Holy Spirit at the start of combat if outside melee range", 0, 0, ActionTargets.Hostile, 64)
-            .AddOption(RangedStrategy.OpenerCast, "Automatically use Holy Spirit at the start of combat regardless of range", 0, 0, ActionTargets.Hostile, 64)
-            .AddOption(RangedStrategy.ForceCast, "Force use of Holy Spirit", 0, 0, ActionTargets.Hostile, 64) //TODO: remove this option - dupe
-            .AddOption(RangedStrategy.RangedCast, "Use Holy Spirit as ranged choice if outside melee range", 0, 0, ActionTargets.Hostile, 64)
-            .AddOption(RangedStrategy.RangedCastStationary, "Use Holy Spirit as ranged choice if outside melee range and stationary", 0, 0, ActionTargets.Hostile, 64)
-            .AddOption(RangedStrategy.OpenerRanged, "Use Shield Lob at the start of combat if outside melee range", 0, 0, ActionTargets.Hostile, 15)
-            .AddOption(RangedStrategy.Opener, "Use Shield Lob at the start of combat regardless of range", 0, 0, ActionTargets.Hostile, 15)
-            .AddOption(RangedStrategy.Force, "Force use of Shield Lob", 0, 0, ActionTargets.Hostile, 15)
-            .AddOption(RangedStrategy.Ranged, "Use Shield Lob as ranged choice if outside melee range", 0, 0, ActionTargets.Hostile, 15)
-            .AddOption(RangedStrategy.Forbid, "Prohibit the use of any ranged attacks", 0, 0, ActionTargets.Hostile, 15)
+            .AddOption(RangedStrategy.OpenerCast, "Automatically use Holy Spirit at the start of combat, regardless of range", 0, 0, ActionTargets.Hostile, 64)
+            .AddOption(RangedStrategy.RangedCast, "Automatically use Holy Spirit as ranged choice if outside melee range", 0, 0, ActionTargets.Hostile, 64)
+            .AddOption(RangedStrategy.RangedCastStationary, "Automatically use Holy Spirit as ranged choice if outside melee range and stationary", 0, 0, ActionTargets.Hostile, 64)
+            .AddOption(RangedStrategy.OpenerRanged, "Automatically use Shield Lob at the start of combat if outside melee range", 0, 0, ActionTargets.Hostile, 15)
+            .AddOption(RangedStrategy.Opener, "Automatically use Shield Lob at the start of combat regardless of range", 0, 0, ActionTargets.Hostile, 15)
+            .AddOption(RangedStrategy.Ranged, "Automatically use Shield Lob as ranged choice if outside melee range", 0, 0, ActionTargets.Hostile, 15)
+            .AddOption(RangedStrategy.Force, "Force Shield Lob", 0, 0, ActionTargets.Hostile, 15)
+            .AddOption(RangedStrategy.Forbid, "Do not use any ranged attacks", 0, 0, ActionTargets.Hostile, 15)
             .AddAssociatedActions(AID.ShieldLob, AID.HolySpirit);
 
         res.DefineOGCD(Track.SpiritsWithin, AID.SpiritsWithin, "SW", "Spirits Within", 145, 30, 0, ActionTargets.Hostile, 30).AddAssociatedActions(AID.SpiritsWithin, AID.Expiacion);
@@ -132,22 +133,23 @@ public sealed class AkechiPLD(RotationModuleManager manager, Actor player) : Ake
     private float SUPstatus => Status(SID.SupplicationReady, 30);
     private float SEPstatus => Status(SID.SepulchreReady, 30);
     private float CONFstatus => Status(SID.ConfiteorReady, 30);
+    private float INTcd => Cooldown(AID.Intervene);
     private AID BestSpirits => Unlocked(AID.Expiacion) ? AID.Expiacion : AID.SpiritsWithin;
     private AID BestRequiescat => Unlocked(AID.Imperator) ? AID.Imperator : AID.Requiescat;
     private AID BestHolyCircle => Unlocked(AID.HolyCircle) ? AID.HolyCircle : AID.HolySpirit;
     private AID BestEnder => Unlocked(AID.RoyalAuthority) ? AID.RoyalAuthority : Unlocked(AID.RageOfHalone) ? AID.RageOfHalone : AID.FastBlade;
 
-    private AID NextSTCombo(bool finish) => LastComboAction switch
+    private AID NextSTCombo(bool wantFinish = true) => LastComboAction switch
     {
-        AID.RiotBlade => finish && Unlocked(BestEnder) ? BestEnder : AID.FastBlade,
+        AID.RiotBlade => wantFinish && Unlocked(BestEnder) ? BestEnder : AID.FastBlade,
         AID.FastBlade => Unlocked(AID.RiotBlade) ? AID.RiotBlade : AID.FastBlade,
-        AID.TotalEclipse => finish && Unlocked(AID.Prominence) ? AID.Prominence : AID.FastBlade,
+        AID.TotalEclipse => wantFinish && Unlocked(AID.Prominence) ? AID.Prominence : AID.FastBlade,
         _ => AID.FastBlade
     };
-    private AID NextAOECombo(bool finish) => LastComboAction switch
+    private AID NextAOECombo(bool wantFinish) => LastComboAction switch
     {
-        AID.TotalEclipse => finish && Unlocked(AID.Prominence) ? AID.Prominence : AID.TotalEclipse,
-        AID.RiotBlade => finish && Unlocked(BestEnder) ? BestEnder : AID.TotalEclipse,
+        AID.TotalEclipse => wantFinish && Unlocked(AID.Prominence) ? AID.Prominence : AID.TotalEclipse,
+        AID.RiotBlade => wantFinish && Unlocked(BestEnder) ? BestEnder : AID.TotalEclipse,
         AID.FastBlade => Unlocked(AID.RiotBlade) ? AID.RiotBlade : AID.TotalEclipse,
         _ => AID.TotalEclipse
     };
@@ -239,18 +241,21 @@ public sealed class AkechiPLD(RotationModuleManager manager, Actor player) : Ake
                 var dash = strategy.Option(Track.Dash);
                 var dashStrat = dash.As<DashStrategy>();
                 var dashTarget = SingleTargetChoice(mainTarget, dash);
+                var dashMinimum = dashTarget != null && INTcd < 30.6f;
                 var (dashCondition, dashPrio) = dashStrat switch
                 {
-                    DashStrategy.Automatic => (InCombat(dashTarget) && !IsMoving && In3y(dashTarget) && ReadyIn(AID.Intervene) <= 0.5f && HasStatus(SID.FightOrFlight), OGCDPriority.SlightlyLow),
-                    DashStrategy.Force => (!LastActionUsed(AID.Intervene), OGCDPriority.Forced),
+                    DashStrategy.Automatic => (!IsMoving && In3y(dashTarget) && HasStatus(SID.FightOrFlight), OGCDPriority.SlightlyLow),
+                    DashStrategy.Force => (true, OGCDPriority.Forced),
                     DashStrategy.GapClose => (!In3y(dashTarget), OGCDPriority.SlightlyLow),
                     DashStrategy.GapClose5 => (!In5y(dashTarget), OGCDPriority.SlightlyLow),
                     DashStrategy.GapClose10 => (!In10y(dashTarget), OGCDPriority.SlightlyLow),
-                    DashStrategy.GapCloseOpener => (IsFirstGCD && !In3y(dashTarget), OGCDPriority.SlightlyLow),
-                    DashStrategy.Opener => (IsFirstGCD, OGCDPriority.SlightlyLow),
+                    DashStrategy.GapCloseOpener => (IsFirstGCD && !In3y(dashTarget), OGCDPriority.Max),
+                    DashStrategy.Opener => (IsFirstGCD, OGCDPriority.Max),
+                    DashStrategy.OvercapSafe => (!IsMoving && In3y(dashTarget) && INTcd <= GCD, OGCDPriority.Max),
+                    DashStrategy.OvercapUnsafe => (INTcd <= GCD, OGCDPriority.Max),
                     _ => (false, OGCDPriority.None)
                 };
-                if (dashCondition)
+                if (dashMinimum && dashCondition)
                     QueueOGCD(AID.Intervene, dashTarget, dashPrio);
             }
 
@@ -352,9 +357,8 @@ public sealed class AkechiPLD(RotationModuleManager manager, Actor player) : Ake
             RangedStrategy.Automatic => (rTarget != null && away, IsMoving || MP < 1000 ? AID.ShieldLob : AID.HolySpirit, GCDPriority.Low + 1),
             RangedStrategy.OpenerRanged => (IsFirstGCD && away, AID.ShieldLob, GCDPriority.Low + 1),
             RangedStrategy.OpenerRangedCast => (IsFirstGCD && away && !IsMoving, Unlocked(AID.HolySpirit) ? AID.HolySpirit : AID.ShieldLob, GCDPriority.AboveAverage - 1),
-            RangedStrategy.Opener => (IsFirstGCD, AID.ShieldLob, (GCDPriority)0),
+            RangedStrategy.Opener => (IsFirstGCD, AID.ShieldLob, GCDPriority.Low + 1),
             RangedStrategy.OpenerCast => (IsFirstGCD && !IsMoving, Unlocked(AID.HolySpirit) ? AID.HolySpirit : AID.ShieldLob, GCDPriority.AboveAverage - 1),
-            RangedStrategy.ForceCast => (true, Unlocked(AID.HolySpirit) ? AID.HolySpirit : AID.ShieldLob, GCDPriority.Forced),
             RangedStrategy.Force => (true, AID.ShieldLob, GCDPriority.Forced),
             RangedStrategy.Ranged => (away, AID.ShieldLob, GCDPriority.Low + 1),
             RangedStrategy.RangedCast => (away && !IsMoving, Unlocked(AID.HolySpirit) ? AID.HolySpirit : AID.ShieldLob, GCDPriority.AboveAverage - 1),

--- a/BossMod/Autorotation/Standard/akechi/Tank/AkechiPLD.cs
+++ b/BossMod/Autorotation/Standard/akechi/Tank/AkechiPLD.cs
@@ -10,9 +10,9 @@ public sealed class AkechiPLD(RotationModuleManager manager, Actor player) : Ake
     public enum AOEStrategy { AutoFinish, ForceSTFinish, ForceAOEFinish, AutoBreak, ForceSTBreak, ForceAOEBreak }
     public enum AtonementStrategy { Automatic, ForceAtonement, ForceSupplication, ForceSepulchre, Delay }
     public enum BladeComboStrategy { Automatic, ForceConfiteor, ForceFaith, ForceTruth, ForceValor, Delay }
-    public enum GoringBladeStrategy { Automatic, Early, Late, Force, Delay }
-    public enum HolyStrategy { Automatic, Early, Late, OnlySpirit, OnlyCircle, ForceSpirit, ForceCircle, Delay }
-    public enum DashStrategy { Automatic, Force, Force1, GapClose, GapClose1, Delay }
+    public enum GoringBladeStrategy { Automatic, Late, Force, Delay }
+    public enum HolyStrategy { Automatic, Early, Late, VeryLate, OnlySpirit, OnlyCircle, ForceSpirit, ForceCircle, Delay }
+    public enum DashStrategy { Automatic, GapClose, GapClose5, GapClose10, GapCloseOpener, Opener, Force, Delay }
     public enum BuffsStrategy { Automatic, Together, RaidBuffsOnly, Force, ForceWeave, Delay }
     public enum RangedStrategy { Automatic, OpenerRangedCast, OpenerCast, ForceCast, RangedCast, RangedCastStationary, OpenerRanged, Opener, Force, Ranged, Forbid }
 
@@ -34,73 +34,75 @@ public sealed class AkechiPLD(RotationModuleManager manager, Actor player) : Ake
             .AddAssociatedActions(AID.FastBlade, AID.RiotBlade, AID.RageOfHalone, AID.RoyalAuthority, AID.Prominence, AID.TotalEclipse);
 
         res.Define(Track.Atonement).As<AtonementStrategy>("Atones", "Atonement Combo", 155)
-            .AddOption(AtonementStrategy.Automatic, "Normal use of Atonement & its combo chain")
-            .AddOption(AtonementStrategy.ForceAtonement, "Force use of Atonement", 0, 30, ActionTargets.Hostile, 76)
-            .AddOption(AtonementStrategy.ForceSupplication, "Force use of Supplication", 0, 30, ActionTargets.Hostile, 76)
-            .AddOption(AtonementStrategy.ForceSepulchre, "Force use of Sepulchre", 0, 0, ActionTargets.Hostile, 76)
-            .AddOption(AtonementStrategy.Delay, "Delay use of Atonement & its combo chain", 0, 0, ActionTargets.None, 60)
+            .AddOption(AtonementStrategy.Automatic, "Automatically use full Atonement combo - will hold if Fight or Flight is imminent (unless Fight or Flight is user disabled)")
+            .AddOption(AtonementStrategy.ForceAtonement, "Force use of Atonement (if available)", 0, 30, ActionTargets.Hostile, 76)
+            .AddOption(AtonementStrategy.ForceSupplication, "Force use of Supplication (if available)", 0, 30, ActionTargets.Hostile, 76)
+            .AddOption(AtonementStrategy.ForceSepulchre, "Force use of Sepulchre (if available)", 0, 0, ActionTargets.Hostile, 76)
+            .AddOption(AtonementStrategy.Delay, "Do not use full Atonement combo", 0, 0, ActionTargets.None, 60)
             .AddAssociatedActions(AID.Atonement, AID.Supplication, AID.Sepulchre);
 
         res.Define(Track.BladeCombo).As<BladeComboStrategy>("Blades", "Confiteor + Blade Combo", 160)
-            .AddOption(BladeComboStrategy.Automatic, "Normal use of Confiteor & Blades combo chain")
-            .AddOption(BladeComboStrategy.ForceConfiteor, "Force use of Confiteor", 0, 0, ActionTargets.Hostile, 80)
-            .AddOption(BladeComboStrategy.ForceFaith, "Force use of Blade of Faith", 0, 0, ActionTargets.Hostile, 90)
-            .AddOption(BladeComboStrategy.ForceTruth, "Force use of Blade of Truth", 0, 0, ActionTargets.Hostile, 90)
-            .AddOption(BladeComboStrategy.ForceValor, "Force use of Blade of Valor", 0, 0, ActionTargets.Hostile, 90)
-            .AddOption(BladeComboStrategy.Delay, "Delay use of Confiteor & Blades combo chain", 0, 0, ActionTargets.None, 80)
+            .AddOption(BladeComboStrategy.Automatic, "Automatically use full Blades combo - if no blades, will use best Holy action")
+            .AddOption(BladeComboStrategy.ForceConfiteor, "Force use of Confiteor (if available)", 0, 0, ActionTargets.Hostile, 80)
+            .AddOption(BladeComboStrategy.ForceFaith, "Force use of Blade of Faith (if available)", 0, 0, ActionTargets.Hostile, 90)
+            .AddOption(BladeComboStrategy.ForceTruth, "Force use of Blade of Truth (if available)", 0, 0, ActionTargets.Hostile, 90)
+            .AddOption(BladeComboStrategy.ForceValor, "Force use of Blade of Valor (if available)", 0, 0, ActionTargets.Hostile, 90)
+            .AddOption(BladeComboStrategy.Delay, "Do not use full Blades combo", 0, 0, ActionTargets.None, 80)
             .AddAssociatedActions(AID.Confiteor, AID.BladeOfFaith, AID.BladeOfTruth, AID.BladeOfValor);
 
         res.Define(Track.FightOrFlight).As<BuffsStrategy>("FoF", "Fight or Flight", 170)
-            .AddOption(BuffsStrategy.Automatic, "Normal use Fight or Flight")
-            .AddOption(BuffsStrategy.Together, "Use Fight or Flight only with Requiescat / Imperator; will delay in attempt to align itself with Requiescat / Imperator if misaligned", 60, 20, ActionTargets.Self, 2)
-            .AddOption(BuffsStrategy.RaidBuffsOnly, "Use Fight or Flight only with raid buffs; will delay in attempt to align itself with raid buffs", 60, 20, ActionTargets.Self, 2)
-            .AddOption(BuffsStrategy.Force, "Force Fight or Flight usage", 60, 20, ActionTargets.Self, 2)
-            .AddOption(BuffsStrategy.ForceWeave, "Force Fight or Flight usage inside the next possible weave window", 60, 20, ActionTargets.Self, 2)
-            .AddOption(BuffsStrategy.Delay, "Delay Fight or Flight usage", 0, 0, ActionTargets.None, 2)
+            .AddOption(BuffsStrategy.Automatic, "Automatically use Fight or Flight on cooldown")
+            .AddOption(BuffsStrategy.Together, "Automatically use Fight or Flight only with Requiescat - will delay in attempt to align itself with Requiescat if misaligned", 60, 20, ActionTargets.Self, 2)
+            .AddOption(BuffsStrategy.RaidBuffsOnly, "Automatically use Fight or Flight only with raid buffs - will delay in attempt to align itself with raid buffs", 60, 20, ActionTargets.Self, 2)
+            .AddOption(BuffsStrategy.Force, "Force use of Fight or Flight (if available)", 60, 20, ActionTargets.Self, 2)
+            .AddOption(BuffsStrategy.ForceWeave, "Force use of Fight or Flight inside the next possible weave window (if available)", 60, 20, ActionTargets.Self, 2)
+            .AddOption(BuffsStrategy.Delay, "Do not use Fight or Flight", 0, 0, ActionTargets.None, 2)
             .AddAssociatedActions(AID.FightOrFlight);
 
         res.Define(Track.Requiescat).As<BuffsStrategy>("Req.", "Requiescat", 165)
-            .AddOption(BuffsStrategy.Automatic, "Use Requiescat / Imperator normally")
-            .AddOption(BuffsStrategy.Together, "Use Requiescat / Imperator only with Fight or Flight; will delay in attempt to align itself with Fight or Flight", 60, 20, ActionTargets.Self, 68)
-            .AddOption(BuffsStrategy.RaidBuffsOnly, "Use Requiescat / Imperator only with raid buffs; will delay in attempt to align itself with raid buffs", 180, 20, ActionTargets.Self, 68)
-            .AddOption(BuffsStrategy.Force, "Force Requiescat / Imperator usage", 180, 20, ActionTargets.Self, 68)
-            .AddOption(BuffsStrategy.ForceWeave, "Force Requiescat / Imperator usage inside the next possible weave window", 180, 20, ActionTargets.Self, 68)
-            .AddOption(BuffsStrategy.Delay, "Delay Requiescat / Imperator usage", 0, 0, ActionTargets.None, 68)
+            .AddOption(BuffsStrategy.Automatic, "Automatically use Requiescat on cooldown")
+            .AddOption(BuffsStrategy.Together, "Automatically use Requiescat only with Fight or Flight - will delay in attempt to align itself with Fight or Flight", 60, 20, ActionTargets.Self, 68)
+            .AddOption(BuffsStrategy.RaidBuffsOnly, "Automatically use Requiescat only with raid buffs - will delay in attempt to align itself with raid buffs", 60, 20, ActionTargets.Self, 68)
+            .AddOption(BuffsStrategy.Force, "Force use of Requiescat (if available)", 60, 20, ActionTargets.Self, 68)
+            .AddOption(BuffsStrategy.ForceWeave, "Force use of Requiescat inside the next possible weave window (if available)", 60, 20, ActionTargets.Self, 68)
+            .AddOption(BuffsStrategy.Delay, "Do not use Requiescat", 0, 0, ActionTargets.None, 68)
             .AddAssociatedActions(AID.Requiescat, AID.Imperator);
 
         res.Define(Track.GoringBlade).As<GoringBladeStrategy>("GB", "Goring Blade", 135)
-            .AddOption(GoringBladeStrategy.Automatic, "Normal use of Goring Blade")
-            .AddOption(GoringBladeStrategy.Early, "Use Goring Blade before spending Requiescat stacks", 0, 0, ActionTargets.Hostile, 68)
-            .AddOption(GoringBladeStrategy.Late, "Use Goring Blade after spending Requiescat stacks", 0, 0, ActionTargets.Hostile, 68)
-            .AddOption(GoringBladeStrategy.Force, "Force use of Goring Blade", 0, 0, ActionTargets.Hostile, 54)
-            .AddOption(GoringBladeStrategy.Delay, "Delay use of Goring Blade", 0, 0, ActionTargets.None, 54)
+            .AddOption(GoringBladeStrategy.Automatic, "Automatically use Goring Blade as soon as possible when in burst")
+            .AddOption(GoringBladeStrategy.Late, "Automatically use Goring Blade after spending Requiescat stacks in burst (or if status is expiring)", 0, 0, ActionTargets.Hostile, 68)
+            .AddOption(GoringBladeStrategy.Force, "Force use of Goring Blade (if available)", 0, 0, ActionTargets.Hostile, 54)
+            .AddOption(GoringBladeStrategy.Delay, "Do not use Goring Blade", 0, 0, ActionTargets.None, 54)
             .AddAssociatedActions(AID.GoringBlade);
 
-        res.Define(Track.Holy).As<HolyStrategy>("Holy", "Holy Spirit / Circle", 150)
-            .AddOption(HolyStrategy.Automatic, "Automatically choose best Holy action under Divine Might based on targets")
-            .AddOption(HolyStrategy.Early, "Use best Holy action under Divine Might ASAP", 0, 0, ActionTargets.Hostile, 68)
-            .AddOption(HolyStrategy.Late, "Use best Holy action under Divine Might after Atonement combo (or if nothing else left)", 0, 0, ActionTargets.Hostile, 68)
-            .AddOption(HolyStrategy.OnlySpirit, "Only use Holy Spirit as optimal Holy action", 0, 0, ActionTargets.Hostile, 64)
-            .AddOption(HolyStrategy.OnlyCircle, "Only use Holy Circle as optimal Holy action", 0, 0, ActionTargets.Hostile, 72)
-            .AddOption(HolyStrategy.ForceSpirit, "Force use of Holy Spirit", 0, 0, ActionTargets.Hostile, 64)
-            .AddOption(HolyStrategy.ForceCircle, "Force use of Holy Circle", 0, 0, ActionTargets.Hostile, 72)
-            .AddOption(HolyStrategy.Delay, "Delay use of Holy actions", 0, 0, ActionTargets.None, 64)
+        res.Define(Track.Holy).As<HolyStrategy>("Holy", "(Divine Might) Holy Spirit/Circle", 150)
+            .AddOption(HolyStrategy.Automatic, "Automatically choose best Divine Might Holy action based on targets")
+            .AddOption(HolyStrategy.Early, "Automatically choose best Divine Might Holy action as soon as possible", 0, 0, ActionTargets.Hostile, 68)
+            .AddOption(HolyStrategy.Late, "Automatically choose best Divine Might Holy action after Atonement combo (or if nothing else left to use)", 0, 0, ActionTargets.Hostile, 68)
+            .AddOption(HolyStrategy.VeryLate, "Automatically choose best Divine Might Holy action at the very last possible moment (right before next Atonement)", 0, 0, ActionTargets.Hostile, 68)
+            .AddOption(HolyStrategy.OnlySpirit, "Only use Holy Spirit as best Divine Might Holy action", 0, 0, ActionTargets.Hostile, 64)
+            .AddOption(HolyStrategy.OnlyCircle, "Only use Holy Circle as best Divine Might Holy action", 0, 0, ActionTargets.Hostile, 72)
+            .AddOption(HolyStrategy.ForceSpirit, "Force use of raw or buffed Holy Spirit (if available)", 0, 0, ActionTargets.Hostile, 64)
+            .AddOption(HolyStrategy.ForceCircle, "Force use of raw or buffed Holy Circle (if available)", 0, 0, ActionTargets.Hostile, 72)
+            .AddOption(HolyStrategy.Delay, "Do not use any Holy actions under Divine Might", 0, 0, ActionTargets.None, 64)
             .AddAssociatedActions(AID.HolySpirit, AID.HolyCircle);
 
         res.Define(Track.Dash).As<DashStrategy>("Dash", "Intervene", 95)
-            .AddOption(DashStrategy.Automatic, "Normal use of Intervene")
+            .AddOption(DashStrategy.Automatic, "Automatically use both Intervene charges when in burst, not moving, & safely inside melee range")
+            .AddOption(DashStrategy.GapClose, "Automatically use Intervene as gap closer if outside melee range", 30, 0, ActionTargets.Hostile, 66)
+            .AddOption(DashStrategy.GapClose5, "Automatically use Intervene as gap closer if further than five yalms", 30, 0, ActionTargets.Hostile, 66)
+            .AddOption(DashStrategy.GapClose10, "Automatically use Intervene as gap closer if further than ten yalms", 30, 0, ActionTargets.Hostile, 66)
+            .AddOption(DashStrategy.GapCloseOpener, "Automatically use Intervene as gap closer at the start of combat if out of melee range", 30, 0, ActionTargets.Hostile, 66)
+            .AddOption(DashStrategy.Opener, "Automatically use Intervene at the start of combat, regardless of range", 30, 0, ActionTargets.Hostile, 66)
             .AddOption(DashStrategy.Force, "Force use of Intervene", 30, 0, ActionTargets.Hostile, 66)
-            .AddOption(DashStrategy.Force1, "Force use of Intervene; Hold one charge for manual usage", 30, 0, ActionTargets.Hostile, 66)
-            .AddOption(DashStrategy.GapClose, "Use as gap closer if outside melee range", 30, 0, ActionTargets.None, 66)
-            .AddOption(DashStrategy.GapClose1, "Use as gap closer if outside melee range; Hold one charge for manual usage", 30, 0, ActionTargets.None, 66)
-            .AddOption(DashStrategy.Delay, "Delay use of Intervene", 0, 0, ActionTargets.None, 66)
+            .AddOption(DashStrategy.Delay, "Do not use Intervene", 0, 0, ActionTargets.None, 66)
             .AddAssociatedActions(AID.Intervene);
 
         res.Define(Track.Ranged).As<RangedStrategy>("Ranged", "Shield Lob / Holy Spirit", 100)
-            .AddOption(RangedStrategy.Automatic, "Uses Holy Spirit when stationary; Uses Shield Lob if moving")
-            .AddOption(RangedStrategy.OpenerRangedCast, "Use Holy Spirit at the start of combat if outside melee range", 0, 0, ActionTargets.Hostile, 64)
-            .AddOption(RangedStrategy.OpenerCast, "Use Holy Spirit at the start of combat regardless of range", 0, 0, ActionTargets.Hostile, 64)
-            .AddOption(RangedStrategy.ForceCast, "Force use of Holy Spirit", 0, 0, ActionTargets.Hostile, 64)
+            .AddOption(RangedStrategy.Automatic, "Automatically use Holy Spirit if stationary or use Shield Lob if moving")
+            .AddOption(RangedStrategy.OpenerRangedCast, "Automatically use Holy Spirit at the start of combat if outside melee range", 0, 0, ActionTargets.Hostile, 64)
+            .AddOption(RangedStrategy.OpenerCast, "Automatically use Holy Spirit at the start of combat regardless of range", 0, 0, ActionTargets.Hostile, 64)
+            .AddOption(RangedStrategy.ForceCast, "Force use of Holy Spirit", 0, 0, ActionTargets.Hostile, 64) //TODO: remove this option - dupe
             .AddOption(RangedStrategy.RangedCast, "Use Holy Spirit as ranged choice if outside melee range", 0, 0, ActionTargets.Hostile, 64)
             .AddOption(RangedStrategy.RangedCastStationary, "Use Holy Spirit as ranged choice if outside melee range and stationary", 0, 0, ActionTargets.Hostile, 64)
             .AddOption(RangedStrategy.OpenerRanged, "Use Shield Lob at the start of combat if outside melee range", 0, 0, ActionTargets.Hostile, 15)
@@ -117,34 +119,44 @@ public sealed class AkechiPLD(RotationModuleManager manager, Actor player) : Ake
         return res;
     }
 
-    private int BladeComboStep;
-    private (float Left, bool IsActive) DivineMight;
-    private (float CD, float Left, bool IsReady, bool IsActive) FightOrFlight;
-    private (float CD, float Left, bool IsReady, bool IsActive) GoringBlade;
-    private (float TotalCD, int Charges, bool IsReady) Intervene;
-    private (float CD, float Left, bool IsReady, bool IsActive) Requiescat;
-    private (float Left, bool IsReady, bool IsActive) Atonement;
-    private (float Left, bool IsReady, bool IsActive) Supplication;
-    private (float Left, bool IsReady, bool IsActive) Sepulchre;
-    private (float Left, bool HasMP, bool IsReady, bool IsActive) Confiteor;
-    private (float Left, bool IsReady, bool IsActive) BladeOfHonor;
-    private bool WantAOE;
     private bool Opener;
-    private int NumSplashTargets;
-    private Enemy? BestSplashTargets;
-    private Enemy? BestSplashTarget;
-    private bool ForceAOE;
 
+    private PaladinGauge Gauge => World.Client.GetGauge<PaladinGauge>();
+    private int BladeComboStep => Gauge.ConfiteorComboStep;
+    private float FOFstatus => Status(SID.FightOrFlight, 30);
+    private float FOFcd => Cooldown(AID.FightOrFlight);
+    private float REQstatus => Status(SID.Requiescat, 30);
+    private float GBstatus => Status(SID.GoringBladeReady, 30);
+    private float DMstatus => Status(SID.DivineMight, 30);
+    private float ATOstatus => Status(SID.AtonementReady, 30);
+    private float SUPstatus => Status(SID.SupplicationReady, 30);
+    private float SEPstatus => Status(SID.SepulchreReady, 30);
+    private float CONFstatus => Status(SID.ConfiteorReady, 30);
     private AID BestSpirits => Unlocked(AID.Expiacion) ? AID.Expiacion : AID.SpiritsWithin;
     private AID BestRequiescat => Unlocked(AID.Imperator) ? AID.Imperator : AID.Requiescat;
     private AID BestHolyCircle => Unlocked(AID.HolyCircle) ? AID.HolyCircle : AID.HolySpirit;
+    private AID BestEnder => Unlocked(AID.RoyalAuthority) ? AID.RoyalAuthority : Unlocked(AID.RageOfHalone) ? AID.RageOfHalone : AID.FastBlade;
 
+    private AID NextSTCombo(bool finish) => LastComboAction switch
+    {
+        AID.RiotBlade => finish && Unlocked(BestEnder) ? BestEnder : AID.FastBlade,
+        AID.FastBlade => Unlocked(AID.RiotBlade) ? AID.RiotBlade : AID.FastBlade,
+        AID.TotalEclipse => finish && Unlocked(AID.Prominence) ? AID.Prominence : AID.FastBlade,
+        _ => AID.FastBlade
+    };
+    private AID NextAOECombo(bool finish) => LastComboAction switch
+    {
+        AID.TotalEclipse => finish && Unlocked(AID.Prominence) ? AID.Prominence : AID.TotalEclipse,
+        AID.RiotBlade => finish && Unlocked(BestEnder) ? BestEnder : AID.TotalEclipse,
+        AID.FastBlade => Unlocked(AID.RiotBlade) ? AID.RiotBlade : AID.TotalEclipse,
+        _ => AID.TotalEclipse
+    };
     private (bool, OGCDPriority) ShouldBuffUp(BuffsStrategy strategy, Actor? target, bool ready, bool together)
     {
         if (!ready)
             return (false, OGCDPriority.None);
 
-        var minimal = Player.InCombat && target != null && In3y(target) && MP >= 4000;
+        var minimal = InCombat(target) && MP >= 4000 && (Unlocked(AID.Imperator) ? In25y(target) : In3y(target));
         return strategy switch
         {
             BuffsStrategy.Automatic => (minimal && Opener, OGCDPriority.Severe),
@@ -156,94 +168,41 @@ public sealed class AkechiPLD(RotationModuleManager manager, Actor player) : Ake
     }
     private bool ShouldUsePotion(StrategyValues strategy) => strategy.Potion() switch
     {
-        PotionStrategy.AlignWithBuffs => Player.InCombat && FightOrFlight.CD <= 4f,
+        PotionStrategy.AlignWithBuffs => Player.InCombat && FOFcd <= 4f,
         PotionStrategy.AlignWithRaidBuffs => Player.InCombat && (RaidBuffsIn <= 5000 || RaidBuffsLeft > 0),
         PotionStrategy.Immediate => true,
         _ => false
     };
-    private AID BestEnder => Unlocked(AID.RoyalAuthority) ? AID.RoyalAuthority : Unlocked(AID.RageOfHalone) ? AID.RageOfHalone : AID.FastBlade;
 
     public override void Execution(StrategyValues strategy, Enemy? primaryTarget)
     {
-        var gauge = World.Client.GetGauge<PaladinGauge>();
-        BladeComboStep = gauge.ConfiteorComboStep;
-        DivineMight.Left = Status(SID.DivineMight, 30);
-        DivineMight.IsActive = DivineMight.Left > 0f;
-        FightOrFlight.CD = Cooldown(AID.FightOrFlight);
-        FightOrFlight.Left = Status(SID.FightOrFlight, 20);
-        FightOrFlight.IsActive = FightOrFlight.CD is >= 39.5f and <= 60;
-        FightOrFlight.IsReady = ActionReady(AID.FightOrFlight);
-        GoringBlade.Left = Status(SID.GoringBladeReady, 30);
-        GoringBlade.IsActive = GoringBlade.Left > 0f;
-        GoringBlade.IsReady = Unlocked(AID.GoringBlade) && GoringBlade.IsActive;
-        Intervene.TotalCD = Cooldown(AID.Intervene);
-        Intervene.Charges = Intervene.TotalCD <= 2f ? 2 : Intervene.TotalCD is <= 31f and > 2f ? 1 : 0;
-        Intervene.IsReady = Unlocked(AID.Intervene) && Intervene.Charges > 0;
-        Requiescat.CD = Cooldown(BestRequiescat);
-        Requiescat.Left = Status(SID.Requiescat, 30);
-        Requiescat.IsActive = Requiescat.Left > 0;
-        Requiescat.IsReady = Unlocked(AID.Requiescat) && Requiescat.CD < 0.6f;
-        Atonement.Left = Status(SID.AtonementReady, 30);
-        Atonement.IsActive = Atonement.Left > 0;
-        Atonement.IsReady = Unlocked(AID.Atonement) && Atonement.IsActive;
-        Supplication.Left = Status(SID.SupplicationReady, 30);
-        Supplication.IsActive = Supplication.Left > 0;
-        Supplication.IsReady = Unlocked(AID.Supplication) && Supplication.IsActive;
-        Sepulchre.Left = Status(SID.SepulchreReady, 30);
-        Sepulchre.IsActive = Sepulchre.Left > 0;
-        Sepulchre.IsReady = Unlocked(AID.Sepulchre) && Sepulchre.IsActive;
-        Confiteor.Left = Status(SID.ConfiteorReady, 30);
-        Confiteor.IsActive = Confiteor.Left > 0;
-        Confiteor.IsReady = Unlocked(AID.Confiteor) && Confiteor.IsActive && MP >= 1000;
-        BladeOfHonor.Left = Status(SID.BladeOfHonorReady, 30);
-        BladeOfHonor.IsActive = BladeOfHonor.Left > 0;
-        BladeOfHonor.IsReady = Unlocked(AID.BladeOfHonor) && BladeOfHonor.IsActive;
-        WantAOE = TargetsInAOECircle(5f, 3) || ForceAOE;
-        (BestSplashTargets, NumSplashTargets) = GetBestTarget(primaryTarget, 25, IsSplashTarget);
-        BestSplashTarget = Unlocked(AID.Confiteor) && NumSplashTargets > 1 ? BestSplashTargets : primaryTarget;
-        Opener = CombatTimer <= 10 ? ComboLastMove == AID.RoyalAuthority : ComboTimer > 10;
+        Opener = CombatTimer <= 10 ? LastComboAction == AID.RoyalAuthority : ComboTimer > 10;
+        var bladesTarget = GetBestTarget(primaryTarget, 25, IsSplashTarget).Best?.Actor;
         var mainTarget = primaryTarget?.Actor;
 
         if (strategy.HoldEverything())
             return;
 
+        GetNextTarget(strategy, ref primaryTarget, 3);
+        GoalZoneCombined(strategy, 3, Hints.GoalAOECircle(5), AID.TotalEclipse, 3, maximumActionRange: 20);
+
         var aoe = strategy.Option(Track.AOE);
         var aoeStrat = aoe.As<AOEStrategy>();
-        ForceAOE = aoeStrat is AOEStrategy.ForceAOEFinish or AOEStrategy.ForceAOEBreak;
-        var stFinish = ComboLastMove switch
-        {
-            AID.TotalEclipse => Unlocked(AID.Prominence) ? AID.Prominence : AID.FastBlade,
-            AID.RiotBlade => Unlocked(BestEnder) ? BestEnder : AID.FastBlade,
-            AID.FastBlade => Unlocked(AID.RiotBlade) ? AID.RiotBlade : AID.FastBlade,
-            _ => AID.FastBlade,
-        };
-        var stBreak = ComboLastMove switch
-        {
-            AID.RiotBlade => Unlocked(BestEnder) ? BestEnder : AID.FastBlade,
-            AID.FastBlade => Unlocked(AID.RiotBlade) ? AID.RiotBlade : AID.FastBlade,
-            _ => AID.FastBlade,
-        };
-        var aoeFinish = ComboLastMove switch
-        {
-            AID.RiotBlade => Unlocked(BestEnder) ? BestEnder : AID.TotalEclipse,
-            AID.FastBlade => Unlocked(AID.RiotBlade) ? AID.RiotBlade : AID.TotalEclipse,
-            AID.TotalEclipse => Unlocked(AID.Prominence) ? AID.Prominence : AID.TotalEclipse,
-            _ => AID.TotalEclipse,
-        };
-        var aoeBreak = (ComboLastMove is AID.TotalEclipse && Unlocked(AID.Prominence)) ? AID.Prominence : AID.TotalEclipse;
+        var forceAOE = aoeStrat is AOEStrategy.ForceAOEFinish or AOEStrategy.ForceAOEBreak;
+        var wantAOE = TargetsInAOECircle(5f, 3) || forceAOE;
         var stTarget = SingleTargetChoice(mainTarget, aoe);
-        var autoTarget = WantAOE ? Player : stTarget;
+        var autoTarget = wantAOE ? Player : stTarget;
         var (aoeAction, aoeTarget) = aoeStrat switch
         {
-            AOEStrategy.AutoFinish => (WantAOE ? aoeFinish : stFinish, autoTarget),
-            AOEStrategy.ForceSTFinish => (stFinish, stTarget),
-            AOEStrategy.ForceAOEFinish => (aoeFinish, Player),
-            AOEStrategy.AutoBreak => (WantAOE ? aoeBreak : stBreak, autoTarget),
-            AOEStrategy.ForceSTBreak => (stBreak, stTarget),
-            AOEStrategy.ForceAOEBreak => (aoeBreak, Player),
+            AOEStrategy.AutoFinish => (wantAOE ? NextAOECombo(true) : NextSTCombo(true), autoTarget),
+            AOEStrategy.AutoBreak => (wantAOE ? NextAOECombo(false) : NextSTCombo(false), autoTarget),
+            AOEStrategy.ForceSTFinish => (NextSTCombo(true), stTarget),
+            AOEStrategy.ForceSTBreak => (NextSTCombo(false), stTarget),
+            AOEStrategy.ForceAOEFinish => (NextAOECombo(true), Player),
+            AOEStrategy.ForceAOEBreak => (NextAOECombo(false), Player),
             _ => (AID.None, null)
         };
-        if ((WantAOE ? In5y(aoeTarget) : In3y(aoeTarget)) && aoeTarget != null)
+        if (aoeTarget != null && (wantAOE ? In5y(aoeTarget) : In3y(aoeTarget)))
             QueueGCD(aoeAction, aoeTarget, GCDPriority.Low);
 
         var fof = strategy.Option(Track.FightOrFlight);
@@ -254,26 +213,27 @@ public sealed class AkechiPLD(RotationModuleManager manager, Actor player) : Ake
             {
                 if (!strategy.HoldBuffs())
                 {
-                    var (fofCondition, fofPrio) = ShouldBuffUp(fofStrat, mainTarget, FightOrFlight.IsReady, Requiescat.CD < 1f);
+                    var (fofCondition, fofPrio) = ShouldBuffUp(fofStrat, mainTarget, ActionReady(AID.FightOrFlight), Cooldown(BestRequiescat) < 1f);
                     if (fofCondition)
                         QueueOGCD(AID.FightOrFlight, Player, fofPrio);
 
                     var req = strategy.Option(Track.Requiescat);
                     var reqStrat = req.As<BuffsStrategy>();
-                    var (reqCondition, reqPrio) = ShouldBuffUp(reqStrat, mainTarget, Requiescat.IsReady, FightOrFlight.CD > 55f);
+                    var reqTarget = SingleTargetChoice(mainTarget, req);
+                    var (reqCondition, reqPrio) = ShouldBuffUp(reqStrat, mainTarget, ActionReady(BestRequiescat), FOFcd > 55f);
                     if (reqCondition)
-                        QueueOGCD(BestRequiescat, SingleTargetChoice(mainTarget, req), reqPrio);
+                        QueueOGCD(BestRequiescat, reqTarget, reqPrio);
                 }
 
                 var cos = strategy.Option(Track.CircleOfScorn);
                 var cosStrat = cos.As<OGCDStrategy>();
-                if (ShouldUseOGCD(cosStrat, mainTarget, ActionReady(AID.CircleOfScorn), In5y(mainTarget) && FightOrFlight.CD is < 57.55f and > 12))
+                if (ShouldUseOGCD(cosStrat, mainTarget, ActionReady(AID.CircleOfScorn), In5y(mainTarget) && FOFcd is < 57.55f and > 12))
                     QueueOGCD(AID.CircleOfScorn, Player, OGCDPrio(cosStrat, OGCDPriority.AboveAverage));
 
                 var sw = strategy.Option(Track.SpiritsWithin);
                 var swStrat = sw.As<OGCDStrategy>();
                 var swTarget = SingleTargetChoice(mainTarget, sw);
-                if (ShouldUseOGCD(swStrat, swTarget, ActionReady(BestSpirits), In3y(swTarget) && FightOrFlight.CD is < 57.55f and > 12))
+                if (ShouldUseOGCD(swStrat, swTarget, ActionReady(BestSpirits), In3y(swTarget) && FOFcd is < 57.55f and > 12))
                     QueueOGCD(BestSpirits, swTarget, OGCDPrio(swStrat, OGCDPriority.Average));
 
                 var dash = strategy.Option(Track.Dash);
@@ -281,11 +241,13 @@ public sealed class AkechiPLD(RotationModuleManager manager, Actor player) : Ake
                 var dashTarget = SingleTargetChoice(mainTarget, dash);
                 var (dashCondition, dashPrio) = dashStrat switch
                 {
-                    DashStrategy.Automatic => (Player.InCombat && dashTarget != null && !IsMoving && In3y(dashTarget) && Intervene.IsReady && FightOrFlight.IsActive, OGCDPriority.SlightlyLow),
-                    DashStrategy.Force => (true, OGCDPriority.Forced),
-                    DashStrategy.Force1 => (Intervene.TotalCD < 1f, OGCDPriority.Forced),
+                    DashStrategy.Automatic => (InCombat(dashTarget) && !IsMoving && In3y(dashTarget) && ReadyIn(AID.Intervene) <= 0.5f && HasStatus(SID.FightOrFlight), OGCDPriority.SlightlyLow),
+                    DashStrategy.Force => (!LastActionUsed(AID.Intervene), OGCDPriority.Forced),
                     DashStrategy.GapClose => (!In3y(dashTarget), OGCDPriority.SlightlyLow),
-                    DashStrategy.GapClose1 => (Intervene.TotalCD < 1f && !In3y(dashTarget), OGCDPriority.SlightlyLow),
+                    DashStrategy.GapClose5 => (!In5y(dashTarget), OGCDPriority.SlightlyLow),
+                    DashStrategy.GapClose10 => (!In10y(dashTarget), OGCDPriority.SlightlyLow),
+                    DashStrategy.GapCloseOpener => (IsFirstGCD && !In3y(dashTarget), OGCDPriority.SlightlyLow),
+                    DashStrategy.Opener => (IsFirstGCD, OGCDPriority.SlightlyLow),
                     _ => (false, OGCDPriority.None)
                 };
                 if (dashCondition)
@@ -294,18 +256,18 @@ public sealed class AkechiPLD(RotationModuleManager manager, Actor player) : Ake
 
             var boh = strategy.Option(Track.BladeOfHonor);
             var bohStrat = boh.As<OGCDStrategy>();
-            var bohTarget = AOETargetChoice(mainTarget, BestSplashTarget?.Actor, boh, strategy);
-            if (ShouldUseOGCD(bohStrat, bohTarget, BladeOfHonor.IsReady))
+            var bohTarget = AOETargetChoice(mainTarget, bladesTarget, boh, strategy);
+            if (ShouldUseOGCD(bohStrat, bohTarget, HasStatus(SID.BladeOfHonorReady)))
                 QueueOGCD(AID.BladeOfHonor, bohTarget, OGCDPrio(bohStrat, OGCDPriority.Low));
 
             var gb = strategy.Option(Track.GoringBlade);
             var gbStrat = gb.As<GoringBladeStrategy>();
             var gbTarget = SingleTargetChoice(mainTarget, gb);
-            var gbMinimum = gbTarget != null && In3y(gbTarget) && GoringBlade.IsReady;
+            var gbMinimum = gbTarget != null && In3y(gbTarget) && GBstatus > GCD;
             var (gbCondition, gbPrio) = gbStrat switch
             {
-                GoringBladeStrategy.Automatic or GoringBladeStrategy.Early => (true, GCDPriority.High),
-                GoringBladeStrategy.Late => (!Requiescat.IsActive && GoringBlade.Left is < 25f and not 0f, GCDPriority.SlightlyHigh),
+                GoringBladeStrategy.Automatic => (true, GCDPriority.High),
+                GoringBladeStrategy.Late => (REQstatus <= GCD && GBstatus is < 25f and not 0f, GCDPriority.SlightlyHigh),
                 GoringBladeStrategy.Force => (true, GCDPriority.Forced),
                 _ => (false, GCDPriority.None)
             };
@@ -318,13 +280,13 @@ public sealed class AkechiPLD(RotationModuleManager manager, Actor player) : Ake
 
         var boftv = strategy.Option(Track.BladeCombo);
         var boftvStrat = boftv.As<BladeComboStrategy>();
-        var boftvTarget = AOETargetChoice(mainTarget, BestSplashTarget?.Actor, boftv, strategy);
-        var boftvBest = BladeComboStep == 3 ? AID.BladeOfValor : BladeComboStep == 2 ? AID.BladeOfTruth : BladeComboStep == 1 && Unlocked(AID.BladeOfFaith) ? AID.BladeOfFaith : Confiteor.IsReady ? AID.Confiteor : WantAOE ? BestHolyCircle : AID.HolySpirit;
+        var boftvTarget = AOETargetChoice(mainTarget, bladesTarget, boftv, strategy);
+        var boftvBest = BladeComboStep == 3 ? AID.BladeOfValor : BladeComboStep == 2 ? AID.BladeOfTruth : BladeComboStep == 1 && Unlocked(AID.BladeOfFaith) ? AID.BladeOfFaith : CONFstatus > GCD ? AID.Confiteor : wantAOE ? BestHolyCircle : AID.HolySpirit;
         var boftvMinimum = boftvTarget != null && In25y(boftvTarget);
         var (boftvCondition, boftvAction, boftvPrio) = boftvStrat switch
         {
-            BladeComboStrategy.Automatic => (Requiescat.IsActive && BladeComboStep is 0 or 1 or 2 or 3, boftvBest, GCDPriority.ModeratelyHigh),
-            BladeComboStrategy.ForceConfiteor => (Confiteor.IsReady && BladeComboStep is 0, AID.Confiteor, GCDPriority.Forced),
+            BladeComboStrategy.Automatic => (REQstatus > GCD && BladeComboStep is 0 or 1 or 2 or 3, boftvBest, GCDPriority.ModeratelyHigh),
+            BladeComboStrategy.ForceConfiteor => (Unlocked(AID.Confiteor) && CONFstatus > GCD && BladeComboStep is 0, AID.Confiteor, GCDPriority.Forced),
             BladeComboStrategy.ForceFaith => (BladeComboStep is 1, AID.BladeOfFaith, GCDPriority.Forced),
             BladeComboStrategy.ForceTruth => (BladeComboStep is 2, AID.BladeOfTruth, GCDPriority.Forced),
             BladeComboStrategy.ForceValor => (BladeComboStep is 3, AID.BladeOfValor, GCDPriority.Forced),
@@ -333,23 +295,23 @@ public sealed class AkechiPLD(RotationModuleManager manager, Actor player) : Ake
         if (boftvMinimum && boftvCondition)
             QueueGCD(boftvAction, boftvTarget, boftvPrio);
 
-        var buffActive = DivineMight.IsActive || Atonement.IsActive || Supplication.IsActive || Sepulchre.IsActive;
-        var dmacSkipHold = ComboLastMove is AID.RiotBlade && FightOrFlight.CD < 0.6f;
+        var buffActive = DMstatus > GCD || ATOstatus > GCD || SUPstatus > GCD || SEPstatus > GCD;
+        var dmacSkipHold = LastComboAction is AID.RiotBlade && FOFcd > GCD;
         var dmacHold = fofStrat != BuffsStrategy.Delay && !strategy.HoldBuffs() && buffActive && !dmacSkipHold &&
-            ((ComboLastMove is AID.RoyalAuthority ? !CanFitSkSGCD(FightOrFlight.CD, 2) : ComboLastMove is AID.FastBlade ? !CanFitSkSGCD(FightOrFlight.CD, 1) : ComboLastMove is AID.RiotBlade && !CanFitSkSGCD(FightOrFlight.CD)) ||
+            ((LastComboAction is AID.RoyalAuthority ? !CanFitSkSGCD(FOFcd, 2) : LastComboAction is AID.FastBlade ? !CanFitSkSGCD(FOFcd, 1) : LastComboAction is AID.RiotBlade && !CanFitSkSGCD(FOFcd)) ||
             dmacSkipHold);
 
         var atone = strategy.Option(Track.Atonement);
         var atoneStrat = atone.As<AtonementStrategy>();
         var aTarget = SingleTargetChoice(mainTarget, atone);
-        var aMinimum = aTarget != null && In3y(aTarget) && !dmacHold && (Atonement.IsReady || Supplication.IsReady || Sepulchre.IsReady);
-        var bestAtonement = Sepulchre.IsReady ? AID.Sepulchre : Supplication.IsReady ? AID.Supplication : AID.Atonement;
+        var aMinimum = aTarget != null && In3y(aTarget) && !dmacHold && (ATOstatus > GCD || SUPstatus > GCD || SEPstatus > GCD);
+        var bestAtonement = SEPstatus > GCD ? AID.Sepulchre : SUPstatus > GCD ? AID.Supplication : AID.Atonement;
         var (aCondition, aAction, aPriority) = atoneStrat switch
         {
             AtonementStrategy.Automatic => (aMinimum, bestAtonement, GCDPriority.AboveAverage),
-            AtonementStrategy.ForceAtonement => (Atonement.IsReady, AID.Atonement, GCDPriority.Forced),
-            AtonementStrategy.ForceSupplication => (Supplication.IsReady, AID.Supplication, GCDPriority.Forced),
-            AtonementStrategy.ForceSepulchre => (Sepulchre.IsReady, AID.Sepulchre, GCDPriority.Forced),
+            AtonementStrategy.ForceAtonement => (ATOstatus > GCD, AID.Atonement, GCDPriority.Forced),
+            AtonementStrategy.ForceSupplication => (SUPstatus > GCD, AID.Supplication, GCDPriority.Forced),
+            AtonementStrategy.ForceSepulchre => (SEPstatus > GCD, AID.Sepulchre, GCDPriority.Forced),
             _ => (false, AID.None, GCDPriority.None)
         };
         if (aMinimum && aCondition)
@@ -357,9 +319,9 @@ public sealed class AkechiPLD(RotationModuleManager manager, Actor player) : Ake
 
         var dmh = strategy.Option(Track.Holy);
         var dmhStrat = dmh.As<HolyStrategy>();
-        var usedmhAOE = dmhStrat is HolyStrategy.OnlyCircle or HolyStrategy.ForceCircle || WantAOE;
+        var usedmhAOE = dmhStrat is HolyStrategy.OnlyCircle or HolyStrategy.ForceCircle || wantAOE;
         var dmhTarget = usedmhAOE ? Player : SingleTargetChoice(mainTarget, dmh);
-        var dmhMinimum = dmhTarget != null && DivineMight.IsActive && !dmacHold;
+        var dmhMinimum = dmhTarget != null && DMstatus > GCD && !dmacHold;
         var hsMinimum = Unlocked(AID.HolySpirit) && In25y(dmhTarget) && dmhMinimum;
         var hcMinimum = Unlocked(AID.HolyCircle) && In5y(dmhTarget) && dmhMinimum;
         var bestHoly = usedmhAOE ? BestHolyCircle : AID.HolySpirit;
@@ -368,6 +330,7 @@ public sealed class AkechiPLD(RotationModuleManager manager, Actor player) : Ake
             HolyStrategy.Automatic => (hsMinimum, bestHoly, GCDPriority.AboveAverage - 1),
             HolyStrategy.Early => (hsMinimum, bestHoly, GCDPriority.AboveAverage + 1),
             HolyStrategy.Late => (hsMinimum, bestHoly, GCDPriority.AboveAverage - 1),
+            HolyStrategy.VeryLate => (Unlocked(AID.HolySpirit) && In25y(dmhTarget) && dmhTarget != null && DMstatus > GCD && (LastComboAction is AID.RiotBlade || DMstatus < 3), bestHoly, GCDPriority.AboveAverage - 2),
             HolyStrategy.OnlySpirit => (hsMinimum, AID.HolySpirit, GCDPriority.AboveAverage - 1),
             HolyStrategy.OnlyCircle => (hcMinimum, AID.HolyCircle, GCDPriority.AboveAverage - 1),
             HolyStrategy.ForceSpirit => (hsMinimum, AID.HolySpirit, GCDPriority.Forced),
@@ -376,30 +339,28 @@ public sealed class AkechiPLD(RotationModuleManager manager, Actor player) : Ake
         };
         if (dmhCondition)
         {
-            var lastsecbuff = (fofStrat != BuffsStrategy.Delay && FightOrFlight.Left is <= 2.5f and >= 0.01f && !Supplication.IsActive && !Sepulchre.IsActive) || DivineMight.Left is <= 2.5f and > 0f;
+            var lastsecbuff = (fofStrat != BuffsStrategy.Delay && FOFstatus is <= 2.5f and >= 0.01f && SUPstatus <= GCD && SEPstatus <= GCD) || DMstatus is <= 2.5f and > 0f;
             QueueGCD(dmhAction, dmhTarget, lastsecbuff ? GCDPriority.SlightlyHigh : dmhPrio);
         }
 
         var r = strategy.Option(Track.Ranged);
         var rStrat = r.As<RangedStrategy>();
         var rTarget = SingleTargetChoice(mainTarget, r);
+        var away = !In3y(rTarget);
         var (rCondition, rAction, rPriority) = rStrat switch
         {
-            RangedStrategy.Automatic => (rTarget != null && !In3y(rTarget), IsMoving || MP < 1000 ? AID.ShieldLob : AID.HolySpirit, GCDPriority.Low + 1),
-            RangedStrategy.OpenerRanged => (IsFirstGCD && !In3y(rTarget), AID.ShieldLob, GCDPriority.Low + 1),
-            RangedStrategy.OpenerRangedCast => (IsFirstGCD && !In3y(rTarget) && !IsMoving, Unlocked(AID.HolySpirit) ? AID.HolySpirit : AID.ShieldLob, GCDPriority.AboveAverage - 1),
+            RangedStrategy.Automatic => (rTarget != null && away, IsMoving || MP < 1000 ? AID.ShieldLob : AID.HolySpirit, GCDPriority.Low + 1),
+            RangedStrategy.OpenerRanged => (IsFirstGCD && away, AID.ShieldLob, GCDPriority.Low + 1),
+            RangedStrategy.OpenerRangedCast => (IsFirstGCD && away && !IsMoving, Unlocked(AID.HolySpirit) ? AID.HolySpirit : AID.ShieldLob, GCDPriority.AboveAverage - 1),
             RangedStrategy.Opener => (IsFirstGCD, AID.ShieldLob, (GCDPriority)0),
             RangedStrategy.OpenerCast => (IsFirstGCD && !IsMoving, Unlocked(AID.HolySpirit) ? AID.HolySpirit : AID.ShieldLob, GCDPriority.AboveAverage - 1),
             RangedStrategy.ForceCast => (true, Unlocked(AID.HolySpirit) ? AID.HolySpirit : AID.ShieldLob, GCDPriority.Forced),
             RangedStrategy.Force => (true, AID.ShieldLob, GCDPriority.Forced),
-            RangedStrategy.Ranged => (!In3y(rTarget), AID.ShieldLob, GCDPriority.Low + 1),
-            RangedStrategy.RangedCast => (!In3y(rTarget) && !IsMoving, Unlocked(AID.HolySpirit) ? AID.HolySpirit : AID.ShieldLob, GCDPriority.AboveAverage - 1),
+            RangedStrategy.Ranged => (away, AID.ShieldLob, GCDPriority.Low + 1),
+            RangedStrategy.RangedCast => (away && !IsMoving, Unlocked(AID.HolySpirit) ? AID.HolySpirit : AID.ShieldLob, GCDPriority.AboveAverage - 1),
             _ => (false, AID.None, GCDPriority.None)
         };
         if (rCondition)
             QueueGCD(rAction, rTarget, rPriority);
-
-        GetNextTarget(strategy, ref primaryTarget, 3);
-        GoalZoneCombined(strategy, 3, Hints.GoalAOECircle(5), AID.TotalEclipse, 3, maximumActionRange: 20);
     }
 }

--- a/BossMod/Autorotation/Standard/akechi/Tank/AkechiPLD.cs
+++ b/BossMod/Autorotation/Standard/akechi/Tank/AkechiPLD.cs
@@ -219,8 +219,8 @@ public sealed class AkechiPLD(RotationModuleManager manager, Actor player) : Ake
 
                     var req = strategy.Option(Track.Requiescat);
                     var reqStrat = req.As<BuffsStrategy>();
-                    var reqTarget = SingleTargetChoice(mainTarget, req);
-                    var (reqCondition, reqPrio) = ShouldBuffUp(reqStrat, mainTarget, ActionReady(BestRequiescat), FOFcd > 55f);
+                    var reqTarget = Unlocked(AID.Imperator) ? AOETargetChoice(mainTarget, bladesTarget, req, strategy) : SingleTargetChoice(mainTarget, req);
+                    var (reqCondition, reqPrio) = ShouldBuffUp(reqStrat, reqTarget, ActionReady(BestRequiescat), FOFcd > 55f);
                     if (reqCondition)
                         QueueOGCD(BestRequiescat, reqTarget, reqPrio);
                 }


### PR DESCRIPTION
Closes #741 

- [x] Fixed issue with `Requiescat` cooldown value being incorrect in cooldown planner
- [x] Fixed issue with `Imperator` only being used while in melee range
- [x] Fixed issue with `Imperator` targeting 
- Now correctly aims for best splash target
- [x] Added `VeryLate` option to `HolyStrategy` 
- Can now use right before next Divine Might grant
- [x] Refactored options for `DashStrategy`
- `Automatic`, `>3y`,`>5y`, `>10y`, Opener only, Opener only `>3y`, overcap safely, overcap aggressively
- [x] Removed `Early` option from `GoringBladeStrategy`
- Unnecessary as `Automatic` behavior is literally the same thing
- [x] Definitions cleanup
- [x] Spaghetti cleanup