### PR TITLE
Adds edge cushion for more positional margin

### DIFF
--- a/BossMod/Autorotation/MiscAI/GoToPositional.cs
+++ b/BossMod/Autorotation/MiscAI/GoToPositional.cs
@@ -4,8 +4,11 @@ public sealed class GoToPositional(RotationModuleManager manager, Actor player) 
 {
     public enum Tracks
     {
-        Positional
+        Positional,
+        EdgeBuffer
     }
+
+    public enum EdgeBufferStrategy { None, Small, Medium, Large }
 
     public static RotationModuleDefinition Definition()
     {
@@ -17,6 +20,13 @@ public sealed class GoToPositional(RotationModuleManager manager, Actor player) 
         {
             track.AddOption(positional);
         }
+
+        def.Define(Tracks.EdgeBuffer).As<EdgeBufferStrategy>("EdgeBuffer", "Edge buffer", 20)
+            .AddOption(EdgeBufferStrategy.None, "Stand at positional edges")
+            .AddOption(EdgeBufferStrategy.Small, "Prefer staying 0.5y inside from the edges")
+            .AddOption(EdgeBufferStrategy.Medium, "Prefer staying 1.5y inside from the edges")
+            .AddOption(EdgeBufferStrategy.Large, "Prefer staying 3y inside from the edges");
+
         return def;
     }
 
@@ -43,7 +53,15 @@ public sealed class GoToPositional(RotationModuleManager manager, Actor player) 
             _ => true
         };
 
+        var cushion = strategy.Option(Tracks.EdgeBuffer).As<EdgeBufferStrategy>() switch
+        {
+            EdgeBufferStrategy.Small => 0.5f,
+            EdgeBufferStrategy.Medium => 1.5f,
+            EdgeBufferStrategy.Large => 3.0f,
+            _ => 0f
+        };
+
         Hints.RecommendedPositional = (primaryTarget, positional, true, correct);
-        Hints.GoalZones.Add(Hints.GoalSingleTarget(primaryTarget, positional));
+        Hints.GoalZones.Add(Hints.GoalSingleTarget(primaryTarget, positional, cushion: cushion));
     }
 }

--- a/BossMod/BossModule/AIHints.cs
+++ b/BossMod/BossModule/AIHints.cs
@@ -330,12 +330,13 @@ public sealed class AIHints
     public Func<WPos, float> GoalSingleTarget(Actor target, float range, float weight = 1) => GoalSingleTarget(target.Position, range + target.HitboxRadius + 0.5f, weight);
 
     // simple goal zone that returns 1 if target is in range (usually melee), 2 if it's also in correct positional
-    public Func<WPos, float> GoalSingleTarget(WPos target, Angle rotation, Positional positional, float radius)
+    public Func<WPos, float> GoalSingleTarget(WPos target, Angle rotation, Positional positional, float radius, float cushion = 0)
     {
         if (positional == Positional.Any)
             return GoalSingleTarget(target, radius); // more efficient implementation
         var effRsq = radius * radius;
         var targetDir = rotation.ToDirection();
+        var cushionThreshold = cushion * MathF.Sqrt(2);
         return p =>
         {
             var offset = p - target;
@@ -347,15 +348,15 @@ public sealed class AIHints
             var side = Math.Abs(targetDir.Dot(offset.OrthoL()));
             var inPositional = positional switch
             {
-                Positional.Flank => side > Math.Abs(front),
-                Positional.Rear => -front > side,
-                Positional.Front => front > side, // TODO: reconsider this, it's not a real positional?..
+                Positional.Flank => side - Math.Abs(front) > cushionThreshold,
+                Positional.Rear => -front - side > cushionThreshold,
+                Positional.Front => front - side > cushionThreshold, // TODO: reconsider this, it's not a real positional?..
                 _ => false
             };
             return inPositional ? 2 : 1;
         };
     }
-    public Func<WPos, float> GoalSingleTarget(Actor target, Positional positional, float range = 3) => GoalSingleTarget(target.Position, target.Rotation, positional, range + target.HitboxRadius + 0.5f);
+    public Func<WPos, float> GoalSingleTarget(Actor target, Positional positional, float range = 3, float cushion = 0) => GoalSingleTarget(target.Position, target.Rotation, positional, range + target.HitboxRadius + 0.5f, cushion);
 
     // simple goal zone that returns number of targets in aoes; note that performance is a concern for these functions, and perfection isn't required, so eg they ignore forbidden targets, etc
     public Func<WPos, float> GoalAOECircle(float radius)


### PR DESCRIPTION
Same context as overdodge for Automatic Movement, but here we can go more towards the center of the positional to have more margin. This is very useful specially with ping, since we can account a few more frames to be in the correct positional before the boss moves, and it's less likely to fail the positional since without this, a micro movement from boss could lead to not being in the correct positional edge anymore.