### PR TITLE
CDPlanReminders

### DIFF
--- a/BossMod/Autorotation/AutorotationConfig.cs
+++ b/BossMod/Autorotation/AutorotationConfig.cs
@@ -48,4 +48,7 @@ public sealed class AutorotationConfig : ConfigNode
 
     [PropertyDisplay("Disable autorotation if the boss is pulled without a countdown", tooltip: "Only applies if you have a cooldown plan active.", since: "7.5.1.28")]
     public bool PlannedPullSafety = true;
+
+    [PropertyDisplay("Disable autorotation if a cooldown plan is selected", tooltip: "Only applies if you have timeline reminder active")]
+    public bool DisableIfPlanSelected = false;
 }

--- a/BossMod/Autorotation/PlanExecution.cs
+++ b/BossMod/Autorotation/PlanExecution.cs
@@ -23,6 +23,8 @@ public sealed class PlanExecution
         public bool IsActive(float t, StateData s) => t >= WindowStart && t <= WindowEnd && IntersectBranchRange(s.BranchID, s.NumBranches);
     }
 
+    public readonly record struct UpcomingEntry(string Name, uint IconId, uint Color, float TimeUntilStart, float TimeUntilEnd);
+
     public readonly record struct ModuleData(Type Type, RotationModuleDefinition Definition, List<List<EntryData>> Tracks, List<StrategyValue> Defaults);
 
     public readonly BossModule Module;
@@ -103,6 +105,36 @@ public sealed class PlanExecution
         var s = FindCurrentStateData();
         var t = GetVirtualTime(s);
         return GetEntryAt(ForcedTargets, ws, playerSlot, t, s)?.Value as StrategyValueTrack;
+    }
+
+    // returns up to maxPerTrack soonest not-yet-expired entries per track, within maxLookahead seconds of 'now' (sorted by time until start)
+    public List<UpcomingEntry> GetUpcomingEntries(WorldState ws, int playerSlot, float maxLookahead, int maxPerTrack = 1)
+    {
+        var s = FindCurrentStateData();
+        var t = GetVirtualTime(s);
+        List<UpcomingEntry> res = [];
+        foreach (var data in Strategies)
+        {
+            for (int i = 0; i < data.Tracks.Count; ++i)
+            {
+                if (data.Definition.Configs[i] is not StrategyConfigTrack config)
+                    continue;
+
+                var candidates = data.Tracks[i]
+                    .Where(e => e.WindowEnd > t && e.WindowStart - t <= maxLookahead && e.IntersectBranchRange(s.BranchID, s.NumBranches) && FilterEntry(e, ws, playerSlot))
+                    .OrderBy(e => e.WindowStart)
+                    .Take(maxPerTrack);
+
+                foreach (var entry in candidates)
+                {
+                    var value = (StrategyValueTrack)entry.Value;
+                    var option = config.Options[value.Option];
+                    res.Add(new(option.UIName, config.AssociatedActions.FirstOrDefault().Icon(), option.Color, entry.WindowStart - t, entry.WindowEnd - t));
+                }
+            }
+        }
+        res.SortBy(e => e.TimeUntilStart);
+        return res;
     }
 
     private StateData ProcessState(StateMachineTree tree, StateMachineTree.Node curState, StateData? prev, StateData? nextPhaseStart)

--- a/BossMod/Autorotation/RotationModuleManager.cs
+++ b/BossMod/Autorotation/RotationModuleManager.cs
@@ -336,9 +336,10 @@ public sealed class RotationModuleManager : IDisposable
         }
 
         // some jank: we can't check value of this.Planner because the expected plan isn't loaded until either countdown starts or boss is pulled, and BMM doesn't activate the module until after this event fires, so the best we can do is check what the plan is expected to be
-        else if (actor.InCombat && WorldState.Client.CountdownRemaining == null && Config.PlannedPullSafety && Bossmods.LoadedModules is [var mod] && Database.Plans.GetPlans(mod.GetType(), actor.Class).SelectedIndex >= 0)
+        else if (actor.InCombat && ((Config.DisableIfPlanSelected && Bossmods.Config.TimelineRemindersEnabled) || (WorldState.Client.CountdownRemaining == null && Config.PlannedPullSafety))
+            && Bossmods.LoadedModules is [var mod] && Database.Plans.GetPlans(mod.GetType(), actor.Class).SelectedIndex >= 0)
         {
-            Service.Log($"[RMM] Boss pulled without countdown => force-disabling from '{PresetNames}'");
+            Service.Log($"[RMM] Cooldown plan selected => force-disabling from '{PresetNames}'");
             SetForceDisabled();
         }
     }

--- a/BossMod/BossModule/BossModuleConfig.cs
+++ b/BossMod/BossModule/BossModuleConfig.cs
@@ -136,6 +136,61 @@ public class BossModuleConfig : ConfigNode
     [PropertyDisplay("Show player hints and warnings")]
     public bool ShowPlayerHints = true;
 
+    public enum TimelineRemindersDir
+    {
+        [PropertyDisplay("Right to left")]
+        RightToLeft,
+        [PropertyDisplay("Left to right")]
+        LeftToRight,
+        [PropertyDisplay("Bottom to top")]
+        BottomToTop,
+        [PropertyDisplay("Top to bottom")]
+        TopToBottom
+    }
+
+    // timeline reminders settings
+    [SectionStart]
+    [PropertyDisplay("Enable timeline reminders", tooltip: "Shows a separate overlay with upcoming cooldown-plan actions as a sliding timeline, similar to WoW's TimelineReminders addon")]
+    public bool TimelineRemindersEnabled = false;
+
+    [PropertyDisplay("Lookahead (seconds)", tooltip: "How many seconds before a planned action's cast window opens it starts appearing on the timeline", depends: nameof(TimelineRemindersEnabled))]
+    [PropertySlider(1, 120, Speed = 1)]
+    public float TimelineRemindersLookahead = 30;
+
+    [PropertyDisplay("Max upcoming occurrences per track", tooltip: "How many future occurrences of the same repeating action can be shown on the timeline at once", depends: nameof(TimelineRemindersEnabled))]
+    [PropertySlider(1, 10, Speed = 1)]
+    public int TimelineRemindersMaxPerTrack = 1;
+
+    [PropertyDisplay("Icon size", depends: nameof(TimelineRemindersEnabled))]
+    [PropertySlider(8, 128, Speed = 1)]
+    public int TimelineRemindersIconSize = 40;
+
+    [PropertyDisplay("Countdown text size", depends: nameof(TimelineRemindersEnabled))]
+    [PropertySlider(0.1f, 100, Speed = 1)]
+    public float TimelineRemindersFontSize = 17;
+
+    [PropertyDisplay("Speed (pixels/second)", tooltip: "How fast icons travel toward the 'now' line. Icons too far out to fit on screen at this speed pile up at the far edge and start sliding once there's room", depends: nameof(TimelineRemindersEnabled))]
+    [PropertySlider(1, 500, Speed = 1)]
+    public float TimelineRemindersSpeed = 35;
+
+    [PropertyDisplay("Direction", tooltip: "Which way icons travel as their cast window approaches", depends: nameof(TimelineRemindersEnabled))]
+    public TimelineRemindersDir TimelineRemindersDirection = TimelineRemindersDir.RightToLeft;
+
+    public enum TimelineRemindersTextPos
+    {
+        [PropertyDisplay("Top")]
+        Top,
+        [PropertyDisplay("Bottom")]
+        Bottom,
+        [PropertyDisplay("Left")]
+        Left,
+        [PropertyDisplay("Right")]
+        Right
+    }
+
+    [PropertyDisplay("Countdown text position", tooltip: "Where the countdown number is drawn relative to the icon", depends: nameof(TimelineRemindersEnabled))]
+    public TimelineRemindersTextPos TimelineRemindersTextPosition = TimelineRemindersTextPos.Bottom;
+
     // misc. settings
     [SectionStart]
     [PropertyDisplay("Show movement hints in world")]

--- a/BossMod/BossModule/BossModuleTimelineRemindersWindow.cs
+++ b/BossMod/BossModule/BossModuleTimelineRemindersWindow.cs
@@ -1,0 +1,135 @@
+using BossMod.Autorotation;
+using Dalamud.Bindings.ImGui;
+
+namespace BossMod;
+
+// overlay that shows upcoming cooldown-plan actions as a scrolling timeline (similar to WoW's TimelineReminders/LiquidReminders addons)
+// entries move at a constant configurable speed toward a fixed 'now' line; anything too far out to fit on screen at that speed
+// piles up stacked at the far edge (so the window always looks 'full') and only starts actually sliding once it would fit,
+// continue drifting past the line while their cast window is open, and disappear once the window closes
+public class BossModuleTimelineRemindersWindow : UIWindow
+{
+    private readonly RotationModuleManager _rotation;
+    private const float NearFraction = 0.2f; // 'now' line sits this far from the edge of the window it's closest to
+
+    public BossModuleTimelineRemindersWindow(RotationModuleManager rotation) : base("Timeline reminders", false, new(750, 120))
+    {
+        _rotation = rotation;
+        RespectCloseHotkey = false;
+    }
+
+    private BossModuleConfig Config => Service.Config.Get<BossModuleConfig>();
+    private bool? _lastHorizontal;
+
+    public override void PreOpenCheck()
+    {
+        IsOpen = Config.TimelineRemindersEnabled && (Config.ShowDemo || _rotation.Planner?.Plan != null);
+        Flags = ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse;
+        if (Config.Lock)
+            Flags |= ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoInputs;
+
+        // apply a direction-appropriate default size whenever the user switches between horizontal and vertical directions,
+        // so eg switching to a vertical direction doesn't leave the window stuck wide-and-short
+        var horizontal = Config.TimelineRemindersDirection is BossModuleConfig.TimelineRemindersDir.RightToLeft or BossModuleConfig.TimelineRemindersDir.LeftToRight;
+        if (_lastHorizontal != horizontal)
+        {
+            _lastHorizontal = horizontal;
+            Size = horizontal ? new(750, 120) : new(120, 750);
+            SizeCondition = ImGuiCond.Always;
+        }
+        else
+        {
+            Size = null;
+        }
+    }
+
+    // fake entries so the window can be sized/positioned without an active plan, mirroring the radar's ShowDemo mode
+    private static readonly List<PlanExecution.UpcomingEntry> _demoEntries =
+    [
+        new("Demo action 1", 0, 0xff4080ff, -2, 2),
+        new("Demo action 2", 0, 0xff00c0ff, 8, 22),
+        new("Demo action 3", 0, 0xffa0ff40, 15, 40),
+    ];
+
+    public override void Draw()
+    {
+        var planner = _rotation.Planner;
+        var entries = planner?.Plan != null
+            ? planner.GetUpcomingEntries(_rotation.WorldState, _rotation.PlayerSlot, Config.TimelineRemindersLookahead, Config.TimelineRemindersMaxPerTrack)
+            : _demoEntries;
+
+        var iconSize = Config.TimelineRemindersIconSize;
+        var pos = ImGui.GetWindowPos();
+        var size = ImGui.GetWindowSize();
+
+        var dir = Config.TimelineRemindersDirection;
+        var horizontal = dir is BossModuleConfig.TimelineRemindersDir.RightToLeft or BossModuleConfig.TimelineRemindersDir.LeftToRight;
+        // 'arrival' end is the edge entries travel toward (where the now-line sits); low = left/top, high = right/bottom
+        var arrivalIsLow = dir is BossModuleConfig.TimelineRemindersDir.RightToLeft or BossModuleConfig.TimelineRemindersDir.BottomToTop;
+        var sign = arrivalIsLow ? 1f : -1f;
+
+        var primaryStart = horizontal ? pos.X : pos.Y;
+        var primarySize = horizontal ? size.X : size.Y;
+        var nowCoord = primaryStart + primarySize * (arrivalIsLow ? NearFraction : 1 - NearFraction);
+        var crossCenter = horizontal ? pos.Y + size.Y * 0.5f : pos.X + size.X * 0.5f;
+        var pixelsPerSecond = Config.TimelineRemindersSpeed;
+
+        // show upcoming spells at the oposite end of the window
+        var farSpan = arrivalIsLow ? primaryStart + primarySize - nowCoord : nowCoord - primaryStart;
+        var maxVisibleSeconds = MathF.Max((farSpan - iconSize) / pixelsPerSecond, 0f);
+
+        //only show next stacked spells countdown
+        float? soonestStacked = null;
+        foreach (var e in entries)
+        {
+            if (e.TimeUntilStart > maxVisibleSeconds && (soonestStacked == null || e.TimeUntilStart < soonestStacked))
+                soonestStacked = e.TimeUntilStart;
+        }
+
+        var drawList = ImGui.GetWindowDrawList();
+        if (horizontal)
+            drawList.AddLine(new(nowCoord, pos.Y), new(nowCoord, pos.Y + size.Y), 0xffffffff, 2);
+        else
+            drawList.AddLine(new(pos.X, nowCoord), new(pos.X + size.X, nowCoord), 0xffffffff, 2);
+
+        // entries are sorted soonest-first; draw farthest-first so the soonest one ends up on top when icons overlap
+        for (int idx = entries.Count - 1; idx >= 0; --idx)
+        {
+            var e = entries[idx];
+            var coord = nowCoord + sign * MathF.Min(e.TimeUntilStart, maxVisibleSeconds) * pixelsPerSecond;
+            if (coord < primaryStart - iconSize || coord > primaryStart + primarySize + iconSize)
+                continue;
+
+            var iconPos = horizontal
+                ? new Vector2(coord - iconSize * 0.5f, crossCenter - iconSize * 0.5f)
+                : new Vector2(crossCenter - iconSize * 0.5f, coord - iconSize * 0.5f);
+            if (e.IconId != 0 && Service.Texture.TryGetFromGameIcon(e.IconId, out var tex))
+            {
+                var wrap = tex.GetWrapOrEmpty();
+                drawList.AddImage(wrap.Handle, iconPos, iconPos + new Vector2(iconSize));
+            }
+            else
+            {
+                drawList.AddRectFilled(iconPos, iconPos + new Vector2(iconSize), e.Color != 0 ? e.Color : 0xff808080);
+            }
+
+            if (e.TimeUntilStart <= maxVisibleSeconds || e.TimeUntilStart == soonestStacked)
+            {
+                var countdown = (e.TimeUntilStart <= 0 ? "+" : "") + (-e.TimeUntilStart).ToString("f0");
+                var fontSize = Config.TimelineRemindersFontSize;
+                var textSize = ImGui.CalcTextSizeA(ImGui.GetFont(), fontSize, 1000, -1, countdown, out _);
+                var textPos = Config.TimelineRemindersTextPosition switch
+                {
+                    BossModuleConfig.TimelineRemindersTextPos.Top => new Vector2(iconPos.X + iconSize * 0.5f - textSize.X * 0.5f, iconPos.Y - textSize.Y - 2),
+                    BossModuleConfig.TimelineRemindersTextPos.Left => new Vector2(iconPos.X - textSize.X - 2, iconPos.Y + iconSize * 0.5f - textSize.Y * 0.5f),
+                    BossModuleConfig.TimelineRemindersTextPos.Right => new Vector2(iconPos.X + iconSize + 2, iconPos.Y + iconSize * 0.5f - textSize.Y * 0.5f),
+                    _ => new Vector2(iconPos.X + iconSize * 0.5f - textSize.X * 0.5f, iconPos.Y + iconSize + 2),
+                };
+                drawList.AddText(ImGui.GetFont(), fontSize, textPos, 0xffffffff, countdown);
+            }
+
+            if (ImGui.IsMouseHoveringRect(iconPos, iconPos + new Vector2(iconSize)))
+                ImGui.SetTooltip(e.Name);
+        }
+    }
+}

--- a/BossMod/Data/ActionID.cs
+++ b/BossMod/Data/ActionID.cs
@@ -66,6 +66,12 @@ public readonly record struct ActionID(uint Raw)
         _ => 0
     };
 
+    public readonly uint Icon() => Type switch
+    {
+        ActionType.Spell => Service.LuminaRow<Lumina.Excel.Sheets.Action>(ID)?.Icon ?? 0,
+        _ => 0
+    };
+
     public readonly float CastTime() => Type switch
     {
         ActionType.Spell => (Service.LuminaRow<Lumina.Excel.Sheets.Action>(ID)?.Cast100ms ?? 0) * 0.1f,

--- a/BossMod/Services/TickService.cs
+++ b/BossMod/Services/TickService.cs
@@ -52,6 +52,7 @@ internal class TickService : DisposableMediatorSubscriberBase, IHostedService
 
     private readonly BossModuleMainWindow _wndBossmod;
     private readonly BossModuleHintsWindow _wndBossmodHints;
+    private readonly BossModuleTimelineRemindersWindow _wndTimelineReminders;
     private readonly ZoneModuleWindow _wndZone;
     private readonly ReplayManagementWindow _wndReplay;
     private readonly UIRotationWindow _wndRotation;
@@ -163,6 +164,7 @@ internal class TickService : DisposableMediatorSubscriberBase, IHostedService
 
         _wndBossmod = new BossModuleMainWindow(_bossmod, _zonemod);
         _wndBossmodHints = new BossModuleHintsWindow(_bossmod, _zonemod);
+        _wndTimelineReminders = new BossModuleTimelineRemindersWindow(_rotation);
         _wndZone = new ZoneModuleWindow(_zonemod);
         _wndReplay = new ReplayManagementWindow(_ws, _bossmod, _rotationDB, replayDir);
         _wndRotation = new UIRotationWindow(_rotation, _amex, () => OpenConfigUI("Autorotation Presets"));


### PR DESCRIPTION
Overlay that shows upcoming cooldown-plan actions as a scrolling timeline (similar to WoW's TimelineReminders/LiquidReminders addons)

Claude hath gifted me with a piece of code. This has been a dream feature of mine for a while now. 
The goal of the feature it to be used as a reminder of upcoming spells without having the AI rotation press the buttons for me.
I think I put a fair amount of configurability into the settings but always open to adding more. 

https://www.youtube.com/watch?v=zuldqTHZodI for Review
<img width="542" height="231" alt="image" src="https://github.com/user-attachments/assets/4612bae4-3dcf-4934-80f9-ef4437392468" />
<img width="1386" height="1049" alt="image" src="https://github.com/user-attachments/assets/ef88bde5-1b57-4d15-b029-4e496beca6ca" />
